### PR TITLE
Merge OCR2VRFRelayer into Relay

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -35,6 +35,8 @@ type Relayer interface {
 	Service
 	NewConfigProvider(rargs RelayArgs) (ConfigProvider, error)
 	NewMedianProvider(rargs RelayArgs, pargs PluginArgs) (MedianProvider, error)
+	NewDKGProvider(rargs RelayArgs, transmitterID string) (DKGProvider, error)
+	NewOCR2VRFProvider(rargs RelayArgs, transmitterID string) (OCR2VRFProvider, error)
 }
 
 // The bootstrap jobs only watch config.
@@ -56,13 +58,6 @@ type MedianProvider interface {
 	Plugin
 	ReportCodec() median.ReportCodec
 	MedianContract() median.MedianContract
-}
-
-// OCR2VRFRelayer contains the relayer and instantiating functions for OCR2VRF providers.
-type OCR2VRFRelayer interface {
-	Relayer
-	NewDKGProvider(rargs RelayArgs, transmitterID string) (DKGProvider, error)
-	NewOCR2VRFProvider(rargs RelayArgs, transmitterID string) (OCR2VRFProvider, error)
 }
 
 // DKGProvider provides all components needed for a DKG plugin.


### PR DESCRIPTION
## Summary

Folds the `OCR2VRFRelayer` interface into the base `Relayer` interface by adding `NewDKGProvider` and `NewOCR2VRFProvider` directly to `Relayer`, and removes the now-redundant `OCR2VRFRelayer` type.

## Why

Every relayer that supports OCR2VRF should expose its constructors through the common `Relayer` interface rather than a separate one, so callers don't need to type-assert.
