### PR TITLE
pkg/services/servicetest: remove debug fmt.Println

### DIFF
--- a/pkg/services/servicetest/run.go
+++ b/pkg/services/servicetest/run.go
@@ -49,7 +49,6 @@ func RunHealthy(tb TestingT, s services.Service) {
 			for k, v := range s.HealthReport() {
 				err = errors.Join(err, fmt.Errorf("%s: %w", k, v))
 			}
-			fmt.Println("Health report: ", err)
 			return
 		}
 		for s.Ready() != nil {


### PR DESCRIPTION
I left behind a `fmt.Println` in #251 :facepalm: 