### PR TITLE
BCF-3041: simplify client conn

### DIFF
--- a/pkg/loop/internal/config.go
+++ b/pkg/loop/internal/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 var _ types.ConfigProvider = (*configProviderClient)(nil)
+var _ GRPCClientConn = (*configProviderClient)(nil)
 
 type configProviderClient struct {
 	*ServiceClient

--- a/pkg/loop/internal/median.go
+++ b/pkg/loop/internal/median.go
@@ -178,8 +178,6 @@ type medianProviderClient struct {
 	codec              types.Codec
 }
 
-func (m *medianProviderClient) ClientConn() grpc.ClientConnInterface { return m.cc }
-
 func newMedianProviderClient(b *BrokerExt, cc grpc.ClientConnInterface) *medianProviderClient {
 	m := &medianProviderClient{pluginProviderClient: newPluginProviderClient(b.WithName("MedianProviderClient"), cc)}
 	m.reportCodec = &reportCodecClient{b, pb.NewReportCodecClient(m.cc)}

--- a/pkg/loop/internal/mercury.go
+++ b/pkg/loop/internal/mercury.go
@@ -178,7 +178,7 @@ func (c *MercuryAdapterClient) NewMercuryV3Factory(ctx context.Context,
 				registerCommonServices(s, provider)
 
 				mercury_pb.RegisterReportCodecV3Server(s, mercury_common_internal.NewReportCodecV3Server(s, provider.ReportCodecV3()))
-
+				// don't register the other codecs, as they are not used in v3
 				mercury_pb.RegisterReportCodecV1Server(s, mercury_pb.UnimplementedReportCodecV1Server{})
 				mercury_pb.RegisterReportCodecV2Server(s, mercury_pb.UnimplementedReportCodecV2Server{})
 			})
@@ -345,7 +345,8 @@ func (ms *mercuryAdapterServer) NewMercuryV3Factory(ctx context.Context, req *me
 
 var (
 	_ types.MercuryProvider = (*mercuryProviderClient)(nil)
-	_ GRPCClientConn        = (*mercuryProviderClient)(nil)
+	// in practice, inherited from pluginProviderClient
+	_ GRPCClientConn = (*mercuryProviderClient)(nil)
 )
 
 type mercuryProviderClient struct {
@@ -358,8 +359,6 @@ type mercuryProviderClient struct {
 	chainReader        types.ChainReader
 	mercuryChainReader mercury.ChainReader
 }
-
-func (m *mercuryProviderClient) ClientConn() grpc.ClientConnInterface { return m.cc }
 
 func newMercuryProviderClient(b *BrokerExt, cc grpc.ClientConnInterface) *mercuryProviderClient {
 	m := &mercuryProviderClient{pluginProviderClient: newPluginProviderClient(b.WithName("MercuryProviderClient"), cc)}

--- a/pkg/loop/internal/plugin_provider.go
+++ b/pkg/loop/internal/plugin_provider.go
@@ -15,7 +15,10 @@ type pluginProviderClient struct {
 	codec               types.Codec
 }
 
-func (p *pluginProviderClient) ClientConn() grpc.ClientConnInterface { return p.cc }
+var _ types.PluginProvider = (*pluginProviderClient)(nil)
+
+// in practice, inherited from configProviderClient
+var _ GRPCClientConn = (*pluginProviderClient)(nil)
 
 func newPluginProviderClient(b *BrokerExt, cc grpc.ClientConnInterface) *pluginProviderClient {
 	p := &pluginProviderClient{configProviderClient: newConfigProviderClient(b.WithName("PluginProviderClient"), cc)}

--- a/pkg/loop/internal/service.go
+++ b/pkg/loop/internal/service.go
@@ -15,7 +15,10 @@ import (
 var ErrPluginUnavailable = errors.New("plugin unavailable")
 
 var _ services.Service = (*ServiceClient)(nil)
+var _ GRPCClientConn = (*ServiceClient)(nil)
 
+// ServiceClient is the base client implementation of a loop as a client to the core node or
+// to another loop that is proxied through the core node.
 type ServiceClient struct {
 	b    *BrokerExt
 	cc   grpc.ClientConnInterface
@@ -64,6 +67,9 @@ func (s *ServiceClient) HealthReport() map[string]error {
 	hr[s.b.Logger.Name()] = nil
 	return hr
 }
+
+// ClientConn implements GRPCClientConn interface
+func (s *ServiceClient) ClientConn() grpc.ClientConnInterface { return s.cc }
 
 var _ pb.ServiceServer = (*ServiceServer)(nil)
 


### PR DESCRIPTION
we are inheriting  a private field and wrapping that field in a method to satisfy an interface in multiple places.

this puts the method defintiion lower in the stack to the method in inheriting and adds comments about the plumbing.