### PR TITLE
Make MercuryProvider extend PluginProvider

### DIFF
--- a/pkg/types/provider_mercury.go
+++ b/pkg/types/provider_mercury.go
@@ -10,10 +10,11 @@ import (
 // MercuryProvider provides components needed for a mercury OCR2 plugin.
 // Mercury requires config tracking but does not transmit on-chain.
 type MercuryProvider interface {
-	ConfigProvider
+	PluginProvider
+
 	ReportCodecV1() v1.ReportCodec
 	ReportCodecV2() v2.ReportCodec
 	ReportCodecV3() v3.ReportCodec
 	OnchainConfigCodec() mercury.OnchainConfigCodec
-	ContractTransmitter() mercury.Transmitter
+	MercuryServerFetcher() mercury.MercuryServerFetcher
 }


### PR DESCRIPTION
We want to replace the `New<Product>Provider` methods in the relayer interface with a single, polymorphic `NewPluginProvider` method which extends a common PluginProvider interface exposing the three OCR components required to set up an Oracle.

At the moment the MedianProvider and FunctionsProvider both extend this interface, but Mercury does not since it extends the OCR ContractTransmitter with a few additional methods.

This modifies Mercury's interface by splitting this transmitter into two separate components, once which implements `ocrtypes.ContractTransmitter` and another which encompasses the additional methods (and implements `mercury.MercuryServerFetcher`). This is a largely cosmetic change, since under the hood the transmitter can remain the same struct, just exposed in two different methods.