### PR TITLE
pkg/sqlutil: add QueryHook for wrapping Queryers with timeouts, prometheus metrics and slow query logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/jonboulle/clockwork v0.4.0
 	github.com/jpillora/backoff v1.0.0
+	github.com/lib/pq v1.2.0
 	github.com/linkedin/goavro/v2 v2.12.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9

--- a/pkg/sqlutil/hook.go
+++ b/pkg/sqlutil/hook.go
@@ -1,0 +1,126 @@
+package sqlutil
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+var _ DB = &WrappedDB{}
+
+// WrappedDB is a [DB] which invokes a [QueryHook] on each call.
+type WrappedDB struct {
+	db   DB
+	lggr logger.Logger
+	hook QueryHook
+}
+
+// QueryHook is a func that is executed for each query, providing an opportunity to measure, log, inspect/modify errors, etc.
+// The do func *must* be called.
+// Logs emitted through the provided logger.Logger will have the caller's line info.
+//
+// See [MonitorHook] and [TimeoutHook] for examples.
+type QueryHook func(ctx context.Context, lggr logger.Logger, do func(context.Context) error, query string, args ...any) error
+
+// NewWrappedDB returns a new [WrappedDB] that calls each [QueryHook] in the provided order.
+func NewWrappedDB(db DB, l logger.Logger, hs ...QueryHook) *WrappedDB {
+	iq := WrappedDB{db: db,
+		lggr: logger.Helper(logger.Named(l, "WrappedDB"), 2), // skip our own wrapper and one interceptor
+		hook: noopHook,
+	}
+	switch len(hs) {
+	case 0:
+		return &iq
+	case 1:
+		iq.hook = hs[0]
+		return &iq
+	}
+
+	// Nest the QueryHook calls so that they are wrapped from first to last.
+	// Example:
+	// 	[A, B, C] => A(B(C(do())))
+	for i := len(hs) - 1; i >= 0; i-- {
+		next := hs[i]
+		prev := iq.hook
+		iq.hook = func(ctx context.Context, lggr logger.Logger, do func(context.Context) error, query string, args ...any) error {
+			// opt: cache the construction of these loggers
+			lggr = logger.Helper(lggr, 1) // skip one more for this wrapper
+			return next(ctx, lggr, func(ctx context.Context) error {
+				lggr = logger.Helper(lggr, 2) // skip two more for do() and this extra wrapper
+				return prev(ctx, lggr, do, query, args...)
+			}, query, args...)
+		}
+	}
+	return &iq
+}
+
+func noopHook(ctx context.Context, lggr logger.Logger, do func(context.Context) error, query string, args ...any) error {
+	return do(ctx)
+}
+
+func (w *WrappedDB) DriverName() string {
+	return w.db.DriverName()
+}
+
+func (w *WrappedDB) Rebind(s string) string {
+	return w.db.Rebind(s)
+}
+
+func (w *WrappedDB) BindNamed(s string, i interface{}) (string, []any, error) {
+	return w.db.BindNamed(s, i)
+}
+
+func (w *WrappedDB) QueryContext(ctx context.Context, query string, args ...any) (rows *sql.Rows, err error) {
+	err = w.hook(ctx, w.lggr, func(ctx context.Context) (err error) {
+		rows, err = w.db.QueryContext(ctx, query, args...) //nolint
+		return
+	}, query, args...)
+	return
+}
+
+func (w *WrappedDB) QueryxContext(ctx context.Context, query string, args ...any) (rows *sqlx.Rows, err error) {
+	err = w.hook(ctx, w.lggr, func(ctx context.Context) (err error) {
+		rows, err = w.db.QueryxContext(ctx, query, args...) //nolint:sqlclosecheck
+		return
+	}, query, args...)
+	return
+}
+
+func (w *WrappedDB) QueryRowxContext(ctx context.Context, query string, args ...any) (row *sqlx.Row) {
+	_ = w.hook(ctx, w.lggr, func(ctx context.Context) error {
+		row = w.db.QueryRowxContext(ctx, query, args...)
+		return nil
+	}, query, args...)
+	return
+}
+
+func (w *WrappedDB) ExecContext(ctx context.Context, query string, args ...any) (res sql.Result, err error) {
+	err = w.hook(ctx, w.lggr, func(ctx context.Context) (err error) {
+		res, err = w.db.ExecContext(ctx, query, args...)
+		return
+	}, query, args...)
+	return
+}
+
+func (w *WrappedDB) PrepareContext(ctx context.Context, query string) (stmt *sql.Stmt, err error) {
+	err = w.hook(ctx, w.lggr, func(ctx context.Context) (err error) {
+		stmt, err = w.db.PrepareContext(ctx, query) //nolint:sqlclosecheck
+		return
+	}, query, nil)
+	return
+}
+
+func (w *WrappedDB) GetContext(ctx context.Context, dest interface{}, query string, args ...any) error {
+	return w.hook(ctx, w.lggr, func(ctx context.Context) error {
+		return w.db.GetContext(ctx, dest, query, args...)
+	}, query, args...)
+}
+
+func (w *WrappedDB) SelectContext(ctx context.Context, dest interface{}, query string, args ...any) error {
+	return w.hook(ctx, w.lggr, func(ctx context.Context) error {
+		return w.db.SelectContext(ctx, dest, query, args...)
+	}, query, args...)
+}

--- a/pkg/sqlutil/hook_test.go
+++ b/pkg/sqlutil/hook_test.go
@@ -1,0 +1,124 @@
+package sqlutil
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+)
+
+const (
+	getDur = 10 * time.Millisecond
+	selDur = 200 * time.Millisecond
+)
+
+func TestNewInterceptedQueryer(t *testing.T) {
+	lggr, ol := logger.TestObserved(t, zapcore.InfoLevel)
+	var db DB = &database{}
+	var sentinelErr = errors.New("intercepted error")
+	const fakeError = "fake warning"
+	db = NewWrappedDB(db, lggr, TimeoutHook(selDur/2), noopHook, MonitorHook(func() bool { return true }), noopHook, func(ctx context.Context, lggr logger.Logger, do func(context.Context) error, query string, args ...any) error {
+		err := do(ctx)
+		if err != nil {
+			return err
+		}
+		lggr.Error(fakeError)
+		return sentinelErr
+	})
+	ctx := tests.Context(t)
+
+	// Error intercepted
+	err := db.GetContext(ctx, "test", "foo", 42, "bar")
+	_, file, line, ok := runtime.Caller(0)
+	require.True(t, ok)
+	expCaller := fmt.Sprintf("%s:%d", file, line-1)
+	require.ErrorIs(t, err, sentinelErr)
+	logs := ol.FilterMessage(slowMsg).All()
+	require.Len(t, logs, 1)
+	assert.Equal(t, zapcore.WarnLevel, logs[0].Level)
+	assert.Equal(t, expCaller, logs[0].Caller.String())
+	logs = ol.FilterMessage(fakeError).All()
+	require.Len(t, logs, 1)
+	assert.Equal(t, zapcore.ErrorLevel, logs[0].Level)
+	assert.Equal(t, expCaller, logs[0].Caller.String())
+	_ = ol.TakeAll()
+
+	// Timeout applied
+	err = db.SelectContext(ctx, "test", "foo", 42, "bar")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	logs = ol.FilterMessage(slowMsg).All()
+	require.Len(t, logs, 1)
+	assert.Equal(t, zapcore.DPanicLevel, logs[0].Level)
+	_ = ol.TakeAll()
+
+	// Without default timeout
+	err = db.SelectContext(WithoutDefaultTimeout(ctx), "test", "foo", 42, "bar")
+	require.ErrorIs(t, err, sentinelErr)
+
+	// W/o default, but with our own
+	ctx2, cancel := context.WithTimeout(WithoutDefaultTimeout(ctx), selDur/100)
+	t.Cleanup(cancel)
+	err = db.SelectContext(ctx2, "test", "foo", 42, "bar")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+var _ DB = &database{}
+
+type database struct{}
+
+func (q *database) DriverName() string { return "" }
+
+func (q *database) Rebind(s string) string { return "" }
+
+func (q *database) BindNamed(s string, i interface{}) (string, []interface{}, error) {
+	return "", nil, nil
+}
+
+func (q *database) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return nil, nil
+}
+
+func (q *database) QueryxContext(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error) {
+	return nil, nil
+}
+
+func (q *database) QueryRowxContext(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
+	return nil
+}
+
+func (q *database) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return nil, nil
+}
+
+func (q *database) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return nil, nil
+}
+
+func (q *database) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(getDur):
+	}
+	return nil
+}
+
+func (q *database) SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(selDur):
+	}
+	return nil
+}

--- a/pkg/sqlutil/monitor.go
+++ b/pkg/sqlutil/monitor.go
@@ -1,0 +1,147 @@
+package sqlutil
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+const slowMsg = "SLOW SQL QUERY"
+
+// PromSQLQueryTime is exported temporarily while transitioning the core ORMs.
+var PromSQLQueryTime = promauto.NewHistogram(prometheus.HistogramOpts{
+	Name:    "sql_query_timeout_percent",
+	Help:    "SQL query time as a percentage of timeout.",
+	Buckets: []float64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120},
+})
+
+// MonitorHook returns a [QueryHook] that measures the timing of each query and logs about slow queries at increasing levels of severity.
+// When logAll returns true, every query and error will be logged.
+func MonitorHook(logAll func() bool) QueryHook {
+	return func(ctx context.Context, lggr logger.Logger, do func(context.Context) error, query string, args ...any) error {
+		shouldLog := logAll()
+		ql := newQueryLogger(lggr, query, args...)
+		if shouldLog {
+			ql.logQuery()
+		}
+		defer ql.logTiming(ctx, time.Now())
+		err := do(ctx)
+		if shouldLog && err != nil && !errors.Is(err, sql.ErrNoRows) {
+			ql.logError(err)
+		}
+		return err
+	}
+}
+
+// sprintQ formats the query with the given args and returns the resulting string.
+func sprintQ(query string, args []interface{}) string {
+	if args == nil {
+		return query
+	}
+	var pairs []string
+	for i, arg := range args {
+		// We print by type so one can directly take the logged query string and execute it manually in pg.
+		// Annoyingly it seems as though the logger itself will add an extra \, so you still have to remove that.
+		switch v := arg.(type) {
+		case []byte:
+			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("'\\x%x'", v))
+		case pq.ByteaArray:
+			pairs = append(pairs, fmt.Sprintf("$%d", i+1))
+			if v == nil {
+				pairs = append(pairs, "NULL")
+				continue
+			}
+			if len(v) == 0 {
+				pairs = append(pairs, "ARRAY[]")
+				continue
+			}
+			var s strings.Builder
+			fmt.Fprintf(&s, "ARRAY['\\x%x'", v[0])
+			for j := 1; j < len(v); j++ {
+				fmt.Fprintf(&s, ",'\\x%x'", v[j])
+			}
+			pairs = append(pairs, fmt.Sprintf("%s]", s.String()))
+		case string:
+			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("'%s'", v))
+		default:
+			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("%v", v))
+		}
+	}
+	replacer := strings.NewReplacer(pairs...)
+	queryWithVals := replacer.Replace(query)
+	return strings.ReplaceAll(strings.ReplaceAll(queryWithVals, "\n", " "), "\t", " ")
+}
+
+// queryLogger extends Q with logging helpers for a particular query w/ args.
+type queryLogger struct {
+	lggr logger.SugaredLogger
+
+	query string
+	args  []interface{}
+
+	str func() string
+}
+
+func newQueryLogger(lggr logger.Logger, query string, args ...any) *queryLogger {
+	return &queryLogger{
+		// skip another level since we use internal helpers
+		lggr:  logger.Sugared(logger.Helper(lggr, 1)),
+		query: query, args: args,
+		str: sync.OnceValue(func() string {
+			return sprintQ(query, args)
+		}),
+	}
+}
+
+func (q *queryLogger) String() string {
+	return q.str()
+}
+
+func (q *queryLogger) logQuery() {
+	q.lggr.Debugw("SQL QUERY", "sql", q)
+}
+
+func (q *queryLogger) logError(err error) {
+	q.lggr.Errorw("SQL ERROR", "err", err, "sql", q)
+}
+
+// logTiming logs about context cancellation and timing after a query returns.
+// Queries which use their full timeout log critical level. More than 50% log error, and 10% warn.
+func (q *queryLogger) logTiming(ctx context.Context, start time.Time) {
+	elapsed := time.Since(start)
+	if ctx.Err() != nil {
+		q.lggr.Debugw("SQL CONTEXT CANCELLED", "ms", elapsed.Milliseconds(), "err", ctx.Err(), "sql", q)
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return
+	}
+	timeout := deadline.Sub(start)
+
+	pct := float64(elapsed) / float64(timeout)
+	pct *= 100
+
+	kvs := []any{"ms", elapsed.Milliseconds(), "timeout", timeout.Milliseconds(), "percent", strconv.FormatFloat(pct, 'f', 1, 64), "sql", q}
+
+	if elapsed >= timeout {
+		q.lggr.Criticalw(slowMsg, kvs...)
+	} else if errThreshold := timeout / 5; errThreshold > 0 && elapsed > errThreshold {
+		q.lggr.Errorw(slowMsg, kvs...)
+	} else if warnThreshold := timeout / 10; warnThreshold > 0 && elapsed > warnThreshold {
+		q.lggr.Warnw(slowMsg, kvs...)
+	}
+
+	PromSQLQueryTime.Observe(pct)
+}

--- a/pkg/sqlutil/monitor_test.go
+++ b/pkg/sqlutil/monitor_test.go
@@ -1,0 +1,74 @@
+package sqlutil
+
+import (
+	"database/sql/driver"
+	"strconv"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_sprintQ(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		query string
+		args  []interface{}
+		exp   string
+	}{
+		{"none",
+			"SELECT * FROM table;",
+			nil,
+			"SELECT * FROM table;"},
+		{"one",
+			"SELECT $1 FROM table;",
+			[]interface{}{"foo"},
+			"SELECT 'foo' FROM table;"},
+		{"two",
+			"SELECT $1 FROM table WHERE bar = $2;",
+			[]interface{}{"foo", 1},
+			"SELECT 'foo' FROM table WHERE bar = 1;"},
+		{"limit",
+			"SELECT $1 FROM table LIMIT $2;",
+			[]interface{}{"foo", limit(10)},
+			"SELECT 'foo' FROM table LIMIT 10;"},
+		{"limit-all",
+			"SELECT $1 FROM table LIMIT $2;",
+			[]interface{}{"foo", limit(-1)},
+			"SELECT 'foo' FROM table LIMIT NULL;"},
+		{"bytea",
+			"SELECT $1 FROM table WHERE b = $2;",
+			[]interface{}{"foo", []byte{0x0a}},
+			"SELECT 'foo' FROM table WHERE b = '\\x0a';"},
+		{"bytea[]",
+			"SELECT $1 FROM table WHERE b = $2;",
+			[]interface{}{"foo", pq.ByteaArray([][]byte{{0xa}, {0xb}})},
+			"SELECT 'foo' FROM table WHERE b = ARRAY['\\x0a','\\x0b'];"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sprintQ(tt.query, tt.args)
+			t.Log(tt.query, tt.args)
+			t.Log(got)
+			require.Equal(t, tt.exp, got)
+		})
+	}
+}
+
+var _ driver.Valuer = limit(-1)
+
+// limit is a helper driver.Valuer for LIMIT queries which uses nil/NULL for negative values.
+type limit int
+
+func (l limit) String() string {
+	if l < 0 {
+		return "NULL"
+	}
+	return strconv.Itoa(int(l))
+}
+
+func (l limit) Value() (driver.Value, error) {
+	if l < 0 {
+		return nil, nil
+	}
+	return l, nil
+}

--- a/pkg/sqlutil/timeout.go
+++ b/pkg/sqlutil/timeout.go
@@ -1,0 +1,29 @@
+package sqlutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// TimeoutHook returns a [QueryHook] which adds the defaultTimeout to each context.Context,
+// unless [WithoutDefaultTimeout] has been applied to bypass intentionally.
+func TimeoutHook(defaultTimeout time.Duration) QueryHook {
+	return func(ctx context.Context, lggr logger.Logger, do func(context.Context) error, query string, args ...any) error {
+		if wo := ctx.Value(ctxKeyWithoutDefaultTimeout{}); wo == nil {
+			var cancel func()
+			ctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+			defer cancel()
+		}
+
+		return do(ctx)
+	}
+}
+
+type ctxKeyWithoutDefaultTimeout struct{}
+
+// WithoutDefaultTimeout makes a [context.Context] exempt from the default timeout normally applied by a [TimeoutHook].
+func WithoutDefaultTimeout(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKeyWithoutDefaultTimeout{}, struct{}{})
+}


### PR DESCRIPTION
This PR introduces `sqlutil.QueryHook`s based on the core `pq.Q` type's behavior: https://github.com/smartcontractkit/chainlink/blob/5f212bbc8485fc1fb20076ef5df7842f7bbfc6c1/core/services/pg/q.go#L117

https://smartcontract-it.atlassian.net/browse/BCF-2978

![image](https://github.com/smartcontractkit/chainlink-common/assets/1194128/1cc186bd-13f3-43c7-878d-c39fdfecdb9d)
![image](https://github.com/smartcontractkit/chainlink-common/assets/1194128/a775671a-b6d0-40a5-9b28-a07d6d607016)

