### PR TITLE
Add new method to monitor without Kafka exporter

### DIFF
--- a/pkg/monitoring/monitor.go
+++ b/pkg/monitoring/monitor.go
@@ -116,7 +116,6 @@ func NewMonitorPrometheusOnly(
 
 		HTTPServer: httpServer,
 	}, nil
-
 }
 
 // NewMonitor builds a new Monitor instance using dependency injection.


### PR DESCRIPTION
From RTSP's request, for Starknet we are going to do monitoring without exporting to Kafka because the Kafka topic is unused. As long as we emit metrics to prometheus we have a good enough monitoring solution.