### PR TITLE
pkg/loop/internal: remove CL_DATASOURCE_OVERTIME

### DIFF
--- a/pkg/loop/internal/datasource.go
+++ b/pkg/loop/internal/datasource.go
@@ -3,8 +3,6 @@ package internal
 import (
 	"context"
 	"math/big"
-	"os"
-	"time"
 
 	"google.golang.org/grpc"
 
@@ -12,22 +10,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 )
-
-// github.com/smartcontractkit/libocr/offchainreporting2plus/internal/protocol.ReportingPluginTimeoutWarningGracePeriod
-var datasourceOvertime = 100 * time.Millisecond
-
-func init() {
-	// undocumented escape hatch
-	// TODO: remove with https://smartcontract-it.atlassian.net/browse/BCF-2209
-	if v := os.Getenv("CL_DATASOURCE_OVERTIME"); v != "" {
-		d, err := time.ParseDuration(v)
-		if err == nil {
-			datasourceOvertime = d
-		}
-	}
-}
 
 var _ median.DataSource = (*dataSourceClient)(nil)
 
@@ -58,17 +41,6 @@ type dataSourceServer struct {
 }
 
 func (d *dataSourceServer) Observe(ctx context.Context, request *pb.ObserveRequest) (*pb.ObserveReply, error) {
-	// Pipeline observations may return results after the context is cancelled, so we modify the
-	// deadline to give them time to return before the parent context deadline.
-	// TODO: remove with https://smartcontract-it.atlassian.net/browse/BCF-2209
-	var cancel func()
-	ctx, cancel = utils.ContextWithDeadlineFn(ctx, func(orig time.Time) time.Time {
-		if tenPct := time.Until(orig) / 10; datasourceOvertime > tenPct {
-			return orig.Add(-tenPct)
-		}
-		return orig.Add(-datasourceOvertime)
-	})
-	defer cancel()
 	timestamp, err := reportTimestamp(request.ReportTimestamp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-2209

This PR removes an override specific to LOOPP clients, and the core side follow up applies it generally, from inside the pipeline.

Supports:
- https://github.com/smartcontractkit/chainlink/pull/11555

core ref: BCF-2209-pipeline-ctx