### PR TITLE
rename module to chainlink-common

### DIFF
--- a/.github/workflows/build_external.yml
+++ b/.github/workflows/build_external.yml
@@ -63,9 +63,9 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: "go.mod"
-      - name: Replace chainlink-relay deps
+      - name: Replace chainlink-common deps
         run: |
-          go get github.com/smartcontractkit/chainlink-relay@${{ github.event.pull_request.head.sha }}
+          go get github.com/smartcontractkit/chainlink-common@${{ github.event.pull_request.head.sha }}
           go mod tidy
       - name: Install Solana CLI
         run: ./scripts/install-solana-ci.sh
@@ -95,10 +95,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: ./relayer/go.mod
-      - name: Replace chainlink-relay deps
+      - name: Replace chainlink-common deps
         run: | 
             cd relayer
-            go get github.com/smartcontractkit/chainlink-relay@${{ github.event.pull_request.head.sha }}
+            go get github.com/smartcontractkit/chainlink-common@${{ github.event.pull_request.head.sha }}
             go mod tidy
       - name: Install Nix
         uses: cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590 # v17
@@ -132,9 +132,9 @@ jobs:
   #       uses: actions/setup-go@v3
   #       with:
   #         go-version-file: "go.mod"
-  #     - name: Replace chainlink-relay deps
+  #     - name: Replace chainlink-common deps
   #       run: |
-  #         go get github.com/smartcontractkit/chainlink-relay@${{ github.event.pull_request.head.sha }}
+  #         go get github.com/smartcontractkit/chainlink-common@${{ github.event.pull_request.head.sha }}
   #         go mod tidy
   #     - name: Install Nix
   #       uses: cachix/install-nix-action@v14

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ gomodtidy:
 .PHONY: godoc
 godoc:
 	go install golang.org/x/tools/cmd/godoc@latest
-	# http://localhost:6060/pkg/github.com/smartcontractkit/chainlink-relay/
+	# http://localhost:6060/pkg/github.com/smartcontractkit/chainlink-common/
 	godoc -http=:6060
 
 PHONY: install-protoc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# chainlink-relay
-SDK for building Chainlink Relay network-specific services
+# chainlink-common
+
+SDK for implementing Chainlink Services, like Chain Relayers or Product Plugins.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/smartcontractkit/chainlink-relay
+module github.com/smartcontractkit/chainlink-common
 
 go 1.21
 

--- a/pkg/assets/link.go
+++ b/pkg/assets/link.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils/bytes"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
 
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"

--- a/pkg/assets/link_test.go
+++ b/pkg/assets/link_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/assets"
+	"github.com/smartcontractkit/chainlink-common/pkg/assets"
 )
 
 func TestAssets_NewLinkAndString(t *testing.T) {

--- a/pkg/chains/nodes.go
+++ b/pkg/chains/nodes.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 // pageToken is simple internal representation for coordination requests and responses in a paginated API

--- a/pkg/chains/nodes_test.go
+++ b/pkg/chains/nodes_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 func TestNewPageToken(t *testing.T) {

--- a/pkg/fee/models.go
+++ b/pkg/fee/models.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/chains/label"
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	bigmath "github.com/smartcontractkit/chainlink-relay/pkg/utils/big_math"
+	"github.com/smartcontractkit/chainlink-common/pkg/chains/label"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	bigmath "github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 )
 
 var (

--- a/pkg/fee/models_test.go
+++ b/pkg/fee/models_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // This test is based on EVM Fixed Fee Estimator.

--- a/pkg/loop/README.md
+++ b/pkg/loop/README.md
@@ -6,7 +6,7 @@ Local out of process (LOOP) plugins using [github.com/hashicorp/go-plugin](https
 
 ```mermaid
 flowchart
-    subgraph chainlink-relay/pkg
+    subgraph chainlink-common/pkg
         loop
         internal[loop/internal]
         pb[loop/internal/pb]

--- a/pkg/loop/adapter.go
+++ b/pkg/loop/adapter.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/services"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 // RelayerExt is a subset of [loop.Relayer] for adapting [types.Relayer], typically with a Chain. See [RelayerAdapter].

--- a/pkg/loop/adapters/starknet/signature.go
+++ b/pkg/loop/adapters/starknet/signature.go
@@ -6,7 +6,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
 )
 
 type Signature struct {

--- a/pkg/loop/context_test.go
+++ b/pkg/loop/context_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
 )
 
 func TestContextValues(t *testing.T) {

--- a/pkg/loop/errors.go
+++ b/pkg/loop/errors.go
@@ -1,5 +1,5 @@
 package loop
 
-import "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
+import "github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
 
 var ErrPluginUnavailable = internal.ErrPluginUnavailable

--- a/pkg/loop/internal/broker.go
+++ b/pkg/loop/internal/broker.go
@@ -10,8 +10,8 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 // Broker is a subset of the methods exported by *plugin.GRPCBroker.

--- a/pkg/loop/internal/client.go
+++ b/pkg/loop/internal/client.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 var _ grpc.ClientConnInterface = (*atomicClient)(nil)

--- a/pkg/loop/internal/config.go
+++ b/pkg/loop/internal/config.go
@@ -8,8 +8,8 @@ import (
 
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ types.ConfigProvider = (*configProviderClient)(nil)

--- a/pkg/loop/internal/contract_transmitter.go
+++ b/pkg/loop/internal/contract_transmitter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smartcontractkit/libocr/commontypes"
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
 )
 
 var _ libocr.ContractTransmitter = (*contractTransmitterClient)(nil)

--- a/pkg/loop/internal/datasource.go
+++ b/pkg/loop/internal/datasource.go
@@ -11,8 +11,8 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 // github.com/smartcontractkit/libocr/offchainreporting2plus/internal/protocol.ReportingPluginTimeoutWarningGracePeriod

--- a/pkg/loop/internal/error_log.go
+++ b/pkg/loop/internal/error_log.go
@@ -6,8 +6,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ types.ErrorLog = (*errorLogClient)(nil)

--- a/pkg/loop/internal/median.go
+++ b/pkg/loop/internal/median.go
@@ -15,9 +15,9 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ types.PluginMedian = (*PluginMedianClient)(nil)

--- a/pkg/loop/internal/pb/median.pb.go
+++ b/pkg/loop/internal/pb/median.pb.go
@@ -22,7 +22,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// NewMedianFactoryRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewMedianFactory].
+// NewMedianFactoryRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewMedianFactory].
 type NewMedianFactoryRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -94,7 +94,7 @@ func (x *NewMedianFactoryRequest) GetErrorLogID() uint32 {
 	return 0
 }
 
-// NewMedianFactoryRequest has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewMedianFactory].
+// NewMedianFactoryRequest has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewMedianFactory].
 type NewMedianFactoryReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -142,7 +142,7 @@ func (x *NewMedianFactoryReply) GetReportingPluginFactoryID() uint32 {
 	return 0
 }
 
-// SaveErrorRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.ErrorLog.SaveErrorRequest].
+// SaveErrorRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.ErrorLog.SaveErrorRequest].
 type SaveErrorRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/pkg/loop/internal/pb/median.proto
+++ b/pkg/loop/internal/pb/median.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb";
+option go_package = "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb";
 
 package loop;
 
@@ -12,7 +12,7 @@ service PluginMedian {
   rpc NewMedianFactory (NewMedianFactoryRequest) returns (NewMedianFactoryReply) {}
 }
 
-// NewMedianFactoryRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewMedianFactory].
+// NewMedianFactoryRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewMedianFactory].
 message NewMedianFactoryRequest {
   uint32 medianProviderID = 1;
   uint32 dataSourceID = 2;
@@ -20,7 +20,7 @@ message NewMedianFactoryRequest {
   uint32 errorLogID = 4;
 }
 
-// NewMedianFactoryRequest has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewMedianFactory].
+// NewMedianFactoryRequest has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewMedianFactory].
 message NewMedianFactoryReply {
   uint32 reportingPluginFactoryID = 1;
 }
@@ -29,7 +29,7 @@ service ErrorLog {
   rpc SaveError(SaveErrorRequest) returns (google.protobuf.Empty) {}
 }
 
-// SaveErrorRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.ErrorLog.SaveErrorRequest].
+// SaveErrorRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.ErrorLog.SaveErrorRequest].
 message SaveErrorRequest {
   string message = 1;
 }

--- a/pkg/loop/internal/pb/pipeline_runner.proto
+++ b/pkg/loop/internal/pb/pipeline_runner.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb";
+option go_package = "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb";
 
 package loop;
 

--- a/pkg/loop/internal/pb/relayer.pb.go
+++ b/pkg/loop/internal/pb/relayer.pb.go
@@ -272,7 +272,7 @@ func (x *SignReply) GetSignedData() []byte {
 	return nil
 }
 
-// RelayArgs represents [github.com/smartcontractkit/chainlink-relay/pkg/types.RelayArgs].
+// RelayArgs represents [github.com/smartcontractkit/chainlink-common/pkg/types.RelayArgs].
 type RelayArgs struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -360,7 +360,7 @@ func (x *RelayArgs) GetProviderType() string {
 	return ""
 }
 
-// RelayArgs represents [github.com/smartcontractkit/chainlink-relay/pkg/types.PluginArgs].
+// RelayArgs represents [github.com/smartcontractkit/chainlink-common/pkg/types.PluginArgs].
 type PluginArgs struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -416,7 +416,7 @@ func (x *PluginArgs) GetPluginConfig() []byte {
 	return nil
 }
 
-// NewPluginProviderRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewPluginProvider].
+// NewPluginProviderRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewPluginProvider].
 type NewPluginProviderRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -472,7 +472,7 @@ func (x *NewPluginProviderRequest) GetPluginArgs() *PluginArgs {
 	return nil
 }
 
-// NewPluginProviderReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewPluginProvider].
+// NewPluginProviderReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewPluginProvider].
 type NewPluginProviderReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -520,7 +520,7 @@ func (x *NewPluginProviderReply) GetPluginProviderID() uint32 {
 	return 0
 }
 
-// NewConfigProviderRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewConfigProvider].
+// NewConfigProviderRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewConfigProvider].
 type NewConfigProviderRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -568,7 +568,7 @@ func (x *NewConfigProviderRequest) GetRelayArgs() *RelayArgs {
 	return nil
 }
 
-// NewConfigProviderReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewConfigProvider].
+// NewConfigProviderReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewConfigProvider].
 type NewConfigProviderReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -654,7 +654,7 @@ func (*GetChainStatusRequest) Descriptor() ([]byte, []int) {
 	return file_relayer_proto_rawDescGZIP(), []int{11}
 }
 
-// ChainStatusReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.ChainStatus].
+// ChainStatusReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.ChainStatus].
 type GetChainStatusReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -702,7 +702,7 @@ func (x *GetChainStatusReply) GetChain() *ChainStatus {
 	return nil
 }
 
-// ChainStatus represents [github.com/smartcontractkit/chainlink-relay/pkg/types.ChainStatus].
+// ChainStatus represents [github.com/smartcontractkit/chainlink-common/pkg/types.ChainStatus].
 type ChainStatus struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -766,7 +766,7 @@ func (x *ChainStatus) GetConfig() string {
 	return ""
 }
 
-// ListNodeStatusesRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.ListNodeStatuses].
+// ListNodeStatusesRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.ListNodeStatuses].
 type ListNodeStatusesRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -822,7 +822,7 @@ func (x *ListNodeStatusesRequest) GetPageToken() string {
 	return ""
 }
 
-// ListNodeStatusesReply is a pagination response  for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.ListNodeStatuses].
+// ListNodeStatusesReply is a pagination response  for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.ListNodeStatuses].
 type ListNodeStatusesReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -886,7 +886,7 @@ func (x *ListNodeStatusesReply) GetNextPageToken() string {
 	return ""
 }
 
-// NodeStatus represents [github.com/smartcontractkit/chainlink-relay/pkg/types.NodeStatus].
+// NodeStatus represents [github.com/smartcontractkit/chainlink-common/pkg/types.NodeStatus].
 type NodeStatus struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -958,7 +958,7 @@ func (x *NodeStatus) GetState() string {
 	return ""
 }
 
-// SendTxRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.SendTx].
+// SendTxRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.SendTx].
 type TransactionRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1030,7 +1030,7 @@ func (x *TransactionRequest) GetBalanceCheck() bool {
 	return false
 }
 
-// ObserveRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.DataSource.Observe].
+// ObserveRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.DataSource.Observe].
 type ObserveRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1078,7 +1078,7 @@ func (x *ObserveRequest) GetReportTimestamp() *ReportTimestamp {
 	return nil
 }
 
-// ObserveReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.DataSource.Observe].
+// ObserveReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.DataSource.Observe].
 type ObserveReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2098,7 +2098,7 @@ func (*FromAccountRequest) Descriptor() ([]byte, []int) {
 	return file_relayer_proto_rawDescGZIP(), []int{38}
 }
 
-// FromAccountReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/types.Service.FromAccount].
+// FromAccountReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/types.Service.FromAccount].
 type FromAccountReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2146,7 +2146,7 @@ func (x *FromAccountReply) GetAccount() string {
 	return ""
 }
 
-// NameReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/types.Service.Name].
+// NameReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/types.Service.Name].
 type NameReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2194,7 +2194,7 @@ func (x *NameReply) GetName() string {
 	return ""
 }
 
-// HealthReportReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/types.Service.HealthReport].
+// HealthReportReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/types.Service.HealthReport].
 type HealthReportReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/pkg/loop/internal/pb/relayer.proto
+++ b/pkg/loop/internal/pb/relayer.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb";
+option go_package = "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb";
 
 package loop;
 
@@ -48,7 +48,7 @@ service Relayer {
   rpc Transact (TransactionRequest) returns (google.protobuf.Empty) {}
 }
 
-// RelayArgs represents [github.com/smartcontractkit/chainlink-relay/pkg/types.RelayArgs].
+// RelayArgs represents [github.com/smartcontractkit/chainlink-common/pkg/types.RelayArgs].
 message RelayArgs {
   bytes externalJobID = 1; // [32]byte
   int32 jobID = 2;
@@ -58,62 +58,62 @@ message RelayArgs {
   string providerType = 6;
 }
 
-// RelayArgs represents [github.com/smartcontractkit/chainlink-relay/pkg/types.PluginArgs].
+// RelayArgs represents [github.com/smartcontractkit/chainlink-common/pkg/types.PluginArgs].
 message PluginArgs {
   string transmitterID = 1;
   bytes pluginConfig = 2;
 }
 
-// NewPluginProviderRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewPluginProvider].
+// NewPluginProviderRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewPluginProvider].
 message NewPluginProviderRequest {
   RelayArgs relayArgs = 1;
   PluginArgs pluginArgs = 2;
 }
 
-// NewPluginProviderReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewPluginProvider].
+// NewPluginProviderReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewPluginProvider].
 message NewPluginProviderReply {
   uint32 pluginProviderID = 1;
 }
 
-// NewConfigProviderRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewConfigProvider].
+// NewConfigProviderRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewConfigProvider].
 message NewConfigProviderRequest {
   RelayArgs relayArgs = 1;
 }
 
-// NewConfigProviderReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.NewConfigProvider].
+// NewConfigProviderReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewConfigProvider].
 message NewConfigProviderReply {
   uint32 configProviderID = 1;
 }
 
 message GetChainStatusRequest {}
 
-// ChainStatusReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.ChainStatus].
+// ChainStatusReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.ChainStatus].
 message GetChainStatusReply {
   ChainStatus chain = 1;
 }
 
 
-// ChainStatus represents [github.com/smartcontractkit/chainlink-relay/pkg/types.ChainStatus].
+// ChainStatus represents [github.com/smartcontractkit/chainlink-common/pkg/types.ChainStatus].
 message ChainStatus {
   string id = 1;
   bool enabled = 2;
   string config = 3; // TOML
 }
 
-// ListNodeStatusesRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.ListNodeStatuses].
+// ListNodeStatusesRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.ListNodeStatuses].
 message ListNodeStatusesRequest {
   int32 page_size = 1;
   string page_token = 2;
 }
 
-// ListNodeStatusesReply is a pagination response  for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.ListNodeStatuses].
+// ListNodeStatusesReply is a pagination response  for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.ListNodeStatuses].
 message ListNodeStatusesReply {
   repeated NodeStatus nodes = 1;
   int32 total = 2; // total count of nodes
   string next_page_token =3;
 }
 
-// NodeStatus represents [github.com/smartcontractkit/chainlink-relay/pkg/types.NodeStatus].
+// NodeStatus represents [github.com/smartcontractkit/chainlink-common/pkg/types.NodeStatus].
 message NodeStatus {
   string chainID = 1;
   string name = 2;
@@ -121,7 +121,7 @@ message NodeStatus {
   string state = 4;
 }
 
-// SendTxRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.Relayer.SendTx].
+// SendTxRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.SendTx].
 message TransactionRequest {
   string from = 1;
   string to = 2;
@@ -133,12 +133,12 @@ service DataSource {
   rpc Observe (ObserveRequest) returns (ObserveReply) {}
 }
 
-// ObserveRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.DataSource.Observe].
+// ObserveRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.DataSource.Observe].
 message ObserveRequest {
   ReportTimestamp reportTimestamp = 1;
 }
 
-// ObserveReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop.DataSource.Observe].
+// ObserveReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.DataSource.Observe].
 message ObserveReply {
   BigInt value = 1;
 }
@@ -251,7 +251,7 @@ message LatestConfigDigestAndEpochReply {
 
 message FromAccountRequest {}
 
-// FromAccountReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/types.Service.FromAccount].
+// FromAccountReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/types.Service.FromAccount].
 message FromAccountReply {
   string Account = 1;
 }
@@ -263,12 +263,12 @@ service Service {
   rpc HealthReport (google.protobuf.Empty) returns (HealthReportReply) {}
 }
 
-// NameReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/types.Service.Name].
+// NameReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/types.Service.Name].
 message NameReply {
   string name = 1;
 }
 
-// HealthReportReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/types.Service.HealthReport].
+// HealthReportReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/types.Service.HealthReport].
 message HealthReportReply {
   map<string, string> healthReport = 1;
 }

--- a/pkg/loop/internal/pb/reporting.proto
+++ b/pkg/loop/internal/pb/reporting.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb";
+option go_package = "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb";
 
 package loop;
 

--- a/pkg/loop/internal/pb/reporting_plugin_service.pb.go
+++ b/pkg/loop/internal/pb/reporting_plugin_service.pb.go
@@ -99,7 +99,7 @@ func (x *ReportingPluginServiceConfig) GetTelemetryType() string {
 	return ""
 }
 
-// NewReportingPluginFactoryRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop/reporting_plugins/LOOPPService.NewReportingPluginFactory].
+// NewReportingPluginFactoryRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop/reporting_plugins/LOOPPService.NewReportingPluginFactory].
 type NewReportingPluginFactoryRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -179,7 +179,7 @@ func (x *NewReportingPluginFactoryRequest) GetReportingPluginServiceConfig() *Re
 	return nil
 }
 
-// NewReportingPluginFactoryReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop/reporting_plugins/LOOPPService.NewReportingPluginFactory].
+// NewReportingPluginFactoryReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop/reporting_plugins/LOOPPService.NewReportingPluginFactory].
 type NewReportingPluginFactoryReply struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/pkg/loop/internal/pb/reporting_plugin_service.proto
+++ b/pkg/loop/internal/pb/reporting_plugin_service.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb";
+option go_package = "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb";
 
 package loop;
 
@@ -16,7 +16,7 @@ message ReportingPluginServiceConfig {
   string telemetryType = 5;
 }
 
-// NewReportingPluginFactoryRequest has arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop/reporting_plugins/LOOPPService.NewReportingPluginFactory].
+// NewReportingPluginFactoryRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop/reporting_plugins/LOOPPService.NewReportingPluginFactory].
 message NewReportingPluginFactoryRequest {
   uint32 providerID = 1;
   uint32 errorLogID = 2;
@@ -25,7 +25,7 @@ message NewReportingPluginFactoryRequest {
   ReportingPluginServiceConfig ReportingPluginServiceConfig = 5;
 }
 
-// NewReportingPluginFactoryReply has return arguments for [github.com/smartcontractkit/chainlink-relay/pkg/loop/reporting_plugins/LOOPPService.NewReportingPluginFactory].
+// NewReportingPluginFactoryReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop/reporting_plugins/LOOPPService.NewReportingPluginFactory].
 message NewReportingPluginFactoryReply {
   uint32 ID = 1;
 }

--- a/pkg/loop/internal/pb/telemetry.proto
+++ b/pkg/loop/internal/pb/telemetry.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb";
+option go_package = "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb";
 
 package loop;
 

--- a/pkg/loop/internal/pipeline_runner.go
+++ b/pkg/loop/internal/pipeline_runner.go
@@ -8,8 +8,8 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ types.PipelineRunnerService = (*pipelineRunnerServiceClient)(nil)

--- a/pkg/loop/internal/pipeline_runner_test.go
+++ b/pkg/loop/internal/pipeline_runner_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 type mockPipelineRunner struct {

--- a/pkg/loop/internal/plugin_provider.go
+++ b/pkg/loop/internal/plugin_provider.go
@@ -4,8 +4,8 @@ import (
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 type pluginProviderClient struct {

--- a/pkg/loop/internal/plugin_service.go
+++ b/pkg/loop/internal/plugin_service.go
@@ -12,9 +12,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/services"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 const KeepAliveTickDuration = 5 * time.Second //TODO from config

--- a/pkg/loop/internal/relayer.go
+++ b/pkg/loop/internal/relayer.go
@@ -10,9 +10,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ PluginRelayer = (*PluginRelayerClient)(nil)

--- a/pkg/loop/internal/reporting.go
+++ b/pkg/loop/internal/reporting.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/libocr/commontypes"
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
 )
 
 type reportingPluginFactoryClient struct {

--- a/pkg/loop/internal/reporting_plugin_service.go
+++ b/pkg/loop/internal/reporting_plugin_service.go
@@ -6,9 +6,9 @@ import (
 	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ types.ReportingPluginClient = (*ReportingPluginServiceClient)(nil)

--- a/pkg/loop/internal/service.go
+++ b/pkg/loop/internal/service.go
@@ -8,8 +8,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
 var ErrPluginUnavailable = errors.New("plugin unavailable")

--- a/pkg/loop/internal/telemetry.go
+++ b/pkg/loop/internal/telemetry.go
@@ -7,8 +7,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ types.TelemetryService = (*telemetryServiceClient)(nil)

--- a/pkg/loop/internal/test/cmd/main.go
+++ b/pkg/loop/internal/test/cmd/main.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/reportingplugins"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 func main() {

--- a/pkg/loop/internal/test/error_log.go
+++ b/pkg/loop/internal/test/error_log.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ types.ErrorLog = (*StaticErrorLog)(nil)

--- a/pkg/loop/internal/test/logger_loop.go
+++ b/pkg/loop/internal/test/logger_loop.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 )
 
 const PluginLoggerTestName = "logger-test"

--- a/pkg/loop/internal/test/median.go
+++ b/pkg/loop/internal/test/median.go
@@ -15,8 +15,8 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 func TestPluginMedian(t *testing.T, p types.PluginMedian) {

--- a/pkg/loop/internal/test/pipeline_runner.go
+++ b/pkg/loop/internal/test/pipeline_runner.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ types.PipelineRunnerService = (*StaticPipelineRunnerService)(nil)

--- a/pkg/loop/internal/test/relayer.go
+++ b/pkg/loop/internal/test/relayer.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 type StaticKeystore struct{}

--- a/pkg/loop/internal/test/reporting_plugin.go
+++ b/pkg/loop/internal/test/reporting_plugin.go
@@ -8,8 +8,8 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 type MockConn struct {

--- a/pkg/loop/internal/test/telemetry.go
+++ b/pkg/loop/internal/test/telemetry.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ grpc.ClientConnInterface = (*mockClientConn)(nil)

--- a/pkg/loop/internal/test/test.go
+++ b/pkg/loop/internal/test/test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 const ConfigTOML = `[Foo]

--- a/pkg/loop/internal/test/test_plugin.go
+++ b/pkg/loop/internal/test/test_plugin.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 type HelperProcessCommand struct {

--- a/pkg/loop/internal/types.go
+++ b/pkg/loop/internal/types.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"context"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 type PluginRelayer interface {

--- a/pkg/loop/logger.go
+++ b/pkg/loop/logger.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/exp/slices"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // HCLogLogger returns an [hclog.Logger] backed by the given [logger.Logger].

--- a/pkg/loop/logger_loop_test.go
+++ b/pkg/loop/logger_loop_test.go
@@ -8,8 +8,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 )
 
 func TestHCLogLogger(t *testing.T) {

--- a/pkg/loop/median_service.go
+++ b/pkg/loop/median_service.go
@@ -8,9 +8,9 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ ocrtypes.ReportingPluginFactory = (*MedianService)(nil)

--- a/pkg/loop/median_service_test.go
+++ b/pkg/loop/median_service_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 func TestMedianService(t *testing.T) {

--- a/pkg/loop/plugin.go
+++ b/pkg/loop/plugin.go
@@ -3,8 +3,8 @@ package loop
 import (
 	"sync"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
 // Plugin is a base layer for plugins to easily manage sub-[types.Service]s.

--- a/pkg/loop/plugin_median.go
+++ b/pkg/loop/plugin_median.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 // PluginMedianName is the name for [types.PluginMedian]/[NewGRPCPluginMedian].

--- a/pkg/loop/plugin_median_test.go
+++ b/pkg/loop/plugin_median_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 func TestPluginMedian(t *testing.T) {

--- a/pkg/loop/plugin_relayer.go
+++ b/pkg/loop/plugin_relayer.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 // PluginRelayerName is the name for [types.PluginRelayer]/[NewGRPCPluginRelayer].

--- a/pkg/loop/plugin_relayer_test.go
+++ b/pkg/loop/plugin_relayer_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 )
 
 func TestPluginRelayer(t *testing.T) {

--- a/pkg/loop/process_test.go
+++ b/pkg/loop/process_test.go
@@ -3,7 +3,7 @@ package loop_test
 import (
 	"os/exec"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 )
 
 type HelperProcessCommand test.HelperProcessCommand

--- a/pkg/loop/prom.go
+++ b/pkg/loop/prom.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 type PromServer struct {

--- a/pkg/loop/prom_test.go
+++ b/pkg/loop/prom_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 func TestPromServer(t *testing.T) {

--- a/pkg/loop/relayer_service.go
+++ b/pkg/loop/relayer_service.go
@@ -6,9 +6,9 @@ import (
 	"math/big"
 	"os/exec"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ Relayer = (*RelayerService)(nil)

--- a/pkg/loop/relayer_service_test.go
+++ b/pkg/loop/relayer_service_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 func TestRelayerService(t *testing.T) {

--- a/pkg/loop/reportingplugins/grpc.go
+++ b/pkg/loop/reportingplugins/grpc.go
@@ -6,9 +6,9 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 // PluginServiceName is the name for [types.PluginClient]/[NewGRPCService].

--- a/pkg/loop/reportingplugins/grpc_test.go
+++ b/pkg/loop/reportingplugins/grpc_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/reportingplugins"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 func newStopCh(t *testing.T) <-chan struct{} {

--- a/pkg/loop/reportingplugins/loopp_service.go
+++ b/pkg/loop/reportingplugins/loopp_service.go
@@ -8,10 +8,10 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 var _ ocrtypes.ReportingPluginFactory = (*LOOPPService)(nil)

--- a/pkg/loop/reportingplugins/loopp_service_test.go
+++ b/pkg/loop/reportingplugins/loopp_service_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/reportingplugins"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
-	utilstests "github.com/smartcontractkit/chainlink-relay/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	utilstests "github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 type HelperProcessCommand test.HelperProcessCommand

--- a/pkg/loop/server.go
+++ b/pkg/loop/server.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
 // NewStartedServer returns a started Server.

--- a/pkg/loop/standalone_provider.go
+++ b/pkg/loop/standalone_provider.go
@@ -5,8 +5,8 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
-	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 // RegisterStandAloneProvider register the servers needed for a plugin provider,

--- a/pkg/loop/standalone_provider_test.go
+++ b/pkg/loop/standalone_provider_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 )
 
 func TestRegisterStandAloneProvider(t *testing.T) {

--- a/pkg/loop/telem.go
+++ b/pkg/loop/telem.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal"
 )
 
 type GRPCOpts = internal.GRPCOpts

--- a/pkg/loop/telemetry_test.go
+++ b/pkg/loop/telemetry_test.go
@@ -3,7 +3,7 @@ package loop_test
 import (
 	"testing"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 )
 
 func TestTelemetry(t *testing.T) {

--- a/pkg/monitoring/README.md
+++ b/pkg/monitoring/README.md
@@ -8,7 +8,7 @@ as well as a tutorial for creating new integrations.
 
 ## Documentation
 
-Godoc generated documentation is available [here](https://pkg.go.dev/github.com/smartcontractkit/chainlink-relay/pkg/monitoring#section-readme)
+Godoc generated documentation is available [here](https://pkg.go.dev/github.com/smartcontractkit/chainlink-common/pkg/monitoring#section-readme)
 
 ## Developing the monitoring framework
 

--- a/pkg/monitoring/exporter_kafka.go
+++ b/pkg/monitoring/exporter_kafka.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 // Pipeline represents a succession of transformations on the data coming from a source:

--- a/pkg/monitoring/exporter_kafka_test.go
+++ b/pkg/monitoring/exporter_kafka_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
 )
 
 func TestKafkaExporter(t *testing.T) {

--- a/pkg/monitoring/feed_monitor.go
+++ b/pkg/monitoring/feed_monitor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 type FeedMonitor interface {

--- a/pkg/monitoring/feed_monitor_test.go
+++ b/pkg/monitoring/feed_monitor_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 func TestFeedMonitor(t *testing.T) {

--- a/pkg/monitoring/http.go
+++ b/pkg/monitoring/http.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 // HTTPServer is the HTTP interface exposed by every monitoring.

--- a/pkg/monitoring/logger.go
+++ b/pkg/monitoring/logger.go
@@ -1,6 +1,6 @@
 package monitoring
 
-import "github.com/smartcontractkit/chainlink-relay/pkg/logger"
+import "github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 // Logger is a type alias for backwards compatibility.
 type Logger = logger.Logger

--- a/pkg/monitoring/manager.go
+++ b/pkg/monitoring/manager.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 // Manager restarts the multi-feed monitor whenever the feed configuration list has changed.

--- a/pkg/monitoring/manager_benchmark_test.go
+++ b/pkg/monitoring/manager_benchmark_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 // This benchmark measures how many messages end up in the kafka client given
@@ -15,7 +15,7 @@ import (
 
 // goos: darwin
 // goarch: amd64
-// pkg: github.com/smartcontractkit/chainlink-relay/pkg/monitoring
+// pkg: github.com/smartcontractkit/chainlink-common/pkg/monitoring
 // cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 // (10 jan 2022)
 //

--- a/pkg/monitoring/manager_test.go
+++ b/pkg/monitoring/manager_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 const numPollerUpdates = 10

--- a/pkg/monitoring/mapping.go
+++ b/pkg/monitoring/mapping.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/pb"
 )
 
 // Mapper is an interface for converting Envelopes into data structures that can be encoded in AVRO and sent to Kafka.

--- a/pkg/monitoring/monitor.go
+++ b/pkg/monitoring/monitor.go
@@ -8,9 +8,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 // Monitor is the entrypoint for an on-chain monitor integration.

--- a/pkg/monitoring/monitor_test.go
+++ b/pkg/monitoring/monitor_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 const testMonitorDurationSec = 15

--- a/pkg/monitoring/multi_feed_monitor.go
+++ b/pkg/monitoring/multi_feed_monitor.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 // MultiFeedMonitor manages the flow of data from multiple sources to

--- a/pkg/monitoring/multi_feed_monitor_benchmark_test.go
+++ b/pkg/monitoring/multi_feed_monitor_benchmark_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 // Results:
 // goos: darwin
 // goarch: amd64
-// pkg: github.com/smartcontractkit/chainlink-relay/pkg/monitoring
+// pkg: github.com/smartcontractkit/chainlink-common/pkg/monitoring
 // cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 // (11 Dec 2021)
 //    48993	     35111 ns/op	   44373 B/op	     251 allocs/op

--- a/pkg/monitoring/multi_feed_monitor_test.go
+++ b/pkg/monitoring/multi_feed_monitor_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 const numFeeds = 10

--- a/pkg/monitoring/producer.go
+++ b/pkg/monitoring/producer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
 )
 
 // Producer is an abstraction on top of Kafka to aid with tests.

--- a/pkg/monitoring/schema_registry.go
+++ b/pkg/monitoring/schema_registry.go
@@ -9,7 +9,7 @@ import (
 	"github.com/riferrei/srclient"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
 )
 
 type SchemaRegistry interface {

--- a/pkg/monitoring/schema_registry_test.go
+++ b/pkg/monitoring/schema_registry_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/riferrei/srclient"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/avro"
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/avro"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
 )
 
 const baseSchema = `

--- a/pkg/monitoring/schemas.go
+++ b/pkg/monitoring/schemas.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/linkedin/goavro/v2"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/avro"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/avro"
 )
 
 // This files contains Avro schemas for encoding message to be published to kafka.

--- a/pkg/monitoring/source_rdd.go
+++ b/pkg/monitoring/source_rdd.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
 
 type RDDData struct {

--- a/pkg/monitoring/source_rdd_test.go
+++ b/pkg/monitoring/source_rdd_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/config"
 )
 
 func TestRDDSource(t *testing.T) {

--- a/pkg/monitoring/testutils.go
+++ b/pkg/monitoring/testutils.go
@@ -21,8 +21,8 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/monitoring/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/monitoring/pb"
 )
 
 // Sources

--- a/pkg/reportingplugins/mercury/v1/mercury.go
+++ b/pkg/reportingplugins/mercury/v1/mercury.go
@@ -15,9 +15,9 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // MaxAllowedBlocks indicates the maximum len of LatestBlocks in any given observation.

--- a/pkg/reportingplugins/mercury/v1/mercury_test.go
+++ b/pkg/reportingplugins/mercury/v1/mercury_test.go
@@ -21,8 +21,8 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 )
 
 type testReportCodec struct {

--- a/pkg/reportingplugins/mercury/v1/types.go
+++ b/pkg/reportingplugins/mercury/v1/types.go
@@ -7,7 +7,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 )
 
 type Block struct {

--- a/pkg/reportingplugins/mercury/v1/validation.go
+++ b/pkg/reportingplugins/mercury/v1/validation.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 )
 
 // ValidateCurrentBlock sanity checks number and hash

--- a/pkg/reportingplugins/mercury/v2/mercury.go
+++ b/pkg/reportingplugins/mercury/v2/mercury.go
@@ -14,9 +14,9 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 type Observation struct {

--- a/pkg/reportingplugins/mercury/v2/mercury_test.go
+++ b/pkg/reportingplugins/mercury/v2/mercury_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 )
 
 type testDataSource struct {

--- a/pkg/reportingplugins/mercury/v2/types.go
+++ b/pkg/reportingplugins/mercury/v2/types.go
@@ -5,7 +5,7 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 )
 
 type PAO interface {

--- a/pkg/reportingplugins/mercury/v3/mercury.go
+++ b/pkg/reportingplugins/mercury/v3/mercury.go
@@ -14,9 +14,9 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 type Observation struct {

--- a/pkg/reportingplugins/mercury/v3/mercury_test.go
+++ b/pkg/reportingplugins/mercury/v3/mercury_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 )
 
 type testDataSource struct {

--- a/pkg/reportingplugins/mercury/v3/types.go
+++ b/pkg/reportingplugins/mercury/v3/types.go
@@ -5,7 +5,7 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
 )
 
 type PAO interface {

--- a/pkg/sqlutil/sqlutil.go
+++ b/pkg/sqlutil/sqlutil.go
@@ -36,6 +36,9 @@ func Transact[D any](ctx context.Context, newD func(Queryer) D, q Queryer, opts 
 		// Unsupported or already inside another transaction.
 		return fn(newD(q))
 	}
+	if opts == nil {
+		opts = &TxOptions{}
+	}
 	tx, err := db.BeginTxx(ctx, &opts.TxOptions)
 	if err != nil {
 		return err

--- a/pkg/types/provider_mercury.go
+++ b/pkg/types/provider_mercury.go
@@ -1,10 +1,10 @@
 package types
 
 import (
-	"github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
-	v1 "github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury/v1"
-	v2 "github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury/v2"
-	v3 "github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury/v3"
+	"github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury"
+	v1 "github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury/v1"
+	v2 "github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury/v2"
+	v3 "github.com/smartcontractkit/chainlink-common/pkg/reportingplugins/mercury/v3"
 )
 
 // MercuryProvider provides components needed for a mercury OCR2 plugin.

--- a/pkg/utils/duration.go
+++ b/pkg/utils/duration.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"time"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
 )
 
 // Deprecated: use config.Duration

--- a/pkg/utils/start_stop_once.go
+++ b/pkg/utils/start_stop_once.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/smartcontractkit/chainlink-relay/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
 // StartStopOnce can be embedded in a struct to help implement types.Service.

--- a/pkg/utils/testutils.go
+++ b/pkg/utils/testutils.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 // Deprecated: use tests.Context

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -1,6 +1,6 @@
 package utils
 
-import "github.com/smartcontractkit/chainlink-relay/pkg/config"
+import "github.com/smartcontractkit/chainlink-common/pkg/config"
 
 // Deprecated: use config.URL
 type URL = config.URL

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,7 +6,7 @@ import (
 	mrand "math/rand"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
 // WithJitter adds +/- 10% to a duration

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 # projectKey is required (may be found under "Project Information" in Sonar or in project url)
-sonar.projectKey=smartcontractkit_chainlink-relay
+sonar.projectKey=smartcontractkit_chainlink-common
 sonar.sources=.
 
 # Full exclusions from the static analysis


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-2784

The repo has been renamed. This PR renames the go modules, and rewrites the internal imports and CI references.

Supports:
- https://github.com/smartcontractkit/chainlink-cosmos/pull/385
- https://github.com/smartcontractkit/chainlink-solana/pull/555
- https://github.com/smartcontractkit/chainlink-starknet/pull/335
- https://github.com/smartcontractkit/chainlink/pull/11320