### PR TITLE
OCR3 Capability: Don't error on empty queue

### DIFF
--- a/pkg/capabilities/consensus/ocr3/reporting_plugin_test.go
+++ b/pkg/capabilities/consensus/ocr3/reporting_plugin_test.go
@@ -16,19 +16,20 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 )
 
-func TestReportingPlugin_Query_QueueEmpty(t *testing.T) {
+func TestReportingPlugin_Query_ErrorInQueueCall(t *testing.T) {
 	ctx := tests.Context(t)
 	lggr := logger.Test(t)
 	fc := clockwork.NewFakeClock()
 	s := newStore(0, fc)
-	rp, err := newReportingPlugin(s, nil, defaultBatchSize, ocr3types.ReportingPluginConfig{}, lggr)
+	batchSize := 0
+	rp, err := newReportingPlugin(s, nil, batchSize, ocr3types.ReportingPluginConfig{}, lggr)
 	require.NoError(t, err)
 
 	outcomeCtx := ocr3types.OutcomeContext{
 		PreviousOutcome: []byte(""),
 	}
 	_, err = rp.Query(ctx, outcomeCtx)
-	assert.ErrorIs(t, err, errQueueEmpty)
+	assert.Error(t, err)
 }
 
 func TestReportingPlugin_Query(t *testing.T) {

--- a/pkg/capabilities/consensus/ocr3/store_test.go
+++ b/pkg/capabilities/consensus/ocr3/store_test.go
@@ -47,9 +47,8 @@ func TestOCR3Store(t *testing.T) {
 
 	t.Run("firstN, evicts removed items", func(t *testing.T) {
 		r, err := s.firstN(ctx, 1)
-		assert.Nil(t, r)
-		assert.ErrorContains(t, err, "queue is empty")
-		assert.Len(t, s.requestIDs, 0)
+		assert.NoError(t, err)
+		assert.Len(t, r, 0)
 	})
 
 	t.Run("firstN, zero batch size", func(t *testing.T) {


### PR DESCRIPTION
Empty request queue is not an error. In fact, it will be a very common state when overall load is low.