### PR TITLE
Various Keystone bugfixes

### DIFF
--- a/pkg/capabilities/consensus/ocr3/store.go
+++ b/pkg/capabilities/consensus/ocr3/store.go
@@ -36,21 +36,20 @@ func (s *store) add(ctx context.Context, req *request) error {
 	return nil
 }
 
-func (s *store) getN(ctx context.Context, requestIDs []string) ([]*request, error) {
+// best-effort, doesn't return requests that are not in store
+func (s *store) getN(ctx context.Context, requestIDs []string) []*request {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	o := []*request{}
 	for _, r := range requestIDs {
 		gr, ok := s.requests[r]
-		if !ok {
-			return nil, fmt.Errorf("request with id %s not found", r)
+		if ok {
+			o = append(o, gr)
 		}
-
-		o = append(o, gr)
 	}
 
-	return o, nil
+	return o
 }
 
 func (s *store) firstN(ctx context.Context, batchSize int) ([]*request, error) {

--- a/pkg/capabilities/consensus/ocr3/store_test.go
+++ b/pkg/capabilities/consensus/ocr3/store_test.go
@@ -61,4 +61,12 @@ func TestOCR3Store(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, items, 10)
 	})
+
+	t.Run("getN", func(t *testing.T) {
+		rid2 := uuid.New().String()
+		err := s.add(ctx, req)
+		require.NoError(t, err)
+		reqs := s.getN(ctx, []string{rid, rid2})
+		require.Equal(t, 1, len(reqs))
+	})
 }

--- a/pkg/capabilities/triggers/mercury_trigger.go
+++ b/pkg/capabilities/triggers/mercury_trigger.go
@@ -113,7 +113,9 @@ func (o *MercuryTriggerService) RegisterTrigger(ctx context.Context, callback ch
 	if len(feedIDs) == 0 {
 		return errors.New("no feedIDs to register")
 	}
-
+	if cfg.MaxFrequencyMs <= 0 {
+		return errors.New("MaxFrequencyMs must be greater than 0")
+	}
 	if int64(cfg.MaxFrequencyMs)%o.tickerResolutionMs != 0 {
 		return fmt.Errorf("MaxFrequencyMs must be a multiple of %d", o.tickerResolutionMs)
 	}


### PR DESCRIPTION
1. MaxFrequencyMs can't be set to 0 in Mercury Trigger config.
2. Previous outcome initialization that supports changes in aggregator config.
3. Observation phase can't fail when store.getN() can't find some of the IDs - it should still process the one that were found.