### PR TITLE
Add hex package

### DIFF
--- a/pkg/utils/hex/hex.go
+++ b/pkg/utils/hex/hex.go
@@ -16,17 +16,17 @@ func EnsurePrefix(str string) string {
 	return str
 }
 
-// ToBig parses the given hex string or panics if it is invalid.
-func ToBig(s string) *big.Int {
+// ToBig parses the given hex string and returns error if it is invalid.
+func ToBig(s string) (*big.Int, error) {
 	n, ok := new(big.Int).SetString(s, 16)
 	if !ok {
-		panic(fmt.Errorf(`failed to convert "%s" as hex to big.Int`, s))
+		return nil, fmt.Errorf(`failed to convert "%s" as hex to big.Int`, s)
 	}
-	return n
+	return n, nil
 }
 
-// RemovePrefix removes the prefix (0x) of a given hex string.
-func RemovePrefix(str string) string {
+// TrimPrefix removes the prefix (0x) of a given hex string.
+func TrimPrefix(str string) string {
 	if HasPrefix(str) {
 		return str[2:]
 	}
@@ -41,7 +41,7 @@ func HasPrefix(str string) bool {
 // TryParse parses the given hex string to bytes,
 // it can return error if the hex string is invalid.
 // Follows the semantic of ethereum's FromHex.
-func TryParse(s string) (b []byte, err error) {
+func DecodeString(s string) (b []byte, err error) {
 	if !HasPrefix(s) {
 		err = errors.New("hex string must have 0x prefix")
 	} else {

--- a/pkg/utils/hex/hex.go
+++ b/pkg/utils/hex/hex.go
@@ -1,0 +1,55 @@
+package hex
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// EnsurePrefix adds the prefix (0x) to a given hex string.
+func EnsurePrefix(str string) string {
+	if !strings.HasPrefix(str, "0x") {
+		str = "0x" + str
+	}
+	return str
+}
+
+// ToBig parses the given hex string or panics if it is invalid.
+func ToBig(s string) *big.Int {
+	n, ok := new(big.Int).SetString(s, 16)
+	if !ok {
+		panic(fmt.Errorf(`failed to convert "%s" as hex to big.Int`, s))
+	}
+	return n
+}
+
+// RemovePrefix removes the prefix (0x) of a given hex string.
+func RemovePrefix(str string) string {
+	if HasPrefix(str) {
+		return str[2:]
+	}
+	return str
+}
+
+// HasPrefix returns true if the string starts with 0x.
+func HasPrefix(str string) bool {
+	return len(str) >= 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X')
+}
+
+// TryParse parses the given hex string to bytes,
+// it can return error if the hex string is invalid.
+// Follows the semantic of ethereum's FromHex.
+func TryParse(s string) (b []byte, err error) {
+	if !HasPrefix(s) {
+		err = errors.New("hex string must have 0x prefix")
+	} else {
+		s = s[2:]
+		if len(s)%2 == 1 {
+			s = "0" + s
+		}
+		b, err = hex.DecodeString(s)
+	}
+	return
+}

--- a/pkg/utils/hex/hex.go
+++ b/pkg/utils/hex/hex.go
@@ -16,8 +16,8 @@ func EnsurePrefix(str string) string {
 	return str
 }
 
-// ToBig parses the given hex string and returns error if it is invalid.
-func ToBig(s string) (*big.Int, error) {
+// ParseBig parses the given hex string and returns error if it is invalid.
+func ParseBig(s string) (*big.Int, error) {
 	n, ok := new(big.Int).SetString(s, 16)
 	if !ok {
 		return nil, fmt.Errorf(`failed to convert "%s" as hex to big.Int`, s)
@@ -38,7 +38,7 @@ func HasPrefix(str string) bool {
 	return len(str) >= 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X')
 }
 
-// TryParse parses the given hex string to bytes,
+// DecodeString parses the given hex string to bytes,
 // it can return error if the hex string is invalid.
 // Follows the semantic of ethereum's FromHex.
 func DecodeString(s string) (b []byte, err error) {

--- a/pkg/utils/hex/hex_test.go
+++ b/pkg/utils/hex/hex_test.go
@@ -7,6 +7,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestParseBig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses successfully", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := hex.ParseBig("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := hex.ParseBig("0xabc")
+		assert.Error(t, err)
+	})
+}
+
 func TestTrimPrefix(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/utils/hex/hex_test.go
+++ b/pkg/utils/hex/hex_test.go
@@ -7,6 +7,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTrimPrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("trims prefix", func(t *testing.T) {
+		t.Parallel()
+
+		s := hex.TrimPrefix("0xabc")
+		assert.Equal(t, "abc", s)
+	})
+
+	t.Run("returns the same string if it doesn't have prefix", func(t *testing.T) {
+		t.Parallel()
+
+		s := hex.TrimPrefix("defg")
+		assert.Equal(t, "defg", s)
+	})
+}
+
 func TestHasPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -30,30 +48,29 @@ func TestHasPrefix(t *testing.T) {
 		r := hex.HasPrefix("abc0x")
 		assert.False(t, r)
 	})
-
 }
 
-func TestTryParse(t *testing.T) {
+func TestDecodeString(t *testing.T) {
 	t.Parallel()
 
 	t.Run("0x prefix missing", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := hex.TryParse("abcd")
+		_, err := hex.DecodeString("abcd")
 		assert.Error(t, err)
 	})
 
 	t.Run("wrong hex characters", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := hex.TryParse("0xabcdzzz")
+		_, err := hex.DecodeString("0xabcdzzz")
 		assert.Error(t, err)
 	})
 
 	t.Run("valid hex string", func(t *testing.T) {
 		t.Parallel()
 
-		b, err := hex.TryParse("0x1234")
+		b, err := hex.DecodeString("0x1234")
 		assert.NoError(t, err)
 		assert.Equal(t, []byte{0x12, 0x34}, b)
 	})
@@ -61,7 +78,7 @@ func TestTryParse(t *testing.T) {
 	t.Run("prepend odd length with zero", func(t *testing.T) {
 		t.Parallel()
 
-		b, err := hex.TryParse("0x123")
+		b, err := hex.DecodeString("0x123")
 		assert.NoError(t, err)
 		assert.Equal(t, []byte{0x1, 0x23}, b)
 	})

--- a/pkg/utils/hex/hex_test.go
+++ b/pkg/utils/hex/hex_test.go
@@ -1,0 +1,68 @@
+package hex_test
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasPrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("has prefix", func(t *testing.T) {
+		t.Parallel()
+
+		r := hex.HasPrefix("0xabc")
+		assert.True(t, r)
+	})
+
+	t.Run("doesn't have prefix", func(t *testing.T) {
+		t.Parallel()
+
+		r := hex.HasPrefix("abc")
+		assert.False(t, r)
+	})
+
+	t.Run("has 0x suffix", func(t *testing.T) {
+		t.Parallel()
+
+		r := hex.HasPrefix("abc0x")
+		assert.False(t, r)
+	})
+
+}
+
+func TestTryParse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("0x prefix missing", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := hex.TryParse("abcd")
+		assert.Error(t, err)
+	})
+
+	t.Run("wrong hex characters", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := hex.TryParse("0xabcdzzz")
+		assert.Error(t, err)
+	})
+
+	t.Run("valid hex string", func(t *testing.T) {
+		t.Parallel()
+
+		b, err := hex.TryParse("0x1234")
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{0x12, 0x34}, b)
+	})
+
+	t.Run("prepend odd length with zero", func(t *testing.T) {
+		t.Parallel()
+
+		b, err := hex.TryParse("0x123")
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{0x1, 0x23}, b)
+	})
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math"
 	mrand "math/rand"
-	"strings"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -49,12 +48,4 @@ func ContextWithDeadlineFn(ctx context.Context, deadlineFn func(orig time.Time) 
 func IsZero[C comparable](val C) bool {
 	var zero C
 	return zero == val
-}
-
-// EnsureHexPrefix adds the prefix (0x) to a given hex string.
-func EnsureHexPrefix(str string) string {
-	if !strings.HasPrefix(str, "0x") {
-		str = "0x" + str
-	}
-	return str
 }


### PR DESCRIPTION
Adding `hex` package with common functions from `chainlink` repo to support EVM extraction. Required for: https://github.com/smartcontractkit/chainlink/pull/11584