### PR TITLE
Minor improvements to consensus capability reporting plugin

### DIFF
--- a/pkg/capabilities/consensus/ocr3/capability.go
+++ b/pkg/capabilities/consensus/ocr3/capability.go
@@ -18,7 +18,7 @@ import (
 )
 
 var info = capabilities.MustNewCapabilityInfo(
-	"ocr3",
+	"offchain_reporting",
 	capabilities.CapabilityTypeConsensus,
 	"OCR3 consensus exposed as a capability.",
 	"v1.0.0",
@@ -76,10 +76,10 @@ func (o *capability) Close() error {
 }
 
 type workflowConfig struct {
-	AggregationMethod       string `mapstructure:"aggregation_method"`
-	AggregationMethodConfig map[string]any
-	Encoder                 string
-	EncoderConfig           map[string]any
+	AggregationMethod string         `mapstructure:"aggregation_method"`
+	AggregationConfig map[string]any `mapstructure:"aggregation_config"`
+	Encoder           string         `mapstructure:"encoder"`
+	EncoderConfig     map[string]any `mapstructure:"encoder_config"`
 }
 
 func (o *capability) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {
@@ -97,9 +97,18 @@ func (o *capability) RegisterToWorkflow(ctx context.Context, request capabilitie
 		return err
 	}
 
+	if c.AggregationConfig == nil {
+		o.lggr.Warn("aggregation_config is empty")
+		c.AggregationConfig = map[string]any{}
+	}
+	if c.EncoderConfig == nil {
+		o.lggr.Warn("encoder_config is empty")
+		c.EncoderConfig = map[string]any{}
+	}
+
 	switch c.AggregationMethod {
 	case "data_feeds_2_0":
-		cm, err := values.NewMap(c.AggregationMethodConfig)
+		cm, err := values.NewMap(c.AggregationConfig)
 		if err != nil {
 			return err
 		}

--- a/pkg/capabilities/consensus/ocr3/factory.go
+++ b/pkg/capabilities/consensus/ocr3/factory.go
@@ -30,8 +30,10 @@ type factoryService struct {
 }
 
 const (
-	defaultRequestExpiry time.Duration = 1 * time.Hour
-	defaultBatchSize                   = 1000
+	defaultRequestExpiry       time.Duration = 1 * time.Hour
+	defaultBatchSize                         = 1000
+	defaultMaxPhaseOutputBytes               = 100000
+	defaultMaxReportCount                    = 20
 )
 
 func newFactoryService(config *config) (*factoryService, error) {
@@ -60,7 +62,16 @@ func newFactoryService(config *config) (*factoryService, error) {
 
 func (o *factoryService) NewReportingPlugin(config ocr3types.ReportingPluginConfig) (ocr3types.ReportingPlugin[[]byte], ocr3types.ReportingPluginInfo, error) {
 	rp, err := newReportingPlugin(o.store, o.capability, o.batchSize, config, o.lggr)
-	info := ocr3types.ReportingPluginInfo{Name: "OCR3 Capability Plugin"}
+	info := ocr3types.ReportingPluginInfo{
+		Name: "OCR3 Capability Plugin",
+		Limits: ocr3types.ReportingPluginLimits{
+			MaxQueryLength:       defaultMaxPhaseOutputBytes,
+			MaxObservationLength: defaultMaxPhaseOutputBytes,
+			MaxOutcomeLength:     defaultMaxPhaseOutputBytes,
+			MaxReportLength:      defaultMaxPhaseOutputBytes,
+			MaxReportCount:       defaultMaxReportCount,
+		},
+	}
 	return rp, info, err
 }
 


### PR DESCRIPTION
1. Better logging
2. Non-zero limits for phase output sizes
3. Change capability type name
4. Fix unnecessary exit on empty previous outcome
5. Fix incorrect clearing of ReportsToGenerate
6. Add missing map initialization inside Outcome()
7. Fix aggregator/encoder config parsing