### PR TITLE
Bcf 2572 relayer fuzz test

### DIFF
--- a/pkg/codec/element_extractor.go
+++ b/pkg/codec/element_extractor.go
@@ -21,8 +21,8 @@ const (
 	ElementExtractorLocationDefault = ElementExtractorLocationMiddle
 )
 
-func (e *ElementExtractorLocation) MarshalJSON() ([]byte, error) {
-	switch *e {
+func (e ElementExtractorLocation) MarshalJSON() ([]byte, error) {
+	switch e {
 	case ElementExtractorLocationFirst:
 		return json.Marshal("first")
 	case ElementExtractorLocationMiddle:
@@ -30,7 +30,7 @@ func (e *ElementExtractorLocation) MarshalJSON() ([]byte, error) {
 	case ElementExtractorLocationLast:
 		return json.Marshal("last")
 	default:
-		return nil, fmt.Errorf("%w: %d", types.ErrInvalidType, *e)
+		return nil, fmt.Errorf("%w: %d", types.ErrInvalidType, e)
 	}
 }
 

--- a/pkg/codec/element_extractor_test.go
+++ b/pkg/codec/element_extractor_test.go
@@ -500,7 +500,7 @@ func TestElementExtractor(t *testing.T) {
 		{location: codec.ElementExtractorLocationLast},
 	} {
 		t.Run("Json encoding works", func(t *testing.T) {
-			b, err := json.Marshal(&test.location)
+			b, err := json.Marshal(test.location)
 			require.NoError(t, err)
 			var actual codec.ElementExtractorLocation
 			require.NoError(t, json.Unmarshal(b, &actual))

--- a/pkg/codec/epoch_to_time_test.go
+++ b/pkg/codec/epoch_to_time_test.go
@@ -26,7 +26,7 @@ func TestTimeToUnix(t *testing.T) {
 	tsst := reflect.TypeOf(&testSliceStruct{})
 
 	type testArrayStruct struct{ T [2]int64 }
-	tast := reflect.TypeOf(&testArrayStruct{})
+	tArrSt := reflect.TypeOf(&testArrayStruct{})
 
 	type otherIntegerType struct {
 		A string
@@ -108,14 +108,14 @@ func TestTimeToUnix(t *testing.T) {
 
 	t.Run("RetypeToOffChain converts arrays", func(t *testing.T) {
 		converter := codec.NewEpochToTimeModifier([]string{"T"})
-		convertedType, err := converter.RetypeToOffChain(tast, "")
+		convertedType, err := converter.RetypeToOffChain(tArrSt, "")
 
 		require.NoError(t, err)
 		assert.Equal(t, reflect.Pointer, convertedType.Kind())
 		convertedType = convertedType.Elem()
 
 		require.Equal(t, 1, convertedType.NumField())
-		assert.Equal(t, tast.Elem().Field(0).Name, convertedType.Field(0).Name)
+		assert.Equal(t, tArrSt.Elem().Field(0).Name, convertedType.Field(0).Name)
 		assert.Equal(t, reflect.TypeOf([]*time.Time{}), convertedType.Field(0).Type)
 	})
 
@@ -152,7 +152,7 @@ func TestTimeToUnix(t *testing.T) {
 
 	t.Run("TransformToOnChain converts times to integer array", func(t *testing.T) {
 		converter := codec.NewEpochToTimeModifier([]string{"T"})
-		convertedType, err := converter.RetypeToOffChain(tast, "")
+		convertedType, err := converter.RetypeToOffChain(tArrSt, "")
 		require.NoError(t, err)
 
 		rOffchain := reflect.New(convertedType.Elem())
@@ -214,7 +214,7 @@ func TestTimeToUnix(t *testing.T) {
 
 	t.Run("TransformToOffChain converts times to integer array", func(t *testing.T) {
 		converter := codec.NewEpochToTimeModifier([]string{"T"})
-		convertedType, err := converter.RetypeToOffChain(tast, "")
+		convertedType, err := converter.RetypeToOffChain(tArrSt, "")
 		require.NoError(t, err)
 
 		actual, err := converter.TransformToOffChain(&testArrayStruct{T: [2]int64{anyTimeEpoch, anyTimeEpoch2}}, "")

--- a/pkg/codec/example_test.go
+++ b/pkg/codec/example_test.go
@@ -106,6 +106,11 @@ func Example() {
 
 	ctx := context.Background()
 	b, err := c.Encode(ctx, input, anyUnmodifiedTypeName)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	fmt.Println("Encoded: " + string(b))
 
 	output := &OnChainStruct{}
@@ -138,12 +143,12 @@ func Example() {
 		return
 	}
 
-	fmt.Printf("Decoded wih modifications: %+v\n", output2)
+	fmt.Printf("Decoded with modifications: %+v\n", output2)
 	// Output:
 	// Encoded: {"Aa":10,"Bb":"20","Cc":true,"Dd":"great example","Ee":631515600,"Ff":"dog"}
 	// Decoded: &{Aa:10 Bb:20 Cc:true Dd:great example Ee:631515600 Ff:dog}
 	// Encoded with modifications: {"Aa":10,"Bb":"","Cc":true,"Dd":"great example","Ee":631515600,"Ff":"dog"}
-	// Decoded wih modifications: &{Bb:10 Cc:true Dd:[great example] Ee:1990-01-05 05:00:00 +0000 UTC Zz:foo}
+	// Decoded with modifications: &{Bb:10 Cc:true Dd:[great example] Ee:1990-01-05 05:00:00 +0000 UTC Zz:foo}
 }
 
 func createModsFromConfig() (codec.Modifier, error) {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -157,7 +157,7 @@ func testCritical(t *testing.T, lggr Logger, observed *observer.ObservedLogs, ms
 	Critical(lggr, "foo", "bar")
 	_, filename, lineNum, ok := runtime.Caller(0)
 	require.True(t, ok)
-	lineNum -= 1
+	lineNum--
 
 	all := observed.TakeAll()
 	require.Len(t, all, 1)
@@ -186,7 +186,7 @@ func testCriticalw(t *testing.T, lggr Logger, observed *observer.ObservedLogs, m
 	Criticalw(lggr, "msg", "foo", "bar")
 	_, filename, lineNum, ok := runtime.Caller(0)
 	require.True(t, ok)
-	lineNum -= 1
+	lineNum--
 
 	all := observed.TakeAll()
 	require.Len(t, all, 1)
@@ -216,7 +216,7 @@ func testCriticalf(t *testing.T, lggr Logger, observed *observer.ObservedLogs, m
 	Criticalf(lggr, "foo: %s", "bar")
 	_, filename, lineNum, ok := runtime.Caller(0)
 	require.True(t, ok)
-	lineNum -= 1
+	lineNum--
 
 	all := observed.TakeAll()
 	require.Len(t, all, 1)

--- a/pkg/loop/internal/test/cmd/main.go
+++ b/pkg/loop/internal/test/cmd/main.go
@@ -23,6 +23,9 @@ func main() {
 	limitI := 0
 	flag.IntVar(&limitI, "limit", 0, "the number of services to run")
 
+	var staticChecks bool
+	flag.BoolVar(&staticChecks, "static-checks", false, "run static var checks on static relayer")
+
 	flag.Parse()
 	defer os.Exit(0)
 
@@ -58,7 +61,7 @@ func main() {
 		plugin.Serve(&plugin.ServeConfig{
 			HandshakeConfig: loop.PluginRelayerHandshakeConfig(),
 			Plugins: map[string]plugin.Plugin{
-				loop.PluginRelayerName: &loop.GRPCPluginRelayer{PluginServer: test.StaticPluginRelayer{}, BrokerConfig: loop.BrokerConfig{Logger: lggr, StopCh: stopCh}},
+				loop.PluginRelayerName: &loop.GRPCPluginRelayer{PluginServer: test.StaticPluginRelayer{StaticChecks: staticChecks}, BrokerConfig: loop.BrokerConfig{Logger: lggr, StopCh: stopCh}},
 			},
 			GRPCServer: grpcServer,
 		})

--- a/pkg/loop/internal/test/relayer.go
+++ b/pkg/loop/internal/test/relayer.go
@@ -37,30 +37,34 @@ func (s StaticKeystore) Sign(ctx context.Context, id string, data []byte) ([]byt
 	return signed, nil
 }
 
-type StaticPluginRelayer struct{}
+type StaticPluginRelayer struct {
+	StaticChecks bool
+}
 
 func (s StaticPluginRelayer) NewRelayer(ctx context.Context, config string, keystore types.Keystore) (internal.Relayer, error) {
-	if config != ConfigTOML {
+	if s.StaticChecks && config != ConfigTOML {
 		return nil, fmt.Errorf("expected config %q but got %q", ConfigTOML, config)
 	}
 	keys, err := keystore.Accounts(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if !reflect.DeepEqual([]string{string(account)}, keys) {
+	if s.StaticChecks && !reflect.DeepEqual([]string{string(account)}, keys) {
 		return nil, fmt.Errorf("expected keys %v but got %v", []string{string(account)}, keys)
 	}
 	gotSigned, err := keystore.Sign(ctx, string(account), encoded)
 	if err != nil {
 		return nil, err
 	}
-	if !bytes.Equal(signed, gotSigned) {
+	if s.StaticChecks && !bytes.Equal(signed, gotSigned) {
 		return nil, fmt.Errorf("expected signed bytes %x but got %x", signed, gotSigned)
 	}
-	return staticRelayer{}, nil
+	return staticRelayer{StaticChecks: s.StaticChecks}, nil
 }
 
-type staticRelayer struct{}
+type staticRelayer struct {
+	StaticChecks bool
+}
 
 func (s staticRelayer) Start(ctx context.Context) error { return nil }
 
@@ -73,31 +77,37 @@ func (s staticRelayer) Name() string { panic("unimplemented") }
 func (s staticRelayer) HealthReport() map[string]error { panic("unimplemented") }
 
 func (s staticRelayer) NewConfigProvider(ctx context.Context, r types.RelayArgs) (types.ConfigProvider, error) {
-	if !equalRelayArgs(r, RelayArgs) {
+	if s.StaticChecks && !equalRelayArgs(r, RelayArgs) {
 		return nil, fmt.Errorf("expected relay args:\n\t%v\nbut got:\n\t%v", RelayArgs, r)
 	}
 	return staticConfigProvider{}, nil
 }
 
 func (s staticRelayer) NewMedianProvider(ctx context.Context, r types.RelayArgs, p types.PluginArgs) (types.MedianProvider, error) {
-	ra := newRelayArgsWithProviderType(types.Median)
-	if !equalRelayArgs(r, ra) {
-		return nil, fmt.Errorf("expected relay args:\n\t%v\nbut got:\n\t%v", RelayArgs, r)
+	if s.StaticChecks {
+		ra := newRelayArgsWithProviderType(types.Median)
+		if !equalRelayArgs(r, ra) {
+			return nil, fmt.Errorf("expected relay args:\n\t%v\nbut got:\n\t%v", RelayArgs, r)
+		}
+		if !reflect.DeepEqual(PluginArgs, p) {
+			return nil, fmt.Errorf("expected plugin args %v but got %v", PluginArgs, p)
+		}
 	}
-	if !reflect.DeepEqual(PluginArgs, p) {
-		return nil, fmt.Errorf("expected plugin args %v but got %v", PluginArgs, p)
-	}
+
 	return StaticMedianProvider{}, nil
 }
 
 func (s staticRelayer) NewPluginProvider(ctx context.Context, r types.RelayArgs, p types.PluginArgs) (types.PluginProvider, error) {
-	ra := newRelayArgsWithProviderType(types.Median)
-	if !equalRelayArgs(r, ra) {
-		return nil, fmt.Errorf("expected relay args:\n\t%v\nbut got:\n\t%v", RelayArgs, r)
+	if s.StaticChecks {
+		ra := newRelayArgsWithProviderType(types.Median)
+		if !equalRelayArgs(r, ra) {
+			return nil, fmt.Errorf("expected relay args:\n\t%v\nbut got:\n\t%v", RelayArgs, r)
+		}
+		if !reflect.DeepEqual(PluginArgs, p) {
+			return nil, fmt.Errorf("expected plugin args %v but got %v", PluginArgs, p)
+		}
 	}
-	if !reflect.DeepEqual(PluginArgs, p) {
-		return nil, fmt.Errorf("expected plugin args %v but got %v", PluginArgs, p)
-	}
+
 	return StaticPluginProvider{}, nil
 }
 
@@ -110,7 +120,7 @@ func (s staticRelayer) GetChainStatus(ctx context.Context) (types.ChainStatus, e
 }
 
 func (s staticRelayer) ListNodeStatuses(ctx context.Context, pageSize int32, pageToken string) ([]types.NodeStatus, string, int, error) {
-	if limit != pageSize {
+	if s.StaticChecks && limit != pageSize {
 		return nil, "", -1, fmt.Errorf("expected page_size %d but got %d", limit, pageSize)
 	}
 	if pageToken != "" {
@@ -120,18 +130,21 @@ func (s staticRelayer) ListNodeStatuses(ctx context.Context, pageSize int32, pag
 }
 
 func (s staticRelayer) Transact(ctx context.Context, f, t string, a *big.Int, b bool) error {
-	if f != from {
-		return fmt.Errorf("expected from %s but got %s", from, f)
+	if s.StaticChecks {
+		if f != from {
+			return fmt.Errorf("expected from %s but got %s", from, f)
+		}
+		if t != to {
+			return fmt.Errorf("expected to %s but got %s", to, t)
+		}
+		if amount.Cmp(a) != 0 {
+			return fmt.Errorf("expected amount %s but got %s", amount, a)
+		}
+		if b != balanceCheck { //nolint:gosimple
+			return fmt.Errorf("expected balance check %t but got %t", balanceCheck, b)
+		}
 	}
-	if t != to {
-		return fmt.Errorf("expected to %s but got %s", to, t)
-	}
-	if amount.Cmp(a) != 0 {
-		return fmt.Errorf("expected amount %s but got %s", amount, a)
-	}
-	if b != balanceCheck { //nolint:gosimple
-		return fmt.Errorf("expected balance check %t but got %t", balanceCheck, b)
-	}
+
 	return nil
 }
 
@@ -369,6 +382,7 @@ func RunRelayer(t *testing.T, relayer internal.Relayer) {
 
 func RunFuzzPluginRelayer(f *testing.F, relayerFunc func(*testing.T) internal.PluginRelayer) {
 	f.Add("ABC\xa8\x8c\xb3G\xfc", "", true, []byte{}, true, true, "")
+	f.Add(ConfigTOML, string(account), false, signed, false, false, "")
 
 	f.Fuzz(func(
 		t *testing.T, fConfig string, fAccts string, fAcctErr bool,
@@ -391,7 +405,13 @@ func RunFuzzPluginRelayer(f *testing.F, relayerFunc func(*testing.T) internal.Pl
 }
 
 func RunFuzzRelayer(f *testing.F, relayerFunc func(*testing.T) internal.Relayer) {
+	validRaw := [16]byte(RelayArgs.ExternalJobID)
+	validRawBytes := make([]byte, 16)
+
+	copy(validRawBytes, validRaw[:])
+
 	f.Add([]byte{}, int32(-1), "ABC\xa8\x8c\xb3G\xfc", false, []byte{}, "", "", []byte{})
+	f.Add(validRawBytes, int32(123), "testcontract", true, []byte(ConfigTOML), string(types.Median), "testtransmitter", []byte{100: 88})
 
 	f.Fuzz(func(
 		t *testing.T, fExtJobID []byte, fJobID int32, fContractID string, fNew bool,
@@ -421,16 +441,34 @@ func RunFuzzRelayer(f *testing.F, relayerFunc func(*testing.T) internal.Relayer)
 			PluginConfig:  fPlugConf,
 		}
 
-		_, err = relayer.NewPluginProvider(ctx, fRelayArgs, pArgs)
+		provider, err := relayer.NewPluginProvider(ctx, fRelayArgs, pArgs)
+		// require.NoError(t, provider.Start(ctx))
+		t.Log("provider created")
+		t.Cleanup(func() {
+			t.Log("cleanup called")
+			if provider != nil {
+				assert.NoError(t, provider.Close())
+			}
+		})
 
 		grpcUnavailableErr(t, err)
+		t.Logf("error tested: %s", err)
 	})
 }
 
 type FuzzableProvider[K any] func(context.Context, types.RelayArgs, types.PluginArgs) (K, error)
 
 func RunFuzzProvider[K any](f *testing.F, providerFunc func(*testing.T) FuzzableProvider[K]) {
-	f.Add([]byte{}, int32(-1), "ABC\xa8\x8c\xb3G\xfc", false, []byte{}, "", "", []byte{})
+	validRaw := [16]byte(RelayArgs.ExternalJobID)
+	validRawBytes := make([]byte, 16)
+
+	copy(validRawBytes, validRaw[:])
+
+	f.Add([]byte{}, int32(-1), "ABC\xa8\x8c\xb3G\xfc", false, []byte{}, "", "", []byte{})                                                    // bad inputs
+	f.Add(validRawBytes, int32(123), "testcontract", true, []byte(ConfigTOML), string(types.Median), "testtransmitter", []byte{100: 88})     // valid for MedianProvider
+	f.Add(validRawBytes, int32(123), "testcontract", true, []byte(ConfigTOML), string(types.Mercury), "testtransmitter", []byte{100: 88})    // valid for MercuryProvider
+	f.Add(validRawBytes, int32(123), "testcontract", true, []byte(ConfigTOML), string(types.Functions), "testtransmitter", []byte{100: 88})  // valid for FunctionsProvider
+	f.Add(validRawBytes, int32(123), "testcontract", true, []byte(ConfigTOML), string(types.OCR2Keeper), "testtransmitter", []byte{100: 88}) // valid for AutomationProvider
 
 	f.Fuzz(func(
 		t *testing.T, fExtJobID []byte, fJobID int32, fContractID string, fNew bool,

--- a/pkg/loop/internal/test/relayer.go
+++ b/pkg/loop/internal/test/relayer.go
@@ -59,31 +59,27 @@ func (s StaticPluginRelayer) NewRelayer(ctx context.Context, config string, keys
 	if s.StaticChecks && !bytes.Equal(signed, gotSigned) {
 		return nil, fmt.Errorf("expected signed bytes %x but got %x", signed, gotSigned)
 	}
-	return staticRelayer{StaticChecks: s.StaticChecks}, nil
+	return s, nil
 }
 
-type staticRelayer struct {
-	StaticChecks bool
-}
+func (s StaticPluginRelayer) Start(ctx context.Context) error { return nil }
 
-func (s staticRelayer) Start(ctx context.Context) error { return nil }
+func (s StaticPluginRelayer) Close() error { return nil }
 
-func (s staticRelayer) Close() error { return nil }
+func (s StaticPluginRelayer) Ready() error { panic("unimplemented") }
 
-func (s staticRelayer) Ready() error { panic("unimplemented") }
+func (s StaticPluginRelayer) Name() string { panic("unimplemented") }
 
-func (s staticRelayer) Name() string { panic("unimplemented") }
+func (s StaticPluginRelayer) HealthReport() map[string]error { panic("unimplemented") }
 
-func (s staticRelayer) HealthReport() map[string]error { panic("unimplemented") }
-
-func (s staticRelayer) NewConfigProvider(ctx context.Context, r types.RelayArgs) (types.ConfigProvider, error) {
+func (s StaticPluginRelayer) NewConfigProvider(ctx context.Context, r types.RelayArgs) (types.ConfigProvider, error) {
 	if s.StaticChecks && !equalRelayArgs(r, RelayArgs) {
 		return nil, fmt.Errorf("expected relay args:\n\t%v\nbut got:\n\t%v", RelayArgs, r)
 	}
 	return staticConfigProvider{}, nil
 }
 
-func (s staticRelayer) NewMedianProvider(ctx context.Context, r types.RelayArgs, p types.PluginArgs) (types.MedianProvider, error) {
+func (s StaticPluginRelayer) NewMedianProvider(ctx context.Context, r types.RelayArgs, p types.PluginArgs) (types.MedianProvider, error) {
 	if s.StaticChecks {
 		ra := newRelayArgsWithProviderType(types.Median)
 		if !equalRelayArgs(r, ra) {
@@ -97,7 +93,7 @@ func (s staticRelayer) NewMedianProvider(ctx context.Context, r types.RelayArgs,
 	return StaticMedianProvider{}, nil
 }
 
-func (s staticRelayer) NewPluginProvider(ctx context.Context, r types.RelayArgs, p types.PluginArgs) (types.PluginProvider, error) {
+func (s StaticPluginRelayer) NewPluginProvider(ctx context.Context, r types.RelayArgs, p types.PluginArgs) (types.PluginProvider, error) {
 	if s.StaticChecks {
 		ra := newRelayArgsWithProviderType(types.Median)
 		if !equalRelayArgs(r, ra) {
@@ -111,15 +107,15 @@ func (s staticRelayer) NewPluginProvider(ctx context.Context, r types.RelayArgs,
 	return StaticPluginProvider{}, nil
 }
 
-func (s staticRelayer) NewLLOProvider(ctx context.Context, r types.RelayArgs, p types.PluginArgs) (types.LLOProvider, error) {
+func (s StaticPluginRelayer) NewLLOProvider(ctx context.Context, r types.RelayArgs, p types.PluginArgs) (types.LLOProvider, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s staticRelayer) GetChainStatus(ctx context.Context) (types.ChainStatus, error) {
+func (s StaticPluginRelayer) GetChainStatus(ctx context.Context) (types.ChainStatus, error) {
 	return chain, nil
 }
 
-func (s staticRelayer) ListNodeStatuses(ctx context.Context, pageSize int32, pageToken string) ([]types.NodeStatus, string, int, error) {
+func (s StaticPluginRelayer) ListNodeStatuses(ctx context.Context, pageSize int32, pageToken string) ([]types.NodeStatus, string, int, error) {
 	if s.StaticChecks && limit != pageSize {
 		return nil, "", -1, fmt.Errorf("expected page_size %d but got %d", limit, pageSize)
 	}
@@ -129,7 +125,7 @@ func (s staticRelayer) ListNodeStatuses(ctx context.Context, pageSize int32, pag
 	return nodes, "", total, nil
 }
 
-func (s staticRelayer) Transact(ctx context.Context, f, t string, a *big.Int, b bool) error {
+func (s StaticPluginRelayer) Transact(ctx context.Context, f, t string, a *big.Int, b bool) error {
 	if s.StaticChecks {
 		if f != from {
 			return fmt.Errorf("expected from %s but got %s", from, f)

--- a/pkg/loop/internal/test/test_plugin.go
+++ b/pkg/loop/internal/test/test_plugin.go
@@ -18,17 +18,25 @@ type HelperProcessCommand struct {
 	Limit           int
 	CommandLocation string
 	Command         string
+	StaticChecks    bool
 }
 
 func (h HelperProcessCommand) New() *exec.Cmd {
 	cmdArgs := []string{
 		"go", "run", h.CommandLocation, fmt.Sprintf("-cmd=%s", h.Command),
 	}
+
 	if h.Limit != 0 {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("-limit=%d", h.Limit))
 	}
+
+	if h.StaticChecks {
+		cmdArgs = append(cmdArgs, "-static-checks")
+	}
+
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) // #nosec
 	cmd.Env = os.Environ()
+
 	return cmd
 }
 

--- a/pkg/loop/logger_loop_test.go
+++ b/pkg/loop/logger_loop_test.go
@@ -16,7 +16,7 @@ func TestHCLogLogger(t *testing.T) {
 	lggr, ol := logger.TestObserved(t, zapcore.ErrorLevel)
 	loggerTest := &test.GRPCPluginLoggerTest{Logger: lggr}
 	cc := loggerTest.ClientConfig()
-	cc.Cmd = NewHelperProcessCommand(test.PluginLoggerTestName)
+	cc.Cmd = NewHelperProcessCommand(test.PluginLoggerTestName, false)
 	c := plugin.NewClient(cc)
 	t.Cleanup(c.Kill)
 	_, err := c.Client()

--- a/pkg/loop/median_service_test.go
+++ b/pkg/loop/median_service_test.go
@@ -17,7 +17,7 @@ func TestMedianService(t *testing.T) {
 	t.Parallel()
 
 	median := loop.NewMedianService(logger.Test(t), loop.GRPCOpts{}, func() *exec.Cmd {
-		return NewHelperProcessCommand(loop.PluginMedianName)
+		return NewHelperProcessCommand(loop.PluginMedianName, false)
 	}, test.StaticMedianProvider{}, test.StaticDataSource(), test.StaticJuelsPerFeeCoinDataSource(), &test.StaticErrorLog{})
 	hook := median.PluginService.XXXTestHook()
 	servicetest.Run(t, median)

--- a/pkg/loop/plugin_median_test.go
+++ b/pkg/loop/plugin_median_test.go
@@ -35,7 +35,7 @@ func TestPluginMedianExec(t *testing.T) {
 	stopCh := newStopCh(t)
 	median := loop.GRPCPluginMedian{BrokerConfig: loop.BrokerConfig{Logger: logger.Test(t), StopCh: stopCh}}
 	cc := median.ClientConfig()
-	cc.Cmd = NewHelperProcessCommand(loop.PluginMedianName)
+	cc.Cmd = NewHelperProcessCommand(loop.PluginMedianName, false)
 	c := plugin.NewClient(cc)
 	t.Cleanup(c.Kill)
 	client, err := c.Client()
@@ -48,7 +48,7 @@ func TestPluginMedianExec(t *testing.T) {
 	test.PluginMedian(t, i.(types.PluginMedian))
 
 	t.Run("proxy", func(t *testing.T) {
-		pr := newPluginRelayerExec(t, stopCh)
+		pr := newPluginRelayerExec(t, false, stopCh)
 		p := newMedianProvider(t, pr)
 		pm := test.PluginMedianTest{MedianProvider: p}
 		pm.TestPluginMedian(t, i.(types.PluginMedian))

--- a/pkg/loop/plugin_relayer_test.go
+++ b/pkg/loop/plugin_relayer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 func TestPluginRelayer(t *testing.T) {
@@ -25,6 +26,44 @@ func TestPluginRelayerExec(t *testing.T) {
 	pr := newPluginRelayerExec(t, stopCh)
 
 	test.RunPluginRelayer(t, pr)
+}
+
+func FuzzPluginRelayer(f *testing.F) {
+	test.RunFuzzPluginRelayer(f, fuzzTestWrapPluginRelayConstructor(f))
+}
+
+func FuzzRelayer(f *testing.F) {
+	test.RunFuzzRelayer(f, fuzzTestWrapRelayConstructor(f))
+}
+
+func fuzzTestWrapPluginRelayConstructor(f *testing.F) func(*testing.T) loop.PluginRelayer {
+	f.Helper()
+
+	return func(t *testing.T) loop.PluginRelayer {
+		t.Helper()
+
+		stopCh := newStopCh(t)
+		relayer := newPluginRelayerExec(t, stopCh)
+
+		return relayer
+	}
+}
+
+func fuzzTestWrapRelayConstructor(f *testing.F) func(*testing.T) loop.Relayer {
+	f.Helper()
+
+	return func(t *testing.T) loop.Relayer {
+		t.Helper()
+
+		stopCh := newStopCh(t)
+		p := newPluginRelayerExec(t, stopCh)
+		ctx := tests.Context(t)
+		relayer, err := p.NewRelayer(ctx, test.ConfigTOML, test.StaticKeystore{})
+
+		require.NoError(t, err)
+
+		return relayer
+	}
 }
 
 func newPluginRelayerExec(t *testing.T, stopCh <-chan struct{}) loop.PluginRelayer {

--- a/pkg/loop/plugin_relayer_test.go
+++ b/pkg/loop/plugin_relayer_test.go
@@ -23,7 +23,7 @@ func TestPluginRelayerExec(t *testing.T) {
 	t.Parallel()
 	stopCh := newStopCh(t)
 
-	pr := newPluginRelayerExec(t, stopCh)
+	pr := newPluginRelayerExec(t, true, stopCh)
 
 	test.RunPluginRelayer(t, pr)
 }
@@ -33,7 +33,7 @@ func FuzzPluginRelayer(f *testing.F) {
 		t.Helper()
 
 		stopCh := newStopCh(t)
-		relayer := newPluginRelayerExec(t, stopCh)
+		relayer := newPluginRelayerExec(t, true, stopCh)
 
 		return relayer
 	}
@@ -46,7 +46,7 @@ func FuzzRelayer(f *testing.F) {
 		t.Helper()
 
 		stopCh := newStopCh(t)
-		p := newPluginRelayerExec(t, stopCh)
+		p := newPluginRelayerExec(t, false, stopCh)
 		ctx := tests.Context(t)
 		relayer, err := p.NewRelayer(ctx, test.ConfigTOML, test.StaticKeystore{})
 
@@ -58,10 +58,10 @@ func FuzzRelayer(f *testing.F) {
 	test.RunFuzzRelayer(f, testFunc)
 }
 
-func newPluginRelayerExec(t *testing.T, stopCh <-chan struct{}) loop.PluginRelayer {
+func newPluginRelayerExec(t *testing.T, staticChecks bool, stopCh <-chan struct{}) loop.PluginRelayer {
 	relayer := loop.GRPCPluginRelayer{BrokerConfig: loop.BrokerConfig{Logger: logger.Test(t), StopCh: stopCh}}
 	cc := relayer.ClientConfig()
-	cc.Cmd = NewHelperProcessCommand(loop.PluginRelayerName)
+	cc.Cmd = NewHelperProcessCommand(loop.PluginRelayerName, staticChecks)
 	c := plugin.NewClient(cc)
 	t.Cleanup(c.Kill)
 	client, err := c.Client()

--- a/pkg/loop/plugin_relayer_test.go
+++ b/pkg/loop/plugin_relayer_test.go
@@ -29,17 +29,7 @@ func TestPluginRelayerExec(t *testing.T) {
 }
 
 func FuzzPluginRelayer(f *testing.F) {
-	test.RunFuzzPluginRelayer(f, fuzzTestWrapPluginRelayConstructor(f))
-}
-
-func FuzzRelayer(f *testing.F) {
-	test.RunFuzzRelayer(f, fuzzTestWrapRelayConstructor(f))
-}
-
-func fuzzTestWrapPluginRelayConstructor(f *testing.F) func(*testing.T) loop.PluginRelayer {
-	f.Helper()
-
-	return func(t *testing.T) loop.PluginRelayer {
+	testFunc := func(t *testing.T) loop.PluginRelayer {
 		t.Helper()
 
 		stopCh := newStopCh(t)
@@ -47,12 +37,12 @@ func fuzzTestWrapPluginRelayConstructor(f *testing.F) func(*testing.T) loop.Plug
 
 		return relayer
 	}
+
+	test.RunFuzzPluginRelayer(f, testFunc)
 }
 
-func fuzzTestWrapRelayConstructor(f *testing.F) func(*testing.T) loop.Relayer {
-	f.Helper()
-
-	return func(t *testing.T) loop.Relayer {
+func FuzzRelayer(f *testing.F) {
+	testFunc := func(t *testing.T) loop.Relayer {
 		t.Helper()
 
 		stopCh := newStopCh(t)
@@ -64,6 +54,8 @@ func fuzzTestWrapRelayConstructor(f *testing.F) func(*testing.T) loop.Relayer {
 
 		return relayer
 	}
+
+	test.RunFuzzRelayer(f, testFunc)
 }
 
 func newPluginRelayerExec(t *testing.T, stopCh <-chan struct{}) loop.PluginRelayer {

--- a/pkg/loop/process_test.go
+++ b/pkg/loop/process_test.go
@@ -13,9 +13,10 @@ func (h *HelperProcessCommand) New() *exec.Cmd {
 	return (test.HelperProcessCommand)(*h).New()
 }
 
-func NewHelperProcessCommand(command string) *exec.Cmd {
+func NewHelperProcessCommand(command string, staticChecks bool) *exec.Cmd {
 	h := HelperProcessCommand{
-		Command: command,
+		Command:      command,
+		StaticChecks: staticChecks,
 	}
 	return h.New()
 }

--- a/pkg/loop/relayer_service_test.go
+++ b/pkg/loop/relayer_service_test.go
@@ -16,7 +16,7 @@ import (
 func TestRelayerService(t *testing.T) {
 	t.Parallel()
 	relayer := loop.NewRelayerService(logger.Test(t), loop.GRPCOpts{}, func() *exec.Cmd {
-		return NewHelperProcessCommand(loop.PluginRelayerName)
+		return NewHelperProcessCommand(loop.PluginRelayerName, false)
 	}, test.ConfigTOML, test.StaticKeystore{})
 	hook := relayer.XXXTestHook()
 	servicetest.Run(t, relayer)

--- a/pkg/loop/standalone_provider_test.go
+++ b/pkg/loop/standalone_provider_test.go
@@ -21,7 +21,7 @@ func TestRegisterStandAloneProvider(t *testing.T) {
 	require.ErrorContains(t, err, "expected median provider got")
 
 	stopCh := newStopCh(t)
-	pr := newPluginRelayerExec(t, stopCh)
+	pr := newPluginRelayerExec(t, false, stopCh)
 	mp := newMedianProvider(t, pr)
 	err = loop.RegisterStandAloneProvider(s, mp, "median")
 	require.NoError(t, err)

--- a/pkg/services/servicetest/run_test.go
+++ b/pkg/services/servicetest/run_test.go
@@ -32,7 +32,6 @@ func TestRunHealthy(t *testing.T) {
 			assert.Equal(t, test.expFail, failed)
 		})
 	}
-
 }
 
 func runFake(fn func(t TestingT)) ([]string, bool) {
@@ -72,7 +71,7 @@ func (f *fakeTest) Errorf(format string, args ...interface{}) {
 }
 
 func (f *fakeTest) FailNow() {
-	if f.failed == true {
+	if f.failed {
 		return // only panic the first time
 	}
 	f.failed = true

--- a/pkg/types/automation/basetypes_test.go
+++ b/pkg/types/automation/basetypes_test.go
@@ -566,9 +566,9 @@ func assertJSONContainsAllStructFields(t *testing.T, jsonString string, anyStruc
 	var jsonMap map[string]interface{}
 	var structMap map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(jsonString), &jsonMap), "jsonString is invalid json")
-	structJson, err := json.Marshal(anyStruct)
+	structJSON, err := json.Marshal(anyStruct)
 	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal(structJson, &structMap))
+	require.NoError(t, json.Unmarshal(structJSON, &structMap))
 	assertCongruentKeyStructure(t, structMap, jsonMap)
 }
 

--- a/pkg/utils/bytes/bytes_test.go
+++ b/pkg/utils/bytes/bytes_test.go
@@ -3,8 +3,9 @@ package bytes_test
 import (
 	"testing"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
 )
 
 func TestIsEmpty(t *testing.T) {

--- a/pkg/utils/hex/hex_test.go
+++ b/pkg/utils/hex/hex_test.go
@@ -3,8 +3,9 @@ package hex_test
 import (
 	"testing"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
 )
 
 func TestParseBig(t *testing.T) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.sources=.
 # Full exclusions from the static analysis
 sonar.exclusions=**/mocks/**/*, **/testdata/**/*, **/script/**/*, **/generated/**/*, **/fixtures/**/*, **/docs/**/*, **/tools/**/*, **/*.pb.go, **/*report.xml, **/*.txt, **/*.abi, **/*.bin
 # Coverage exclusions
-sonar.coverage.exclusions=**/*_test.go, fuzz/**
+sonar.coverage.exclusions=**/test/**, **/*_test.go, fuzz/**
 
 # Tests' root folder, inclusions (tests to check and count) and exclusions
 sonar.tests=.


### PR DESCRIPTION
This PR adds basic fuzz testing functions that apply fuzzing to `PluginRelayer.NewRelayer`
`Relayer.NewConfigProvider`. Since fuzzing does not currently support parallel runs, the fuzz
functions are designed in a granular way where a test constructor function that returns the
testable interface is provided to the fuzz testing functions.
    
Nested fuzz tests have not yet been tried, but this generally appears to be a bad idea
considering how fuzz testing works. ex:
    
```
func RunFuzzPluginRelayer(f *testing.F) {
    f.Fuzz(func(t *testing.T)) {
        f.Fuzz(func(t *testing.T)) {
    
        }
    }
}
```