### PR TITLE
Add nop-friendly error logging

### DIFF
--- a/pkg/loop/internal/median.go
+++ b/pkg/loop/internal/median.go
@@ -95,7 +95,7 @@ func (m *PluginMedianClient) NewMedianFactory(ctx context.Context, provider type
 		}
 		return reply.ReportingPluginFactoryID, nil, nil
 	})
-	return newReportingPluginFactoryClient(m.pluginClient.brokerExt, cc), nil
+	return newReportingPluginFactoryClient(m.pluginClient.brokerExt, cc, errorLog), nil
 }
 
 var _ pb.PluginMedianServer = (*pluginMedianServer)(nil)
@@ -156,7 +156,7 @@ func (m *pluginMedianServer) NewMedianFactory(ctx context.Context, request *pb.N
 
 	id, _, err := m.serveNew("ReportingPluginProvider", func(s *grpc.Server) {
 		pb.RegisterServiceServer(s, &serviceServer{srv: factory})
-		pb.RegisterReportingPluginFactoryServer(s, newReportingPluginFactoryServer(factory, m.brokerExt))
+		pb.RegisterReportingPluginFactoryServer(s, newReportingPluginFactoryServer(factory, m.brokerExt, errorLog))
 	}, dsRes, juelsRes, providerRes, errorLogRes)
 	if err != nil {
 		return nil, err

--- a/pkg/loop/internal/reporting.go
+++ b/pkg/loop/internal/reporting.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 

--- a/pkg/loop/internal/reporting_plugin_service.go
+++ b/pkg/loop/internal/reporting_plugin_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/mwitkow/grpc-proxy/proxy"
-	"github.com/pkg/errors"
+	"errors"
 	"google.golang.org/grpc"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"


### PR DESCRIPTION
This PR sends errors from the LOOP binary and GRPC calls to the core node so they can be presented in the UI to NOPs.