### PR TITLE
Add a SetConfig function to the LogEventProvider interface

### DIFF
--- a/pkg/types/automation/interfaces.go
+++ b/pkg/types/automation/interfaces.go
@@ -48,8 +48,14 @@ type Encoder interface {
 
 type LogEventProvider interface {
 	GetLatestPayloads(context.Context) ([]UpkeepPayload, error)
+	SetConfig(LogEventProviderConfig)
 	Start(context.Context) error
 	Close() error
+}
+
+type LogEventProviderConfig struct {
+	BlockRate uint32
+	LogLimit  uint32
 }
 
 type RecoverableProvider interface {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/AUTO-9023

In this PR, we're updating the LogEventProvider interface with a means of setting config values, internal to the log event provider implementation

Compared to the earlier implementation of this PR, we're now defining the config values as floats instead of uint32s

# Related PRs

- chainlink: https://github.com/smartcontractkit/chainlink/pull/12152
- chainlink-automation: https://github.com/smartcontractkit/chainlink-automation/pull/316

