### PR TITLE
Add OCR2VRF+DKG relay types

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -58,16 +58,19 @@ type MedianProvider interface {
 	MedianContract() median.MedianContract
 }
 
+// OCR2VRFRelayer contains the relayer and instantiating functions for OCR2VRF providers.
 type OCR2VRFRelayer interface {
 	Relayer
 	NewDKGProvider(rargs RelayArgs, transmitterID string) (DKGProvider, error)
 	NewOCR2VRFProvider(rargs RelayArgs, transmitterID string) (OCR2VRFProvider, error)
 }
 
+// DKGProvider provides all components needed for a DKG plugin.
 type DKGProvider interface {
 	Plugin
 }
 
+// OCR2VRFProvider provides all components needed for a OCR2VRF plugin.
 type OCR2VRFProvider interface {
 	Plugin
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -57,3 +57,17 @@ type MedianProvider interface {
 	ReportCodec() median.ReportCodec
 	MedianContract() median.MedianContract
 }
+
+type OCR2VRFRelayer interface {
+	Relayer
+	NewDKGProvider(rargs RelayArgs, transmitterID string) (DKGProvider, error)
+	NewOCR2VRFProvider(rargs RelayArgs, transmitterID string) (OCR2VRFProvider, error)
+}
+
+type DKGProvider interface {
+	Plugin
+}
+
+type OCR2VRFProvider interface {
+	Plugin
+}


### PR DESCRIPTION
## Summary

Adds OCR2VRF + DKG relay types to `pkg/types`: a `DKGProvider` and `OCR2VRFProvider` (both extending `Plugin`), and an `OCR2VRFRelayer` interface combining `Relayer` with `NewDKGProvider`/`NewOCR2VRFProvider` constructors.

## Why

Introduces the type skeleton needed for OCR2VRF and DKG relay plugins before the implementations land in the chainlink and relayer repos.
