### PR TITLE
Revert "Add a SetConfig function to the LogEventProvider interface (#367)"

### DIFF
--- a/pkg/types/automation/interfaces.go
+++ b/pkg/types/automation/interfaces.go
@@ -48,15 +48,8 @@ type Encoder interface {
 
 type LogEventProvider interface {
 	GetLatestPayloads(context.Context) ([]UpkeepPayload, error)
-	SetConfig(LogEventProviderConfig)
 	Start(context.Context) error
 	Close() error
-}
-
-type LogEventProviderConfig struct {
-	NumLogUpkeeps    uint32
-	FastExecLogsHigh uint32
-	FastExecLogsLow  uint32
 }
 
 type RecoverableProvider interface {


### PR DESCRIPTION

This reverts commit c9d7b3cf9d07d031b629c3d8083d9fb6afd55e14.