### PR TITLE
pkg/logger: add SugaredLogger methods for Critical & Trace

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -181,56 +181,26 @@ func Helper(l Logger, skip int) Logger {
 	return l
 }
 
-// Critical emits critical level logs (a remapping of [zap.DPanicLevel]) or falls back to error level with a '[crit]' prefix.
+// Deprecated: instead use [SugaredLogger.Critical]:
+//
+//	Sugared(l).Critical(args...)
 func Critical(l Logger, args ...interface{}) {
-	l = Helper(l, 1)
-	switch t := l.(type) {
-	case *logger:
-		t.DPanic(args...)
-		return
-	}
-	c, ok := l.(interface {
-		Critical(args ...interface{})
-	})
-	if ok {
-		c.Critical(args...)
-		return
-	}
-	l.Error(append([]any{"[crit] "}, args...)...)
+	s := &sugared{Logger: l, h: Helper(l, 2)}
+	s.Critical(args...)
 }
 
-// Criticalf emits critical level logs (a remapping of [zap.DPanicLevel]) or falls back to error level with a '[crit]' prefix.
+// Deprecated: instead use [SugaredLogger.Criticalf]:
+//
+//	Sugared(l).Criticalf(args...)
 func Criticalf(l Logger, format string, values ...interface{}) {
-	l = Helper(l, 1)
-	switch t := l.(type) {
-	case *logger:
-		t.DPanicf(format, values...)
-		return
-	}
-	c, ok := l.(interface {
-		Criticalf(format string, values ...interface{})
-	})
-	if ok {
-		c.Criticalf(format, values...)
-		return
-	}
-	l.Errorf("[crit] "+format, values...)
+	s := &sugared{Logger: l, h: Helper(l, 2)}
+	s.Criticalf(format, values...)
 }
 
-// Criticalw emits critical level logs (a remapping of [zap.DPanicLevel]) or falls back to error level with a '[crit]' prefix.
+// Deprecated: instead use [SugaredLogger.Criticalw]:
+//
+//	Sugared(l).Criticalw(args...)
 func Criticalw(l Logger, msg string, keysAndValues ...interface{}) {
-	l = Helper(l, 1)
-	switch t := l.(type) {
-	case *logger:
-		t.DPanicw(msg, keysAndValues...)
-		return
-	}
-	c, ok := l.(interface {
-		Criticalw(msg string, keysAndValues ...interface{})
-	})
-	if ok {
-		c.Criticalw(msg, keysAndValues...)
-		return
-	}
-	l.Errorw("[crit] "+msg, keysAndValues...)
+	s := &sugared{Logger: l, h: Helper(l, 2)}
+	s.Criticalw(msg, keysAndValues...)
 }

--- a/pkg/logger/sugared.go
+++ b/pkg/logger/sugared.go
@@ -3,18 +3,35 @@ package logger
 // SugaredLogger extends the base Logger interface with syntactic sugar, similar to zap.SugaredLogger.
 type SugaredLogger interface {
 	Logger
+
 	// AssumptionViolation variants log at error level with the message prefix "AssumptionViolation: ".
 	AssumptionViolation(args ...interface{})
 	AssumptionViolationf(format string, vals ...interface{})
-	AssumptionViolationw(format string, vals ...interface{})
+	AssumptionViolationw(msg string, keysAndVals ...interface{})
+
 	// ErrorIf logs the error if present.
 	ErrorIf(err error, msg string)
 	// ErrorIfFn calls fn() and logs any returned error along with msg.
-	// Unlike ErrorIf, this can be deffered inline, since the function call is delayed.
+	// Unlike ErrorIf, this can be deffered inline, since the function call is delayed:
+	//
+	//	defer lggr.ErrorIfFn(resource.Close, "Failed to close resource")
 	ErrorIfFn(fn func() error, msg string)
+
+	// Critical emits critical level logs (a remapping of [zap.DPanicLevel]) or falls back to error level with a '[crit]' prefix.
+	Critical(args ...interface{})
+	Criticalf(format string, vals ...interface{})
+	Criticalw(msg string, keysAndVals ...interface{})
+
+	// Trace emits logs only when built with the 'trace' tag.
+	//
+	//	go test -tags trace ./foo -run TestBar
+	Trace(args ...interface{})
+	Tracef(format string, vals ...interface{})
+	Tracew(msg string, keysAndVals ...interface{})
 }
 
 // Sugared returns a new SugaredLogger wrapping the given Logger.
+// Prefer to store the SugaredLogger for reuse, instead of recreating it as needed.
 func Sugared(l Logger) SugaredLogger {
 	return &sugared{
 		Logger: l,
@@ -39,17 +56,66 @@ func (s *sugared) ErrorIfFn(fn func() error, msg string) {
 	}
 }
 
-// AssumptionViolation wraps Error logs with assumption violation tag.
+const assumptionViolationPrefix = "AssumptionViolation: "
+
 func (s *sugared) AssumptionViolation(args ...interface{}) {
-	s.h.Error(append([]interface{}{"AssumptionViolation:"}, args...))
+	s.h.Error(append([]interface{}{assumptionViolationPrefix}, args...))
 }
 
-// AssumptionViolationf wraps Errorf logs with assumption violation tag.
 func (s *sugared) AssumptionViolationf(format string, vals ...interface{}) {
-	s.h.Errorf("AssumptionViolation: "+format, vals...)
+	s.h.Errorf(assumptionViolationPrefix+format, vals...)
 }
 
-// AssumptionViolationw wraps Errorw logs with assumption violation tag.
 func (s *sugared) AssumptionViolationw(msg string, keyvals ...interface{}) {
-	s.h.Errorw("AssumptionViolation: "+msg, keyvals...)
+	s.h.Errorw(assumptionViolationPrefix+msg, keyvals...)
+}
+
+const critPrefix = "[crit] "
+
+func (s *sugared) Critical(args ...interface{}) {
+	switch t := s.h.(type) {
+	case *logger:
+		t.DPanic(args...)
+		return
+	}
+	c, ok := s.h.(interface {
+		Critical(args ...interface{})
+	})
+	if ok {
+		c.Critical(args...)
+		return
+	}
+	s.h.Error(append([]any{critPrefix}, args...)...)
+}
+
+func (s *sugared) Criticalf(format string, values ...interface{}) {
+	switch t := s.h.(type) {
+	case *logger:
+		t.DPanicf(format, values...)
+		return
+	}
+	c, ok := s.h.(interface {
+		Criticalf(format string, values ...interface{})
+	})
+	if ok {
+		c.Criticalf(format, values...)
+		return
+	}
+	s.h.Errorf(critPrefix+format, values...)
+}
+
+func (s *sugared) Criticalw(msg string, keysAndValues ...interface{}) {
+	switch t := s.h.(type) {
+	case *logger:
+		t.DPanicw(msg, keysAndValues...)
+		return
+	}
+	c, ok := s.h.(interface {
+		Criticalw(msg string, keysAndValues ...interface{})
+	})
+	if ok {
+		c.Criticalw(msg, keysAndValues...)
+		return
+	}
+	s.h.Errorw(critPrefix+msg, keysAndValues...)
 }

--- a/pkg/logger/trace.go
+++ b/pkg/logger/trace.go
@@ -4,50 +4,74 @@ package logger
 
 const tracePrefix = "[trace] "
 
-func Trace(l Logger, args ...interface{}) {
-	switch t := l.(type) {
+func (s *sugared) Trace(args ...interface{}) {
+	switch t := s.h.(type) {
 	case *logger:
 		t.DPanic(args...)
 		return
 	}
-	c, ok := l.(interface {
+	c, ok := s.h.(interface {
 		Trace(args ...interface{})
 	})
 	if ok {
 		c.Trace(args...)
 		return
 	}
-	l.Error(append([]any{tracePrefix}, args...)...)
+	s.h.Error(append([]any{tracePrefix}, args...)...)
 }
 
-func Tracef(l Logger, format string, values ...interface{}) {
-	switch t := l.(type) {
+func (s *sugared) Tracef(format string, vals ...interface{}) {
+	switch t := s.h.(type) {
 	case *logger:
 		t.DPanicf(format, values...)
 		return
 	}
-	c, ok := l.(interface {
+	c, ok := s.h.(interface {
 		Tracef(format string, values ...interface{})
 	})
 	if ok {
 		c.Tracef(format, values...)
 		return
 	}
-	l.Errorf(tracePrefix+format, values...)
+	s.h.Errorf(tracePrefix+format, values...)
 }
 
-func Tracew(l Logger, msg string, keysAndValues ...interface{}) {
-	switch t := l.(type) {
+func (s *sugared) Tracew(msg string, keysAndValues ...interface{}) {
+	switch t := s.h.(type) {
 	case *logger:
 		t.DPanicw(msg, keysAndValues...)
 		return
 	}
-	c, ok := l.(interface {
+	c, ok := s.h.(interface {
 		Tracew(msg string, keysAndValues ...interface{})
 	})
 	if ok {
 		c.Tracew(msg, keysAndValues...)
 		return
 	}
-	l.Errorf(tracePrefix+msg, keysAndValues)
+	s.h.Errorf(tracePrefix+msg, keysAndValues)
+}
+
+// Deprecated: instead use [SugaredLogger.Trace]:
+//
+//	Sugared(l).Trace(args...)
+func Trace(l Logger, args ...interface{}) {
+	s := &sugared{Logger: l, h: Helper(l, 2)}
+	s.Trace(args...)
+}
+
+// Deprecated: instead use [SugaredLogger.Tracef]:
+//
+//	Sugared(l).Tracef(args...)
+func Tracef(l Logger, format string, values ...interface{}) {
+	s := &sugared{Logger: l, h: Helper(l, 2)}
+	s.Tracef(fromat, values...)
+}
+
+// Deprecated: instead use [SugaredLogger.Tracew]:
+//
+//	Sugared(l).Tracew(args...)
+func Tracew(l Logger, msg string, keysAndValues ...interface{}) {
+	s := &sugared{Logger: l, h: Helper(l, 2)}
+	s.Tracew(msg, keysAndValues...)
 }

--- a/pkg/logger/trace_noop.go
+++ b/pkg/logger/trace_noop.go
@@ -2,8 +2,23 @@
 
 package logger
 
+func (s *sugared) Trace(args ...interface{}) {}
+
+func (s *sugared) Tracef(format string, vals ...interface{}) {}
+
+func (s *sugared) Tracew(msg string, keysAndValues ...interface{}) {}
+
+// Deprecated: instead use [SugaredLogger.Trace]:
+//
+//	Sugared(l).Trace(args...)
 func Trace(l Logger, args ...interface{}) {}
 
+// Deprecated: instead use [SugaredLogger.Tracef]:
+//
+//	Sugared(l).Tracef(args...)
 func Tracef(l Logger, format string, values ...interface{}) {}
 
+// Deprecated: instead use [SugaredLogger.Tracew]:
+//
+//	Sugared(l).Tracew(args...)
 func Tracew(l Logger, msg string, keysAndValues ...interface{}) {}


### PR DESCRIPTION
This PR aims to simplify some of the inconvenient logger helpers which require you to call `logger.Func(lggr, "foo")` instead of just calling a method `lggr.Func("foo")`, by extending the `SugaredLogger` to include them. This should ease the transition from the core logger, by eliminating the need for many func/method rewrites.