### PR TITLE
Add MercuryCredentials to RelayArgs

### DIFF
--- a/pkg/types/provider_automation.go
+++ b/pkg/types/provider_automation.go
@@ -12,5 +12,7 @@ type AutomationProvider interface {
 	UpkeepStateStore() automation.UpkeepStateStore
 	LogEventProvider() automation.LogEventProvider
 	LogRecoverer() automation.LogRecoverer
+	Encoder() automation.Encoder
 	UpkeepProvider() automation.ConditionalUpkeepProvider
+	PayloadBuilder() automation.PayloadBuilder
 }

--- a/pkg/types/provider_automation.go
+++ b/pkg/types/provider_automation.go
@@ -6,13 +6,12 @@ import "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 type AutomationProvider interface {
 	PluginProvider
 	Registry() automation.Registry
+	Encoder() automation.Encoder
 	TransmitEventProvider() automation.EventProvider
 	BlockSubscriber() automation.BlockSubscriber
 	PayloadBuilder() automation.PayloadBuilder
 	UpkeepStateStore() automation.UpkeepStateStore
 	LogEventProvider() automation.LogEventProvider
 	LogRecoverer() automation.LogRecoverer
-	Encoder() automation.Encoder
 	UpkeepProvider() automation.ConditionalUpkeepProvider
-	PayloadBuilder() automation.PayloadBuilder
 }

--- a/pkg/types/provider_automation.go
+++ b/pkg/types/provider_automation.go
@@ -6,7 +6,6 @@ import "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 type AutomationProvider interface {
 	PluginProvider
 	Registry() automation.Registry
-	Encoder() automation.Encoder
 	TransmitEventProvider() automation.EventProvider
 	BlockSubscriber() automation.BlockSubscriber
 	PayloadBuilder() automation.PayloadBuilder

--- a/pkg/types/relayer.go
+++ b/pkg/types/relayer.go
@@ -22,7 +22,7 @@ type RelayArgs struct {
 	New                bool // Whether this is a first time job add.
 	RelayConfig        []byte
 	ProviderType       string
-	MercuryCredentials MercuryCredentials
+	MercuryCredentials *MercuryCredentials
 }
 
 type MercuryCredentials struct {

--- a/pkg/types/relayer.go
+++ b/pkg/types/relayer.go
@@ -16,12 +16,20 @@ type PluginArgs struct {
 }
 
 type RelayArgs struct {
-	ExternalJobID uuid.UUID
-	JobID         int32
-	ContractID    string
-	New           bool // Whether this is a first time job add.
-	RelayConfig   []byte
-	ProviderType  string
+	ExternalJobID      uuid.UUID
+	JobID              int32
+	ContractID         string
+	New                bool // Whether this is a first time job add.
+	RelayConfig        []byte
+	ProviderType       string
+	MercuryCredentials MercuryCredentials
+}
+
+type MercuryCredentials struct {
+	LegacyURL string
+	URL       string
+	Username  string
+	Password  string
 }
 
 type ChainStatus struct {


### PR DESCRIPTION
This PR reduces the responsibilities of the `AutomationProvider`, since the existing code in core will take care of some services needed for the delegate config, making `AutomationProvider` responsible only for the services passed to the `automationServices` slice

 This PR also introduces a `MercuryCredentials` struct that can be passed in the `RelayArgs`