### PR TITLE
[chore] Move core service types to types/core to mirror package structure; Add RelayerSet

### DIFF
--- a/pkg/capabilities/consensus/ocr3/ocr3.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 )
 
@@ -78,7 +79,7 @@ func NewOCR3(config Config) *Capability {
 	return cp
 }
 
-func (o *Capability) NewReportingPluginFactory(ctx context.Context, cfg commontypes.ReportingPluginServiceConfig, provider commontypes.PluginProvider, pipelineRunner commontypes.PipelineRunnerService, telemetry commontypes.TelemetryClient, errorLog commontypes.ErrorLog, capabilityRegistry commontypes.CapabilitiesRegistry, keyValueStore commontypes.KeyValueStore) (commontypes.OCR3ReportingPluginFactory, error) {
+func (o *Capability) NewReportingPluginFactory(ctx context.Context, cfg core.ReportingPluginServiceConfig, provider commontypes.PluginProvider, pipelineRunner core.PipelineRunnerService, telemetry core.TelemetryClient, errorLog core.ErrorLog, capabilityRegistry core.CapabilitiesRegistry, keyValueStore core.KeyValueStore) (core.OCR3ReportingPluginFactory, error) {
 	factory, err := newFactory(o.config.store, o.config.capability, o.config.BatchSize, o.config.Logger)
 	if err != nil {
 		return nil, err
@@ -92,7 +93,7 @@ func (o *Capability) NewReportingPluginFactory(ctx context.Context, cfg commonty
 	return factory, err
 }
 
-func (o *Capability) NewValidationService(ctx context.Context) (commontypes.ValidationService, error) {
+func (o *Capability) NewValidationService(ctx context.Context) (core.ValidationService, error) {
 	s := &validationService{lggr: o.Logger}
 	o.SubService(s)
 	return s, nil

--- a/pkg/capabilities/consensus/ocr3/ocr3_test.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/mocks"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
@@ -24,14 +25,14 @@ func TestOCR3_ReportingFactoryAddsCapability(t *testing.T) {
 	require.NoError(t, o.Start(ctx))
 
 	var p types.PluginProvider
-	var pr types.PipelineRunnerService
-	var tc types.TelemetryClient
-	var el types.ErrorLog
-	var kv types.KeyValueStore
+	var pr core.PipelineRunnerService
+	var tc core.TelemetryClient
+	var el core.ErrorLog
+	var kv core.KeyValueStore
 	r := mocks.NewCapabilitiesRegistry(t)
 	r.On("Add", mock.Anything, o.config.capability).Return(nil)
 
-	_, err := o.NewReportingPluginFactory(ctx, types.ReportingPluginServiceConfig{}, p, pr, tc, el, r, kv)
+	_, err := o.NewReportingPluginFactory(ctx, core.ReportingPluginServiceConfig{}, p, pr, tc, el, r, kv)
 	require.NoError(t, err)
 }
 
@@ -46,14 +47,14 @@ func TestOCR3_ReportingFactoryIsAService(t *testing.T) {
 	require.NoError(t, o.Start(ctx))
 
 	var p types.PluginProvider
-	var pr types.PipelineRunnerService
-	var tc types.TelemetryClient
-	var el types.ErrorLog
-	var kv types.KeyValueStore
+	var pr core.PipelineRunnerService
+	var tc core.TelemetryClient
+	var el core.ErrorLog
+	var kv core.KeyValueStore
 	r := mocks.NewCapabilitiesRegistry(t)
 	r.On("Add", mock.Anything, o.config.capability).Return(nil)
 
-	factory, err := o.NewReportingPluginFactory(ctx, types.ReportingPluginServiceConfig{}, p, pr, tc, el, r, kv)
+	factory, err := o.NewReportingPluginFactory(ctx, core.ReportingPluginServiceConfig{}, p, pr, tc, el, r, kv)
 	require.NoError(t, err)
 
 	require.NoError(t, factory.Start(ctx))

--- a/pkg/capabilities/consensus/ocr3/validation_service.go
+++ b/pkg/capabilities/consensus/ocr3/validation_service.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
-var _ commontypes.ValidationService = (*validationService)(nil)
+var _ core.ValidationService = (*validationService)(nil)
 
 type validationService struct {
 	lggr logger.Logger

--- a/pkg/loop/internal/core/services/capability/capabilities_registry.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_registry.go
@@ -11,10 +11,10 @@ import (
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
-var _ types.CapabilitiesRegistry = (*capabilitiesRegistryClient)(nil)
+var _ core.CapabilitiesRegistry = (*capabilitiesRegistryClient)(nil)
 
 type capabilitiesRegistryClient struct {
 	*net.BrokerExt
@@ -169,7 +169,7 @@ var _ pb.CapabilitiesRegistryServer = (*capabilitiesRegistryServer)(nil)
 type capabilitiesRegistryServer struct {
 	pb.UnimplementedCapabilitiesRegistryServer
 	*net.BrokerExt
-	impl types.CapabilitiesRegistry
+	impl core.CapabilitiesRegistry
 }
 
 func (c *capabilitiesRegistryServer) Get(ctx context.Context, request *pb.GetRequest) (*pb.GetReply, error) {
@@ -358,7 +358,7 @@ func (c *capabilitiesRegistryServer) Add(ctx context.Context, request *pb.AddReq
 	return &emptypb.Empty{}, nil
 }
 
-func NewCapabilitiesRegistryServer(b *net.BrokerExt, i types.CapabilitiesRegistry) *capabilitiesRegistryServer {
+func NewCapabilitiesRegistryServer(b *net.BrokerExt, i core.CapabilitiesRegistry) *capabilitiesRegistryServer {
 	return &capabilitiesRegistryServer{
 		BrokerExt: b.WithName("CapabilitiesRegistryServer"),
 		impl:      i,

--- a/pkg/loop/internal/core/services/errorlog/error_log.go
+++ b/pkg/loop/internal/core/services/errorlog/error_log.go
@@ -7,10 +7,10 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
-var _ types.ErrorLog = (*errorLogClient)(nil)
+var _ core.ErrorLog = (*errorLogClient)(nil)
 
 type errorLogClient struct {
 	grpc pb.ErrorLogClient
@@ -30,10 +30,10 @@ var _ pb.ErrorLogServer = (*Server)(nil)
 type Server struct {
 	pb.UnimplementedErrorLogServer
 
-	impl types.ErrorLog
+	impl core.ErrorLog
 }
 
-func NewServer(impl types.ErrorLog) *Server {
+func NewServer(impl core.ErrorLog) *Server {
 	return &Server{impl: impl}
 }
 

--- a/pkg/loop/internal/core/services/errorlog/test/error_log.go
+++ b/pkg/loop/internal/core/services/errorlog/test/error_log.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	testtypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test/types"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var ErrorLog = StaticErrorLog{errMsg: "an error"}
@@ -23,6 +23,6 @@ func (s StaticErrorLog) SaveError(ctx context.Context, msg string) error {
 	return nil
 }
 
-func (s StaticErrorLog) Evaluate(ctx context.Context, other types.ErrorLog) error {
+func (s StaticErrorLog) Evaluate(ctx context.Context, other core.ErrorLog) error {
 	return s.SaveError(ctx, s.errMsg)
 }

--- a/pkg/loop/internal/core/services/keystore/test/keystore.go
+++ b/pkg/loop/internal/core/services/keystore/test/keystore.go
@@ -8,7 +8,7 @@ import (
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	testtypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test/types"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var Keystore = staticKeystore{
@@ -19,8 +19,8 @@ var Keystore = staticKeystore{
 	},
 }
 
-var _ types.Keystore = (*staticKeystore)(nil)
-var _ testtypes.Evaluator[types.Keystore] = (*staticKeystore)(nil)
+var _ core.Keystore = (*staticKeystore)(nil)
+var _ testtypes.Evaluator[core.Keystore] = (*staticKeystore)(nil)
 
 type staticKeystoreConfig struct {
 	Account libocr.Account
@@ -46,7 +46,7 @@ func (s staticKeystore) Sign(ctx context.Context, id string, data []byte) ([]byt
 	return s.signed, nil
 }
 
-func (s staticKeystore) Evaluate(ctx context.Context, other types.Keystore) error {
+func (s staticKeystore) Evaluate(ctx context.Context, other core.Keystore) error {
 	accounts, err := s.Accounts(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get accounts: %w", err)

--- a/pkg/loop/internal/core/services/keyvalue/store.go
+++ b/pkg/loop/internal/core/services/keyvalue/store.go
@@ -8,10 +8,10 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
-var _ types.KeyValueStore = (*Client)(nil)
+var _ core.KeyValueStore = (*Client)(nil)
 
 type Client struct {
 	grpc pb.KeyValueStoreClient
@@ -43,10 +43,10 @@ var _ pb.KeyValueStoreServer = (*Server)(nil)
 
 type Server struct {
 	pb.UnimplementedKeyValueStoreServer
-	impl types.KeyValueStore
+	impl core.KeyValueStore
 }
 
-func NewServer(impl types.KeyValueStore) *Server {
+func NewServer(impl core.KeyValueStore) *Server {
 	return &Server{impl: impl}
 }
 

--- a/pkg/loop/internal/core/services/pipeline/pipeline_runner_test.go
+++ b/pkg/loop/internal/core/services/pipeline/pipeline_runner_test.go
@@ -11,19 +11,19 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/jsonserializable"
 )
 
 type mockPipelineRunner struct {
-	taskResults []types.TaskResult
+	taskResults []core.TaskResult
 	err         error
 	spec        string
-	vars        types.Vars
-	options     types.Options
+	vars        core.Vars
+	options     core.Options
 }
 
-func (m *mockPipelineRunner) ExecuteRun(ctx context.Context, spec string, vars types.Vars, options types.Options) (types.TaskResults, error) {
+func (m *mockPipelineRunner) ExecuteRun(ctx context.Context, spec string, vars core.Vars, options core.Options) (core.TaskResults, error) {
 	m.spec, m.vars, m.options = spec, vars, options
 	return m.taskResults, m.err
 }
@@ -37,10 +37,10 @@ func (c *clientAdapter) ExecuteRun(ctx context.Context, in *pb.RunRequest, opts 
 }
 
 func TestPipelineRunnerService(t *testing.T) {
-	originalResults := []types.TaskResult{
+	originalResults := []core.TaskResult{
 		{
 			ID: "1",
-			TaskValue: types.TaskValue{
+			TaskValue: core.TaskValue{
 				Value: jsonserializable.JSONSerializable{
 					Val:   123.123,
 					Valid: true,
@@ -51,7 +51,7 @@ func TestPipelineRunnerService(t *testing.T) {
 		{
 			ID: "2",
 
-			TaskValue: types.TaskValue{
+			TaskValue: core.TaskValue{
 				Value: jsonserializable.JSONSerializable{},
 				Error: errors.New("Error task"),
 			},
@@ -66,8 +66,8 @@ func TestPipelineRunnerService(t *testing.T) {
 	trs, err := client.ExecuteRun(
 		context.Background(),
 		"my-spec",
-		types.Vars{Vars: map[string]interface{}{"my-vars": true}},
-		types.Options{MaxTaskDuration: 10 * time.Second},
+		core.Vars{Vars: map[string]interface{}{"my-vars": true}},
+		core.Options{MaxTaskDuration: 10 * time.Second},
 	)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, originalResults, trs)
@@ -79,10 +79,10 @@ func TestPipelineRunnerService_CallArgs(t *testing.T) {
 	client := &pipelineRunnerServiceClient{grpc: &clientAdapter{srv: srv}}
 
 	spec := "my-spec"
-	vars := types.Vars{
+	vars := core.Vars{
 		Vars: map[string]interface{}{"my-vars": true},
 	}
-	options := types.Options{
+	options := core.Options{
 		MaxTaskDuration: 10 * time.Second,
 	}
 	_, err := client.ExecuteRun(context.Background(), spec, vars, options)

--- a/pkg/loop/internal/core/services/pipeline/test/pipeline_runner.go
+++ b/pkg/loop/internal/core/services/pipeline/test/pipeline_runner.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	testtypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test/types"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/jsonserializable"
 )
 
@@ -19,15 +19,15 @@ answer;
 var PipelineRunner = staticPipelineRunnerService{
 	staticPipelineRunnerConfig: staticPipelineRunnerConfig{
 		spec: pipleineSpec,
-		vars: types.Vars{
+		vars: core.Vars{
 			Vars: map[string]interface{}{"foo": "baz"},
 		},
-		options: types.Options{
+		options: core.Options{
 			MaxTaskDuration: 10 * time.Second,
 		},
-		taskResults: types.TaskResults([]types.TaskResult{
+		taskResults: core.TaskResults([]core.TaskResult{
 			{
-				TaskValue: types.TaskValue{
+				TaskValue: core.TaskValue{
 					Value: jsonserializable.JSONSerializable{
 						Val:   "hello",
 						Valid: true,
@@ -43,16 +43,16 @@ var _ testtypes.PipelineEvaluator = (*staticPipelineRunnerService)(nil)
 
 type staticPipelineRunnerConfig struct {
 	spec        string
-	vars        types.Vars
-	options     types.Options
-	taskResults types.TaskResults
+	vars        core.Vars
+	options     core.Options
+	taskResults core.TaskResults
 }
 
 type staticPipelineRunnerService struct {
 	staticPipelineRunnerConfig
 }
 
-func (pr staticPipelineRunnerService) ExecuteRun(ctx context.Context, s string, v types.Vars, o types.Options) (types.TaskResults, error) {
+func (pr staticPipelineRunnerService) ExecuteRun(ctx context.Context, s string, v core.Vars, o core.Options) (core.TaskResults, error) {
 	if s != pr.spec {
 		return nil, fmt.Errorf("expected %s but got %s", pr.spec, s)
 	}
@@ -65,7 +65,7 @@ func (pr staticPipelineRunnerService) ExecuteRun(ctx context.Context, s string, 
 	return pr.taskResults, nil
 }
 
-func (pr staticPipelineRunnerService) Evaluate(ctx context.Context, other types.PipelineRunnerService) error {
+func (pr staticPipelineRunnerService) Evaluate(ctx context.Context, other core.PipelineRunnerService) error {
 	tr, err := pr.ExecuteRun(ctx, pr.spec, pr.vars, pr.options)
 	if err != nil {
 		return fmt.Errorf("failed to execute pipeline: %w", err)

--- a/pkg/loop/internal/core/services/relayerset/relayerset.go
+++ b/pkg/loop/internal/core/services/relayerset/relayerset.go
@@ -1,0 +1,30 @@
+package relayerset
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
+
+type RelayerSet interface {
+	Get(ctx context.Context, relayID types.RelayID) (Relayer, error)
+	GetAll(ctx context.Context) ([]Relayer, error)
+}
+
+type PluginArgs struct {
+	TransmitterID string
+	PluginConfig  []byte
+}
+
+type RelayArgs struct {
+	ContractID         string
+	RelayConfig        []byte
+	ProviderType       string
+	MercuryCredentials *types.MercuryCredentials
+}
+
+type Relayer interface {
+	services.Service
+	NewPluginProvider(rargs RelayArgs, pargs PluginArgs) (types.PluginProvider, error)
+}

--- a/pkg/loop/internal/core/services/reportingplugin/ocr2/reporting_plugin_service.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr2/reporting_plugin_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/keyvalue"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 
 	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
@@ -20,7 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
-var _ types.ReportingPluginClient = (*ReportingPluginServiceClient)(nil)
+var _ core.ReportingPluginClient = (*ReportingPluginServiceClient)(nil)
 
 type ReportingPluginServiceClient struct {
 	*goplugin.PluginClient
@@ -37,12 +38,12 @@ func NewReportingPluginServiceClient(broker net.Broker, brokerCfg net.BrokerConf
 
 func (m *ReportingPluginServiceClient) NewReportingPluginFactory(
 	ctx context.Context,
-	config types.ReportingPluginServiceConfig,
+	config core.ReportingPluginServiceConfig,
 	grpcProvider grpc.ClientConnInterface,
-	pipelineRunner types.PipelineRunnerService,
-	telemetryService types.TelemetryService,
-	errorLog types.ErrorLog,
-	keyValueStore types.KeyValueStore,
+	pipelineRunner core.PipelineRunnerService,
+	telemetryService core.TelemetryService,
+	errorLog core.ErrorLog,
+	keyValueStore core.KeyValueStore,
 ) (types.ReportingPluginFactory, error) {
 	cc := m.NewClientConn("ReportingPluginServiceFactory", func(ctx context.Context) (id uint32, deps net.Resources, err error) {
 		providerID, providerRes, err := m.Serve("PluginProvider", proxy.NewProxy(grpcProvider))
@@ -107,7 +108,7 @@ func (m *ReportingPluginServiceClient) NewReportingPluginFactory(
 	return NewReportingPluginFactoryClient(m.PluginClient.BrokerExt, cc), nil
 }
 
-func (m *ReportingPluginServiceClient) NewValidationService(ctx context.Context) (types.ValidationService, error) {
+func (m *ReportingPluginServiceClient) NewValidationService(ctx context.Context) (core.ValidationService, error) {
 	cc := m.NewClientConn("validationService", func(ctx context.Context) (id uint32, deps net.Resources, err error) {
 		reply, err := m.reportingPluginService.NewValidationService(ctx, &pb.ValidationServiceRequest{})
 		if err != nil {
@@ -124,15 +125,15 @@ type reportingPluginServiceServer struct {
 	pb.UnimplementedReportingPluginServiceServer
 
 	*net.BrokerExt
-	impl types.ReportingPluginClient
+	impl core.ReportingPluginClient
 }
 
-func RegisterReportingPluginServiceServer(server *grpc.Server, broker net.Broker, brokerCfg net.BrokerConfig, impl types.ReportingPluginClient) error {
+func RegisterReportingPluginServiceServer(server *grpc.Server, broker net.Broker, brokerCfg net.BrokerConfig, impl core.ReportingPluginClient) error {
 	pb.RegisterReportingPluginServiceServer(server, newReportingPluginServiceServer(&net.BrokerExt{Broker: broker, BrokerConfig: brokerCfg}, impl))
 	return nil
 }
 
-func newReportingPluginServiceServer(b *net.BrokerExt, gp types.ReportingPluginClient) *reportingPluginServiceServer {
+func newReportingPluginServiceServer(b *net.BrokerExt, gp core.ReportingPluginClient) *reportingPluginServiceServer {
 	return &reportingPluginServiceServer{BrokerExt: b.WithName("ReportingPluginService"), impl: gp}
 }
 
@@ -175,7 +176,7 @@ func (m *reportingPluginServiceServer) NewReportingPluginFactory(ctx context.Con
 	keyValueStoreRes := net.Resource{Closer: keyValueStoreConn, Name: "KeyValueStore"}
 	keyValueStore := keyvalue.NewClient(keyValueStoreConn)
 
-	config := types.ReportingPluginServiceConfig{
+	config := core.ReportingPluginServiceConfig{
 		ProviderType:  request.ReportingPluginServiceConfig.ProviderType,
 		PluginConfig:  request.ReportingPluginServiceConfig.PluginConfig,
 		PluginName:    request.ReportingPluginServiceConfig.PluginName,

--- a/pkg/loop/internal/core/services/reportingplugin/ocr2/test/factory_servers.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr2/test/factory_servers.go
@@ -16,6 +16,7 @@ import (
 	testtypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var MedianProviderServer = medianFactoryServer{
@@ -31,8 +32,8 @@ const MedianID = "ocr2-reporting-plugin-with-median-provider"
 
 type medianGeneratorConfig struct {
 	medianProvider    testtypes.MedianProviderTester
-	pipeline          testtypes.Evaluator[types.PipelineRunnerService]
-	telemetry         testtypes.Evaluator[types.TelemetryClient]
+	pipeline          testtypes.Evaluator[core.PipelineRunnerService]
+	telemetry         testtypes.Evaluator[core.TelemetryClient]
 	validationService testtypes.ValidationEvaluator
 }
 
@@ -42,7 +43,7 @@ type medianFactoryServer struct {
 
 var _ reportingplugins.ProviderServer[types.MedianProvider] = medianFactoryServer{}
 
-func (s medianFactoryServer) NewValidationService(ctx context.Context) (types.ValidationService, error) {
+func (s medianFactoryServer) NewValidationService(ctx context.Context) (core.ValidationService, error) {
 	return s.validationService, nil
 }
 
@@ -50,7 +51,7 @@ func (s medianFactoryServer) ConnToProvider(conn grpc.ClientConnInterface, broke
 	return s.medianProvider
 }
 
-func (s medianFactoryServer) NewReportingPluginFactory(ctx context.Context, config types.ReportingPluginServiceConfig, provider types.MedianProvider, pipelineRunner types.PipelineRunnerService, telemetry types.TelemetryClient, errorLog types.ErrorLog, keyValueStore types.KeyValueStore) (types.ReportingPluginFactory, error) {
+func (s medianFactoryServer) NewReportingPluginFactory(ctx context.Context, config core.ReportingPluginServiceConfig, provider types.MedianProvider, pipelineRunner core.PipelineRunnerService, telemetry core.TelemetryClient, errorLog core.ErrorLog, keyValueStore core.KeyValueStore) (types.ReportingPluginFactory, error) {
 	err := s.medianProvider.Evaluate(ctx, provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate median provider: %w", err)
@@ -85,7 +86,7 @@ type agnosticPluginFactoryServer struct {
 	validationService testtypes.ValidationEvaluator
 }
 
-func (s agnosticPluginFactoryServer) NewValidationService(ctx context.Context) (types.ValidationService, error) {
+func (s agnosticPluginFactoryServer) NewValidationService(ctx context.Context) (core.ValidationService, error) {
 	return s.validationService, nil
 }
 
@@ -93,7 +94,7 @@ func (s agnosticPluginFactoryServer) ConnToProvider(conn grpc.ClientConnInterfac
 	return s.provider
 }
 
-func (s agnosticPluginFactoryServer) NewReportingPluginFactory(ctx context.Context, config types.ReportingPluginServiceConfig, provider types.PluginProvider, pipelineRunner types.PipelineRunnerService, telemetry types.TelemetryClient, errorLog types.ErrorLog, keyValueStore types.KeyValueStore) (types.ReportingPluginFactory, error) {
+func (s agnosticPluginFactoryServer) NewReportingPluginFactory(ctx context.Context, config core.ReportingPluginServiceConfig, provider types.PluginProvider, pipelineRunner core.PipelineRunnerService, telemetry core.TelemetryClient, errorLog core.ErrorLog, keyValueStore core.KeyValueStore) (types.ReportingPluginFactory, error) {
 	err := s.provider.Evaluate(ctx, provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate agnostic provider: %w", err)

--- a/pkg/loop/internal/core/services/reportingplugin/ocr3/test/factory.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr3/test/factory.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
@@ -28,7 +28,7 @@ type ocr3staticPluginFactory struct {
 	reportingPlugin ocr3staticReportingPlugin
 }
 
-var _ types.OCR3ReportingPluginFactory = (*ocr3staticPluginFactory)(nil)
+var _ core.OCR3ReportingPluginFactory = (*ocr3staticPluginFactory)(nil)
 
 func (o ocr3staticPluginFactory) Name() string { panic("implement me") }
 
@@ -85,7 +85,7 @@ func (o ocr3staticPluginFactory) equalConfig(other ocr3types.ReportingPluginConf
 	return nil
 }
 
-func OCR3ReportingPluginFactory(t *testing.T, factory types.OCR3ReportingPluginFactory) {
+func OCR3ReportingPluginFactory(t *testing.T, factory core.OCR3ReportingPluginFactory) {
 	expectedFactory := Factory
 	t.Run("OCR3ReportingPluginFactory", func(t *testing.T) {
 		ctx := tests.Context(t)

--- a/pkg/loop/internal/core/services/reportingplugin/ocr3/test/factory_generators.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr3/test/factory_generators.go
@@ -14,6 +14,7 @@ import (
 	ocr2test "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/ocr2/test"
 	testtypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var MedianServer = medianServer{
@@ -29,8 +30,8 @@ const OCR3ReportingPluginWithMedianProviderName = "ocr3-reporting-plugin-with-me
 
 type medianGeneratorConfig struct {
 	medianProvider    testtypes.MedianProviderTester
-	pipeline          testtypes.Evaluator[types.PipelineRunnerService]
-	telemetry         testtypes.Evaluator[types.TelemetryClient]
+	pipeline          testtypes.Evaluator[core.PipelineRunnerService]
+	telemetry         testtypes.Evaluator[core.TelemetryClient]
 	validationService testtypes.ValidationEvaluator
 }
 
@@ -38,14 +39,14 @@ type medianServer struct {
 	medianGeneratorConfig
 }
 
-func (s medianServer) NewValidationService(ctx context.Context) (types.ValidationService, error) {
+func (s medianServer) NewValidationService(ctx context.Context) (core.ValidationService, error) {
 	return s.validationService, nil
 }
 func (s medianServer) ConnToProvider(conn grpc.ClientConnInterface, broker net.Broker, brokerConfig net.BrokerConfig) types.MedianProvider {
 	return s.medianProvider
 }
 
-func (s medianServer) NewReportingPluginFactory(ctx context.Context, config types.ReportingPluginServiceConfig, provider types.MedianProvider, pipelineRunner types.PipelineRunnerService, telemetry types.TelemetryClient, errorLog types.ErrorLog, capRegistry types.CapabilitiesRegistry, keyValueStore types.KeyValueStore) (types.OCR3ReportingPluginFactory, error) {
+func (s medianServer) NewReportingPluginFactory(ctx context.Context, config core.ReportingPluginServiceConfig, provider types.MedianProvider, pipelineRunner core.PipelineRunnerService, telemetry core.TelemetryClient, errorLog core.ErrorLog, capRegistry core.CapabilitiesRegistry, keyValueStore core.KeyValueStore) (core.OCR3ReportingPluginFactory, error) {
 	err := s.medianProvider.Evaluate(ctx, provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate median provider: %w", err)
@@ -78,7 +79,7 @@ type agnosticPluginServer struct {
 	validationService testtypes.ValidationEvaluator
 }
 
-func (s agnosticPluginServer) NewValidationService(ctx context.Context) (types.ValidationService, error) {
+func (s agnosticPluginServer) NewValidationService(ctx context.Context) (core.ValidationService, error) {
 	return s.validationService, nil
 }
 
@@ -86,7 +87,7 @@ func (s agnosticPluginServer) ConnToProvider(conn grpc.ClientConnInterface, brok
 	return s.provider
 }
 
-func (s agnosticPluginServer) NewReportingPluginFactory(ctx context.Context, config types.ReportingPluginServiceConfig, provider types.PluginProvider, pipelineRunner types.PipelineRunnerService, telemetry types.TelemetryClient, errorLog types.ErrorLog, capRegistry types.CapabilitiesRegistry, keyValueStore types.KeyValueStore) (types.OCR3ReportingPluginFactory, error) {
+func (s agnosticPluginServer) NewReportingPluginFactory(ctx context.Context, config core.ReportingPluginServiceConfig, provider types.PluginProvider, pipelineRunner core.PipelineRunnerService, telemetry core.TelemetryClient, errorLog core.ErrorLog, capRegistry core.CapabilitiesRegistry, keyValueStore core.KeyValueStore) (core.OCR3ReportingPluginFactory, error) {
 	err := s.provider.Evaluate(ctx, provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate agnostic provider: %w", err)

--- a/pkg/loop/internal/core/services/telemetry/telemetry.go
+++ b/pkg/loop/internal/core/services/telemetry/telemetry.go
@@ -8,16 +8,16 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var (
-	_ types.TelemetryService = (*telemetryServiceClient)(nil)
-	_ types.TelemetryClient  = (*telemetryClient)(nil)
+	_ core.TelemetryService = (*telemetryServiceClient)(nil)
+	_ core.TelemetryClient  = (*telemetryClient)(nil)
 )
 
 type telemetryEndpoint struct {
-	client        types.TelemetryService
+	client        core.TelemetryService
 	network       string
 	chainID       string
 	telemetryType string
@@ -28,16 +28,16 @@ func (t *telemetryEndpoint) SendLog(ctx context.Context, log []byte) error {
 	return t.client.Send(ctx, t.network, t.chainID, t.contractID, t.telemetryType, log)
 }
 
-func NewTelemetryClient(client types.TelemetryService) *telemetryClient {
+func NewTelemetryClient(client core.TelemetryService) *telemetryClient {
 	return &telemetryClient{TelemetryService: client}
 }
 
 type telemetryClient struct {
-	types.TelemetryService
+	core.TelemetryService
 }
 
 // NewEndpoint generates a new monitoring endpoint, returns nil if one cannot be generated.
-func (t *telemetryClient) NewEndpoint(ctx context.Context, network string, chainID string, contractID string, telemetryType string) (types.TelemetryClientEndpoint, error) {
+func (t *telemetryClient) NewEndpoint(ctx context.Context, network string, chainID string, contractID string, telemetryType string) (core.TelemetryClientEndpoint, error) {
 	if contractID == "" {
 		return nil, errors.New("contractID cannot be empty")
 	}
@@ -102,7 +102,7 @@ var _ pb.TelemetryServer = (*telemetryServer)(nil)
 type telemetryServer struct {
 	pb.UnimplementedTelemetryServer
 
-	impl types.TelemetryService
+	impl core.TelemetryService
 }
 
 func (t *telemetryServer) Send(ctx context.Context, message *pb.TelemetryMessage) (*emptypb.Empty, error) {
@@ -115,6 +115,6 @@ func (t *telemetryServer) Send(ctx context.Context, message *pb.TelemetryMessage
 	return &emptypb.Empty{}, err
 }
 
-func NewTelemetryServer(impl types.TelemetryService) *telemetryServer {
+func NewTelemetryServer(impl core.TelemetryService) *telemetryServer {
 	return &telemetryServer{impl: impl}
 }

--- a/pkg/loop/internal/core/services/telemetry/test/telemetry.go
+++ b/pkg/loop/internal/core/services/telemetry/test/telemetry.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/telemetry"
 	testtypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test/types"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var Telemetry = staticTelemetry{
@@ -48,7 +48,7 @@ type staticTelemetry struct {
 	staticTelemetryConfig
 }
 
-func (s staticTelemetry) NewEndpoint(ctx context.Context, network string, chainID string, contractID string, telemType string) (types.TelemetryClientEndpoint, error) {
+func (s staticTelemetry) NewEndpoint(ctx context.Context, network string, chainID string, contractID string, telemType string) (core.TelemetryClientEndpoint, error) {
 	if network != s.network {
 		return nil, fmt.Errorf("expected network %s but got %s", s.network, network)
 	}
@@ -86,7 +86,7 @@ func (s staticTelemetry) Send(ctx context.Context, n string, chid string, conid 
 	return nil
 }
 
-func (s staticTelemetry) Evaluate(ctx context.Context, other types.TelemetryClient) error {
+func (s staticTelemetry) Evaluate(ctx context.Context, other core.TelemetryClient) error {
 	endpoint, err := other.NewEndpoint(ctx, s.network, s.chainID, s.contractID, s.telemType)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate endpoint: %w", err)
@@ -98,7 +98,7 @@ func (s staticTelemetry) Evaluate(ctx context.Context, other types.TelemetryClie
 	return nil
 }
 
-func (s staticTelemetry) Expected() types.TelemetryClient {
+func (s staticTelemetry) Expected() core.TelemetryClient {
 	return s
 }
 

--- a/pkg/loop/internal/core/services/validation/test/validation.go
+++ b/pkg/loop/internal/core/services/validation/test/validation.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var ValidationService = staticValidationService{}
@@ -16,13 +16,13 @@ var GoodPluginConfig = map[string]interface{}{
 	"someFieldName": "someFieldValue",
 }
 
-var _ types.ValidationService = (*staticValidationService)(nil)
+var _ core.ValidationService = (*staticValidationService)(nil)
 
 type staticValidationService struct {
 	services.Service
 }
 
-func (t staticValidationService) Evaluate(ctx context.Context, other types.ValidationService) error {
+func (t staticValidationService) Evaluate(ctx context.Context, other core.ValidationService) error {
 	return other.ValidateConfig(ctx, GoodPluginConfig)
 }
 

--- a/pkg/loop/internal/core/services/validation/validation.go
+++ b/pkg/loop/internal/core/services/validation/validation.go
@@ -9,7 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 type validationServiceClient struct {
@@ -38,7 +38,7 @@ type validationServiceServer struct {
 
 	*net.BrokerExt
 
-	impl types.ValidationServiceServer
+	impl core.ValidationServiceServer
 }
 
 func (v *validationServiceServer) ValidateConfig(ctx context.Context, c *pb.ValidateConfigRequest) (*pb.ValidateConfigResponse, error) {
@@ -49,6 +49,6 @@ func (v *validationServiceServer) ValidateConfig(ctx context.Context, c *pb.Vali
 	return &pb.ValidateConfigResponse{}, nil
 }
 
-func NewValidationServiceServer(impl types.ValidationServiceServer, b *net.BrokerExt) *validationServiceServer {
+func NewValidationServiceServer(impl core.ValidationServiceServer, b *net.BrokerExt) *validationServiceServer {
 	return &validationServiceServer{impl: impl, BrokerExt: b.WithName("ReportingPluginFactoryServer")}
 }

--- a/pkg/loop/internal/relayer/pluginprovider/ext/median/test/median.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/median/test/median.go
@@ -19,10 +19,11 @@ import (
 	reportingplugintest "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/reportingplugin/test"
 	testtypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
-func PluginMedian(t *testing.T, p types.PluginMedian) {
+func PluginMedian(t *testing.T, p core.PluginMedian) {
 	PluginMedianTest{&MedianProvider}.TestPluginMedian(t, p)
 }
 
@@ -30,7 +31,7 @@ type PluginMedianTest struct {
 	types.MedianProvider
 }
 
-func (m PluginMedianTest) TestPluginMedian(t *testing.T, p types.PluginMedian) {
+func (m PluginMedianTest) TestPluginMedian(t *testing.T, p core.PluginMedian) {
 	t.Run("PluginMedian", func(t *testing.T) {
 		ctx := tests.Context(t)
 		factory, err := p.NewMedianFactory(ctx, m.MedianProvider, DataSource, JuelsPerFeeCoinDataSource, &errorlogtest.ErrorLog)
@@ -70,9 +71,9 @@ type staticMedianFactoryServer struct {
 	staticPluginMedianConfig
 }
 
-var _ types.PluginMedian = staticMedianFactoryServer{}
+var _ core.PluginMedian = staticMedianFactoryServer{}
 
-func (s staticMedianFactoryServer) NewMedianFactory(ctx context.Context, provider types.MedianProvider, dataSource, juelsPerFeeCoinDataSource median.DataSource, errorLog types.ErrorLog) (types.ReportingPluginFactory, error) {
+func (s staticMedianFactoryServer) NewMedianFactory(ctx context.Context, provider types.MedianProvider, dataSource, juelsPerFeeCoinDataSource median.DataSource, errorLog core.ErrorLog) (types.ReportingPluginFactory, error) {
 	// the provider may be a grpc client, so we can't compare it directly
 	// but in all of these static tests, the implementation of the provider is expected
 	// to be the same static implementation, so we can compare the expected values

--- a/pkg/loop/internal/relayer/relayer.go
+++ b/pkg/loop/internal/relayer/relayer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/ocr2"
 	looptypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var _ looptypes.PluginRelayer = (*PluginRelayerClient)(nil)
@@ -38,7 +39,7 @@ func NewPluginRelayerClient(broker net.Broker, brokerCfg net.BrokerConfig, conn 
 	return &PluginRelayerClient{PluginClient: pc, grpc: pb.NewPluginRelayerClient(pc)}
 }
 
-func (p *PluginRelayerClient) NewRelayer(ctx context.Context, config string, keystore types.Keystore) (looptypes.Relayer, error) {
+func (p *PluginRelayerClient) NewRelayer(ctx context.Context, config string, keystore core.Keystore) (looptypes.Relayer, error) {
 	cc := p.NewClientConn("Relayer", func(ctx context.Context) (id uint32, deps net.Resources, err error) {
 		var ksRes net.Resource
 		id, ksRes, err = p.ServeNew("Keystore", func(s *grpc.Server) {
@@ -109,7 +110,7 @@ func (p *pluginRelayerServer) NewRelayer(ctx context.Context, request *pb.NewRel
 	return &pb.NewRelayerReply{RelayerID: id}, nil
 }
 
-var _ types.Keystore = (*keystoreClient)(nil)
+var _ core.Keystore = (*keystoreClient)(nil)
 
 type keystoreClient struct {
 	grpc pb.KeystoreClient
@@ -140,7 +141,7 @@ var _ pb.KeystoreServer = (*keystoreServer)(nil)
 type keystoreServer struct {
 	pb.UnimplementedKeystoreServer
 
-	impl types.Keystore
+	impl core.Keystore
 }
 
 func (k *keystoreServer) Accounts(ctx context.Context, _ *emptypb.Empty) (*pb.AccountsReply, error) {

--- a/pkg/loop/internal/relayer/test/relayer.go
+++ b/pkg/loop/internal/relayer/test/relayer.go
@@ -23,6 +23,7 @@ import (
 	testtypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test/types"
 	looptypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
@@ -100,7 +101,7 @@ type staticPluginRelayer struct {
 	staticPluginRelayerConfig
 }
 
-func (s staticPluginRelayer) NewRelayer(ctx context.Context, config string, keystore types.Keystore) (looptypes.Relayer, error) {
+func (s staticPluginRelayer) NewRelayer(ctx context.Context, config string, keystore core.Keystore) (looptypes.Relayer, error) {
 	if s.StaticChecks && config != ConfigTOML {
 		return nil, fmt.Errorf("expected config %q but got %q", ConfigTOML, config)
 	}

--- a/pkg/loop/internal/reportingplugin/median/median.go
+++ b/pkg/loop/internal/reportingplugin/median/median.go
@@ -16,9 +16,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
 	medianprovider "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/ext/median"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
-var _ types.PluginMedian = (*PluginMedianClient)(nil)
+var _ core.PluginMedian = (*PluginMedianClient)(nil)
 
 type PluginMedianClient struct {
 	*goplugin.PluginClient
@@ -33,7 +34,7 @@ func NewPluginMedianClient(broker net.Broker, brokerCfg net.BrokerConfig, conn *
 	return &PluginMedianClient{PluginClient: pc, median: pb.NewPluginMedianClient(pc), ServiceClient: goplugin.NewServiceClient(pc.BrokerExt, pc)}
 }
 
-func (m *PluginMedianClient) NewMedianFactory(ctx context.Context, provider types.MedianProvider, dataSource, juelsPerFeeCoin median.DataSource, errorLog types.ErrorLog) (types.ReportingPluginFactory, error) {
+func (m *PluginMedianClient) NewMedianFactory(ctx context.Context, provider types.MedianProvider, dataSource, juelsPerFeeCoin median.DataSource, errorLog core.ErrorLog) (types.ReportingPluginFactory, error) {
 	cc := m.NewClientConn("MedianPluginFactory", func(ctx context.Context) (id uint32, deps net.Resources, err error) {
 		dataSourceID, dsRes, err := m.ServeNew("DataSource", func(s *grpc.Server) {
 			pb.RegisterDataSourceServer(s, newDataSourceServer(dataSource))
@@ -95,15 +96,15 @@ type pluginMedianServer struct {
 	pb.UnimplementedPluginMedianServer
 
 	*net.BrokerExt
-	impl types.PluginMedian
+	impl core.PluginMedian
 }
 
-func RegisterPluginMedianServer(server *grpc.Server, broker net.Broker, brokerCfg net.BrokerConfig, impl types.PluginMedian) error {
+func RegisterPluginMedianServer(server *grpc.Server, broker net.Broker, brokerCfg net.BrokerConfig, impl core.PluginMedian) error {
 	pb.RegisterPluginMedianServer(server, newPluginMedianServer(&net.BrokerExt{Broker: broker, BrokerConfig: brokerCfg}, impl))
 	return nil
 }
 
-func newPluginMedianServer(b *net.BrokerExt, mp types.PluginMedian) *pluginMedianServer {
+func newPluginMedianServer(b *net.BrokerExt, mp core.PluginMedian) *pluginMedianServer {
 	return &pluginMedianServer{BrokerExt: b.WithName("PluginMedian"), impl: mp}
 }
 

--- a/pkg/loop/internal/reportingplugin/test/factory.go
+++ b/pkg/loop/internal/reportingplugin/test/factory.go
@@ -11,6 +11,7 @@ import (
 	validationtest "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/validation/test"
 	testtypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/stretchr/testify/assert"
@@ -109,7 +110,7 @@ func RunFactory(t *testing.T, factory libocr.ReportingPluginFactory) {
 	})
 }
 
-func RunValidation(t *testing.T, validationService types.ValidationService) {
+func RunValidation(t *testing.T, validationService core.ValidationService) {
 	ctx := tests.Context(t)
 	t.Run("ValidationService", func(t *testing.T) {
 		err := validationService.ValidateConfig(ctx, validationtest.GoodPluginConfig)

--- a/pkg/loop/internal/test/types/interfaces.go
+++ b/pkg/loop/internal/test/types/interfaces.go
@@ -8,6 +8,7 @@ import (
 
 	looptypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 // Evaluator is a helper interface for testing types
@@ -52,14 +53,14 @@ type OffchainConfigDigesterEvaluator interface {
 
 // TelemetryEvaluator is a helper interface for testing TelemetryClients
 type TelemetryEvaluator interface {
-	types.TelemetryClient
-	Evaluator[types.TelemetryClient]
+	core.TelemetryClient
+	Evaluator[core.TelemetryClient]
 }
 
 // PipelineEvaluator is a helper interface for testing PipelineRunnerServices
 type PipelineEvaluator interface {
-	types.PipelineRunnerService
-	Evaluator[types.PipelineRunnerService]
+	core.PipelineRunnerService
+	Evaluator[core.PipelineRunnerService]
 }
 
 // CodecEvaluator is a helper interface for testing Codecs
@@ -70,14 +71,14 @@ type CodecEvaluator interface {
 
 // ErrorLogEvaluator is a helper interface for testing ErrorLogs
 type ErrorLogEvaluator interface {
-	types.ErrorLog
-	Evaluator[types.ErrorLog]
+	core.ErrorLog
+	Evaluator[core.ErrorLog]
 }
 
 // ValidationEvaluator is a helper interface for testing ValidationService
 type ValidationEvaluator interface {
-	types.ValidationService
-	Evaluator[types.ValidationService]
+	core.ValidationService
+	Evaluator[core.ValidationService]
 }
 
 type MedianProviderTester interface {

--- a/pkg/loop/internal/types/types.go
+++ b/pkg/loop/internal/types/types.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 type PluginRelayer interface {
-	NewRelayer(ctx context.Context, config string, keystore types.Keystore) (Relayer, error)
+	NewRelayer(ctx context.Context, config string, keystore core.Keystore) (Relayer, error)
 }
 
 type MedianProvider interface {

--- a/pkg/loop/median_service.go
+++ b/pkg/loop/median_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var _ ocrtypes.ReportingPluginFactory = (*MedianService)(nil)
@@ -22,9 +23,9 @@ type MedianService struct {
 
 // NewMedianService returns a new [*MedianService].
 // cmd must return a new exec.Cmd each time it is called.
-func NewMedianService(lggr logger.Logger, grpcOpts GRPCOpts, cmd func() *exec.Cmd, provider types.MedianProvider, dataSource, juelsPerFeeCoin median.DataSource, errorLog types.ErrorLog) *MedianService {
+func NewMedianService(lggr logger.Logger, grpcOpts GRPCOpts, cmd func() *exec.Cmd, provider types.MedianProvider, dataSource, juelsPerFeeCoin median.DataSource, errorLog core.ErrorLog) *MedianService {
 	newService := func(ctx context.Context, instance any) (types.ReportingPluginFactory, error) {
-		plug, ok := instance.(types.PluginMedian)
+		plug, ok := instance.(core.PluginMedian)
 		if !ok {
 			return nil, fmt.Errorf("expected PluginMedian but got %T", instance)
 		}

--- a/pkg/loop/plugin_median.go
+++ b/pkg/loop/plugin_median.go
@@ -8,16 +8,17 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/reportingplugin/median"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 // PluginMedianName is the name for [types.PluginMedian]/[NewGRPCPluginMedian].
 const PluginMedianName = "median"
 
 // Deprecated
-type PluginMedian = types.PluginMedian
+type PluginMedian = core.PluginMedian
 
 // Deprecated
-type ErrorLog = types.ErrorLog
+type ErrorLog = core.ErrorLog
 
 func PluginMedianHandshakeConfig() plugin.HandshakeConfig {
 	return plugin.HandshakeConfig{
@@ -34,7 +35,7 @@ type GRPCPluginMedian struct {
 
 	BrokerConfig
 
-	PluginServer types.PluginMedian
+	PluginServer core.PluginMedian
 
 	pluginClient *median.PluginMedianClient
 }
@@ -51,7 +52,7 @@ func (p *GRPCPluginMedian) GRPCClient(_ context.Context, broker *plugin.GRPCBrok
 		p.pluginClient.Refresh(broker, conn)
 	}
 
-	return types.PluginMedian(p.pluginClient), nil
+	return core.PluginMedian(p.pluginClient), nil
 }
 
 func (p *GRPCPluginMedian) ClientConfig() *plugin.ClientConfig {

--- a/pkg/loop/plugin_median_test.go
+++ b/pkg/loop/plugin_median_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 func TestPluginMedian(t *testing.T) {
@@ -63,13 +64,13 @@ func TestPluginMedianExec(t *testing.T) {
 	i, err := client.Dispense(loop.PluginMedianName)
 	require.NoError(t, err)
 
-	mediantest.PluginMedian(t, i.(types.PluginMedian))
+	mediantest.PluginMedian(t, i.(core.PluginMedian))
 
 	t.Run("proxy", func(t *testing.T) {
 		pr := newPluginRelayerExec(t, false, stopCh)
 		p := newMedianProvider(t, pr)
 		pm := mediantest.PluginMedianTest{MedianProvider: p}
-		pm.TestPluginMedian(t, i.(types.PluginMedian))
+		pm.TestPluginMedian(t, i.(core.PluginMedian))
 	})
 }
 

--- a/pkg/loop/plugin_relayer.go
+++ b/pkg/loop/plugin_relayer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer"
 	looptypes "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/types"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 // PluginRelayerName is the name for [types.PluginRelayer]/[NewGRPCPluginRelayer].
@@ -25,7 +25,7 @@ func PluginRelayerHandshakeConfig() plugin.HandshakeConfig {
 }
 
 // Deprecated
-type Keystore = types.Keystore
+type Keystore = core.Keystore
 
 type Relayer = looptypes.Relayer
 

--- a/pkg/loop/relayer_service.go
+++ b/pkg/loop/relayer_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var _ Relayer = (*RelayerService)(nil)
@@ -20,7 +21,7 @@ type RelayerService struct {
 
 // NewRelayerService returns a new [*RelayerService].
 // cmd must return a new exec.Cmd each time it is called.
-func NewRelayerService(lggr logger.Logger, grpcOpts GRPCOpts, cmd func() *exec.Cmd, config string, keystore types.Keystore) *RelayerService {
+func NewRelayerService(lggr logger.Logger, grpcOpts GRPCOpts, cmd func() *exec.Cmd, config string, keystore core.Keystore) *RelayerService {
 	newService := func(ctx context.Context, instance any) (Relayer, error) {
 		plug, ok := instance.(PluginRelayer)
 		if !ok {

--- a/pkg/loop/reportingplugins/grpc_test.go
+++ b/pkg/loop/reportingplugins/grpc_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
@@ -29,11 +30,11 @@ func newStopCh(t *testing.T) <-chan struct{} {
 	return stopCh
 }
 
-func PluginGenericTest(t *testing.T, p types.ReportingPluginClient) {
+func PluginGenericTest(t *testing.T, p core.ReportingPluginClient) {
 	t.Run("PluginServer", func(t *testing.T) {
 		ctx := tests.Context(t)
 		factory, err := p.NewReportingPluginFactory(ctx,
-			types.ReportingPluginServiceConfig{},
+			core.ReportingPluginServiceConfig{},
 			nettest.MockConn{},
 			pipelinetest.PipelineRunner,
 			telemetrytest.Telemetry,

--- a/pkg/loop/reportingplugins/loopp_service.go
+++ b/pkg/loop/reportingplugins/loopp_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 var _ ocrtypes.ReportingPluginFactory = (*LOOPPService)(nil)
@@ -23,7 +24,7 @@ type LOOPPService struct {
 }
 
 type LOOPPServiceValidation struct {
-	goplugin.PluginService[*GRPCService[types.PluginProvider], types.ValidationService]
+	goplugin.PluginService[*GRPCService[types.PluginProvider], core.ValidationService]
 }
 
 // NewLOOPPService returns a new [*PluginService].
@@ -33,15 +34,15 @@ func NewLOOPPService(
 	lggr logger.Logger,
 	grpcOpts loop.GRPCOpts,
 	cmd func() *exec.Cmd,
-	config types.ReportingPluginServiceConfig,
+	config core.ReportingPluginServiceConfig,
 	providerConn grpc.ClientConnInterface,
-	pipelineRunner types.PipelineRunnerService,
-	telemetryService types.TelemetryService,
-	errorLog types.ErrorLog,
-	keyValueStore types.KeyValueStore,
+	pipelineRunner core.PipelineRunnerService,
+	telemetryService core.TelemetryService,
+	errorLog core.ErrorLog,
+	keyValueStore core.KeyValueStore,
 ) *LOOPPService {
 	newService := func(ctx context.Context, instance any) (types.ReportingPluginFactory, error) {
-		plug, ok := instance.(types.ReportingPluginClient)
+		plug, ok := instance.(core.ReportingPluginClient)
 		if !ok {
 			return nil, fmt.Errorf("expected GenericPluginClient but got %T", instance)
 		}
@@ -67,8 +68,8 @@ func NewLOOPPServiceValidation(
 	grpcOpts loop.GRPCOpts,
 	cmd func() *exec.Cmd,
 ) *LOOPPServiceValidation {
-	newService := func(ctx context.Context, instance any) (types.ValidationService, error) {
-		plug, ok := instance.(types.ReportingPluginClient)
+	newService := func(ctx context.Context, instance any) (core.ValidationService, error) {
+		plug, ok := instance.(core.ReportingPluginClient)
 		if !ok {
 			return nil, fmt.Errorf("expected ValidationServiceClient but got %T", instance)
 		}

--- a/pkg/loop/reportingplugins/loopp_service_test.go
+++ b/pkg/loop/reportingplugins/loopp_service_test.go
@@ -20,7 +20,7 @@ import (
 	reportingplugintest "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/reportingplugin/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 type HelperProcessCommand test.HelperProcessCommand
@@ -52,7 +52,7 @@ func TestLOOPPService(t *testing.T) {
 		looppSvc := reportingplugins.NewLOOPPService(logger.Test(t), loop.GRPCOpts{}, func() *exec.Cmd {
 			return NewHelperProcessCommand(ts.Plugin)
 		},
-			types.ReportingPluginServiceConfig{},
+			core.ReportingPluginServiceConfig{},
 			nettest.MockConn{},
 			pipelinetest.PipelineRunner,
 			telemetrytest.Telemetry,
@@ -95,7 +95,7 @@ func TestLOOPPService_recovery(t *testing.T) {
 		}
 		return h.New()
 	},
-		types.ReportingPluginServiceConfig{},
+		core.ReportingPluginServiceConfig{},
 		nettest.MockConn{},
 		pipelinetest.PipelineRunner,
 		telemetrytest.Telemetry,

--- a/pkg/loop/reportingplugins/ocr3/grpc.go
+++ b/pkg/loop/reportingplugins/ocr3/grpc.go
@@ -12,12 +12,13 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 const PluginServiceName = "ocr3-plugin-service"
 
 type ProviderServer[T types.PluginProvider] interface {
-	types.OCR3ReportingPluginServer[T]
+	core.OCR3ReportingPluginServer[T]
 	ConnToProvider(conn grpc.ClientConnInterface, broker net.Broker, brokerConfig loop.BrokerConfig) T
 }
 
@@ -34,50 +35,50 @@ type GRPCService[T types.PluginProvider] struct {
 type serverAdapter struct {
 	NewReportingPluginFactoryFn func(
 		context.Context,
-		types.ReportingPluginServiceConfig,
+		core.ReportingPluginServiceConfig,
 		grpc.ClientConnInterface,
-		types.PipelineRunnerService,
-		types.TelemetryService,
-		types.ErrorLog,
-		types.CapabilitiesRegistry,
-		types.KeyValueStore,
-	) (types.OCR3ReportingPluginFactory, error)
+		core.PipelineRunnerService,
+		core.TelemetryService,
+		core.ErrorLog,
+		core.CapabilitiesRegistry,
+		core.KeyValueStore,
+	) (core.OCR3ReportingPluginFactory, error)
 
 	ValidateConfigService
 }
 
 type ValidateConfigService interface {
-	NewValidationService(ctx context.Context) (types.ValidationService, error)
+	NewValidationService(ctx context.Context) (core.ValidationService, error)
 }
 
-func (s serverAdapter) NewValidationService(ctx context.Context) (types.ValidationService, error) {
+func (s serverAdapter) NewValidationService(ctx context.Context) (core.ValidationService, error) {
 	return s.ValidateConfigService.NewValidationService(ctx)
 }
 
 func (s serverAdapter) NewReportingPluginFactory(
 	ctx context.Context,
-	config types.ReportingPluginServiceConfig,
+	config core.ReportingPluginServiceConfig,
 	conn grpc.ClientConnInterface,
-	pr types.PipelineRunnerService,
-	ts types.TelemetryService,
-	errorLog types.ErrorLog,
-	capRegistry types.CapabilitiesRegistry,
-	kv types.KeyValueStore,
-) (types.OCR3ReportingPluginFactory, error) {
+	pr core.PipelineRunnerService,
+	ts core.TelemetryService,
+	errorLog core.ErrorLog,
+	capRegistry core.CapabilitiesRegistry,
+	kv core.KeyValueStore,
+) (core.OCR3ReportingPluginFactory, error) {
 	return s.NewReportingPluginFactoryFn(ctx, config, conn, pr, ts, errorLog, capRegistry, kv)
 }
 
 func (g *GRPCService[T]) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
 	newReportingPluginFactoryFn := func(
 		ctx context.Context,
-		cfg types.ReportingPluginServiceConfig,
+		cfg core.ReportingPluginServiceConfig,
 		conn grpc.ClientConnInterface,
-		pr types.PipelineRunnerService,
-		ts types.TelemetryService,
-		el types.ErrorLog,
-		capRegistry types.CapabilitiesRegistry,
-		kv types.KeyValueStore,
-	) (types.OCR3ReportingPluginFactory, error) {
+		pr core.PipelineRunnerService,
+		ts core.TelemetryService,
+		el core.ErrorLog,
+		capRegistry core.CapabilitiesRegistry,
+		kv core.KeyValueStore,
+	) (core.OCR3ReportingPluginFactory, error) {
 		provider := g.PluginServer.ConnToProvider(conn, broker, g.BrokerConfig)
 		tc := telemetry.NewTelemetryClient(ts)
 		return g.PluginServer.NewReportingPluginFactory(ctx, cfg, provider, pr, tc, el, capRegistry, kv)
@@ -96,7 +97,7 @@ func (g *GRPCService[T]) GRPCClient(_ context.Context, broker *plugin.GRPCBroker
 		g.pluginClient.Refresh(broker, conn)
 	}
 
-	return types.OCR3ReportingPluginClient(g.pluginClient), nil
+	return core.OCR3ReportingPluginClient(g.pluginClient), nil
 }
 
 func (g *GRPCService[T]) ClientConfig() *plugin.ClientConfig {

--- a/pkg/loop/reportingplugins/ocr3/grpc_test.go
+++ b/pkg/loop/reportingplugins/ocr3/grpc_test.go
@@ -17,6 +17,7 @@ import (
 	reportingplugintest "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/reportingplugin/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
@@ -28,16 +29,16 @@ func newStopCh(t *testing.T) <-chan struct{} {
 	return stopCh
 }
 
-func PluginGenericTest(t *testing.T, p types.OCR3ReportingPluginClient) {
+func PluginGenericTest(t *testing.T, p core.OCR3ReportingPluginClient) {
 	t.Run("PluginServer", func(t *testing.T) {
 		ctx := tests.Context(t)
 		factory, err := p.NewReportingPluginFactory(ctx,
-			types.ReportingPluginServiceConfig{},
+			core.ReportingPluginServiceConfig{},
 			nettest.MockConn{},
 			pipelinetest.PipelineRunner,
 			telemetrytest.Telemetry,
 			errorlogtest.ErrorLog,
-			types.CapabilitiesRegistry(nil),
+			core.CapabilitiesRegistry(nil),
 			keyvaluestoretest.KeyValueStore{})
 		require.NoError(t, err)
 

--- a/pkg/loop/reportingplugins/ocr3/loopp_service.go
+++ b/pkg/loop/reportingplugins/ocr3/loopp_service.go
@@ -14,26 +14,27 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 type LOOPPService struct {
-	goplugin.PluginService[*GRPCService[types.PluginProvider], types.OCR3ReportingPluginFactory]
+	goplugin.PluginService[*GRPCService[types.PluginProvider], core.OCR3ReportingPluginFactory]
 }
 
 func NewLOOPPService(
 	lggr logger.Logger,
 	grpcOpts loop.GRPCOpts,
 	cmd func() *exec.Cmd,
-	config types.ReportingPluginServiceConfig,
+	config core.ReportingPluginServiceConfig,
 	providerConn grpc.ClientConnInterface,
-	pipelineRunner types.PipelineRunnerService,
-	telemetryService types.TelemetryService,
-	errorLog types.ErrorLog,
-	capRegistry types.CapabilitiesRegistry,
-	keyValueStore types.KeyValueStore,
+	pipelineRunner core.PipelineRunnerService,
+	telemetryService core.TelemetryService,
+	errorLog core.ErrorLog,
+	capRegistry core.CapabilitiesRegistry,
+	keyValueStore core.KeyValueStore,
 ) *LOOPPService {
-	newService := func(ctx context.Context, instance any) (types.OCR3ReportingPluginFactory, error) {
-		plug, ok := instance.(types.OCR3ReportingPluginClient)
+	newService := func(ctx context.Context, instance any) (core.OCR3ReportingPluginFactory, error) {
+		plug, ok := instance.(core.OCR3ReportingPluginClient)
 		if !ok {
 			return nil, fmt.Errorf("expected OCR3ReportingPluginClient but got %T", instance)
 		}
@@ -60,8 +61,8 @@ func NewLOOPPServiceValidation(
 	grpcOpts loop.GRPCOpts,
 	cmd func() *exec.Cmd,
 ) *reportingplugins.LOOPPServiceValidation {
-	newService := func(ctx context.Context, instance any) (types.ValidationService, error) {
-		plug, ok := instance.(types.OCR3ReportingPluginClient)
+	newService := func(ctx context.Context, instance any) (core.ValidationService, error) {
+		plug, ok := instance.(core.OCR3ReportingPluginClient)
 		if !ok {
 			return nil, fmt.Errorf("expected ValidationServiceClient but got %T", instance)
 		}

--- a/pkg/loop/reportingplugins/ocr3/loopp_service_test.go
+++ b/pkg/loop/reportingplugins/ocr3/loopp_service_test.go
@@ -17,7 +17,7 @@ import (
 	nettest "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
 
 type HelperProcessCommand test.HelperProcessCommand
@@ -56,12 +56,12 @@ func TestLOOPPService(t *testing.T) {
 		looppSvc := NewLOOPPService(logger.Test(t), loop.GRPCOpts{}, func() *exec.Cmd {
 			return NewHelperProcessCommand(ts.Plugin)
 		},
-			types.ReportingPluginServiceConfig{},
+			core.ReportingPluginServiceConfig{},
 			nettest.MockConn{},
 			pipelinetest.PipelineRunner,
 			telemetrytest.Telemetry,
 			errorlogtest.ErrorLog,
-			types.CapabilitiesRegistry(nil),
+			core.CapabilitiesRegistry(nil),
 			keyvaluestoretest.KeyValueStore{})
 		hook := looppSvc.XXXTestHook()
 		servicetest.Run(t, looppSvc)
@@ -100,12 +100,12 @@ func TestLOOPPService_recovery(t *testing.T) {
 		}
 		return h.New()
 	},
-		types.ReportingPluginServiceConfig{},
+		core.ReportingPluginServiceConfig{},
 		nettest.MockConn{},
 		pipelinetest.PipelineRunner,
 		telemetrytest.Telemetry,
 		errorlogtest.ErrorLog,
-		types.CapabilitiesRegistry(nil),
+		core.CapabilitiesRegistry(nil),
 		keyvaluestoretest.KeyValueStore{})
 	servicetest.Run(t, looppSvc)
 

--- a/pkg/types/core/capabilities_registry.go
+++ b/pkg/types/core/capabilities_registry.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"context"

--- a/pkg/types/core/errorlog.go
+++ b/pkg/types/core/errorlog.go
@@ -1,0 +1,7 @@
+package core
+
+import "context"
+
+type ErrorLog interface {
+	SaveError(ctx context.Context, msg string) error
+}

--- a/pkg/types/core/keystore.go
+++ b/pkg/types/core/keystore.go
@@ -1,16 +1,10 @@
-package types
+package core
 
-import (
-	"context"
-)
+import "context"
 
 type Keystore interface {
 	Accounts(ctx context.Context) (accounts []string, err error)
 	// Sign returns data signed by account.
 	// nil data can be used as a no-op to check for account existence.
 	Sign(ctx context.Context, account string, data []byte) (signed []byte, err error)
-}
-
-type ErrorLog interface {
-	SaveError(ctx context.Context, msg string) error
 }

--- a/pkg/types/core/keyvalue_store.go
+++ b/pkg/types/core/keyvalue_store.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import "context"
 

--- a/pkg/types/core/median.go
+++ b/pkg/types/core/median.go
@@ -1,0 +1,14 @@
+package core
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
+
+type PluginMedian interface {
+	// NewMedianFactory returns a new ReportingPluginFactory. If provider implements GRPCClientConn, it can be forwarded efficiently via proxy.
+	NewMedianFactory(ctx context.Context, provider types.MedianProvider, dataSource, juelsPerFeeCoin median.DataSource, errorLog ErrorLog) (types.ReportingPluginFactory, error)
+}

--- a/pkg/types/core/pipeline_runner.go
+++ b/pkg/types/core/pipeline_runner.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"context"

--- a/pkg/types/core/relayerset.go
+++ b/pkg/types/core/relayerset.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
+
+type RelayerSet interface {
+	Get(ctx context.Context, relayID types.RelayID) (Relayer, error)
+
+	// List lists the relayers corresponding to `...types.RelayID`
+	// returning all relayers if len(...types.RelayID) == 0.
+	List(ctx context.Context, relayIDs ...types.RelayID) ([]Relayer, error)
+}
+
+type PluginArgs struct {
+	TransmitterID string
+	PluginConfig  []byte
+}
+
+type RelayArgs struct {
+	ContractID         string
+	RelayConfig        []byte
+	ProviderType       string
+	MercuryCredentials *types.MercuryCredentials
+}
+
+type Relayer interface {
+	services.Service
+	NewPluginProvider(rargs RelayArgs, pargs PluginArgs) (types.PluginProvider, error)
+}

--- a/pkg/types/core/reporting_plugin_service.go
+++ b/pkg/types/core/reporting_plugin_service.go
@@ -1,13 +1,13 @@
-package types
+package core
 
 import (
 	"context"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
-	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"google.golang.org/grpc"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 type ReportingPluginServiceConfig struct {
@@ -21,7 +21,7 @@ type ReportingPluginServiceConfig struct {
 // ReportingPluginClient is the client interface to a plugin running
 // as a generic job (job type = GenericPlugin) inside the core node.
 type ReportingPluginClient interface {
-	NewReportingPluginFactory(ctx context.Context, config ReportingPluginServiceConfig, grpcProvider grpc.ClientConnInterface, pipelineRunner PipelineRunnerService, telemetry TelemetryService, errorLog ErrorLog, keyValueStore KeyValueStore) (ReportingPluginFactory, error)
+	NewReportingPluginFactory(ctx context.Context, config ReportingPluginServiceConfig, grpcProvider grpc.ClientConnInterface, pipelineRunner PipelineRunnerService, telemetry TelemetryService, errorLog ErrorLog, keyValueStore KeyValueStore) (types.ReportingPluginFactory, error)
 	NewValidationService(ctx context.Context) (ValidationService, error)
 }
 
@@ -29,8 +29,8 @@ type ReportingPluginClient interface {
 // as a generic job (job type = GenericPlugin) inside the core node,
 // with the passthrough provider connection converted to the provider
 // expected by the plugin.
-type ReportingPluginServer[T PluginProvider] interface {
-	NewReportingPluginFactory(ctx context.Context, config ReportingPluginServiceConfig, provider T, pipelineRunner PipelineRunnerService, telemetry TelemetryClient, errorLog ErrorLog, keyValueStore KeyValueStore) (ReportingPluginFactory, error)
+type ReportingPluginServer[T types.PluginProvider] interface {
+	NewReportingPluginFactory(ctx context.Context, config ReportingPluginServiceConfig, provider T, pipelineRunner PipelineRunnerService, telemetry TelemetryClient, errorLog ErrorLog, keyValueStore KeyValueStore) (types.ReportingPluginFactory, error)
 	NewValidationService(ctx context.Context) (ValidationService, error)
 }
 
@@ -39,29 +39,12 @@ type OCR3ReportingPluginClient interface {
 	NewValidationService(ctx context.Context) (ValidationService, error)
 }
 
-type OCR3ReportingPluginServer[T PluginProvider] interface {
+type OCR3ReportingPluginServer[T types.PluginProvider] interface {
 	NewReportingPluginFactory(ctx context.Context, config ReportingPluginServiceConfig, provider T, pipelineRunner PipelineRunnerService, telemetry TelemetryClient, errorLog ErrorLog, capRegistry CapabilitiesRegistry, keyValueStore KeyValueStore) (OCR3ReportingPluginFactory, error)
 	NewValidationService(ctx context.Context) (ValidationService, error)
 }
 
-type ReportingPluginFactory interface {
-	Service
-	libocr.ReportingPluginFactory
-}
-
 type OCR3ReportingPluginFactory interface {
-	Service
-	ocr3types.ReportingPluginFactory[[]byte]
-}
-
-type ValidationService interface {
 	services.Service
-	ValidateConfig(ctx context.Context, config map[string]interface{}) error
-}
-
-type ValidationServiceClient interface {
-	ValidateConfig(ctx context.Context, config map[string]interface{}) error
-}
-type ValidationServiceServer interface {
-	ValidateConfig(ctx context.Context, config map[string]interface{}) error
+	ocr3types.ReportingPluginFactory[[]byte]
 }

--- a/pkg/types/core/telemetry.go
+++ b/pkg/types/core/telemetry.go
@@ -1,4 +1,4 @@
-package types
+package core
 
 import (
 	"context"

--- a/pkg/types/core/validation.go
+++ b/pkg/types/core/validation.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+)
+
+type ValidationService interface {
+	services.Service
+	ValidateConfig(ctx context.Context, config map[string]interface{}) error
+}
+
+type ValidationServiceClient interface {
+	ValidateConfig(ctx context.Context, config map[string]interface{}) error
+}
+type ValidationServiceServer interface {
+	ValidateConfig(ctx context.Context, config map[string]interface{}) error
+}

--- a/pkg/types/provider_median.go
+++ b/pkg/types/provider_median.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"context"
-
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 )
 
@@ -12,9 +10,4 @@ type MedianProvider interface {
 	ReportCodec() median.ReportCodec
 	MedianContract() median.MedianContract
 	OnchainConfigCodec() median.OnchainConfigCodec
-}
-
-type PluginMedian interface {
-	// NewMedianFactory returns a new ReportingPluginFactory. If provider implements GRPCClientConn, it can be forwarded efficiently via proxy.
-	NewMedianFactory(ctx context.Context, provider MedianProvider, dataSource, juelsPerFeeCoin median.DataSource, errorLog ErrorLog) (ReportingPluginFactory, error)
 }

--- a/pkg/types/relayer_test.go
+++ b/pkg/types/relayer_test.go
@@ -1,0 +1,54 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdentifier_UnmarshalString(t *testing.T) {
+	type fields struct {
+		Network string
+		ChainID string
+	}
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name    string
+		want    fields
+		args    args
+		wantErr bool
+	}{
+		{name: "evm",
+			args:    args{s: "evm.1"},
+			wantErr: false,
+			want:    fields{Network: NetworkEVM, ChainID: "1"},
+		},
+		{name: "bad network",
+			args:    args{s: "notANetwork.1"},
+			wantErr: true,
+		},
+		{name: "bad pattern",
+			args:    args{s: "evm_1"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &RelayID{}
+			err := i.UnmarshalString(tt.args.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Identifier.UnmarshalString() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.want.Network, i.Network)
+			assert.Equal(t, tt.want.ChainID, i.ChainID)
+		})
+	}
+}
+
+func TestNewID(t *testing.T) {
+	rid := NewRelayID(NetworkEVM, "chain id")
+	assert.Equal(t, NetworkEVM, rid.Network)
+	assert.Equal(t, "chain id", rid.ChainID)
+}

--- a/pkg/types/reporting_plugin_factory.go
+++ b/pkg/types/reporting_plugin_factory.go
@@ -1,0 +1,10 @@
+package types
+
+import (
+	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+type ReportingPluginFactory interface {
+	Service
+	libocr.ReportingPluginFactory
+}


### PR DESCRIPTION
* Move the core API services (keystore, capabilities_registry, kv store, telemetry, etc) into core.
* Also move the API "integration path" methods relating to integration reporting plugins into core.
* Add a RelayerSet API. This duplicates some structs (PluginArgs, RelayArgs), but omits job-related fields.

NOTE: Working on preparing the corresponding PRs to core/chainlink-solana, and will hold off on merging this until those are ready. I'd still appreciate some early feedback at this stage though!