### PR TITLE
NCC-E010110-9NL: Remove float conversion in BigIntHook

### DIFF
--- a/pkg/codec/utils.go
+++ b/pkg/codec/utils.go
@@ -30,10 +30,6 @@ func BigIntHook(_, to reflect.Type, data any) (any, error) {
 		bigInt := big.NewInt(0)
 
 		switch v := data.(type) {
-		case float64:
-			bigInt.SetInt64(int64(v))
-		case float32:
-			bigInt.SetInt64(int64(v))
 		case int:
 			bigInt.SetInt64(int64(v))
 		case int8:


### PR DESCRIPTION
rounding wasn't well defined and was assumed to always round down like go does but it's possible that not all blockchains or users would want the same behaviour.  Also, should have used big.Float as an intermediate and supported that as well if it was to be kept