### PR TITLE
golangci-lint: enable depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - sqlclosecheck
     - noctx
     - whitespace
+    - depguard
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,8 +88,9 @@ linters-settings:
         deny:
           - pkg: "cosmossdk.io/errors"
             desc: Use the standard library instead
-          - pkg: "github.com/ethereum/go-ethereum"
-            desc: This is a chain-agnostic repo
+# TODO re-enable geth exclusion https://smartcontract-it.atlassian.net/browse/BCF-3197
+#          - pkg: "github.com/ethereum/go-ethereum"
+#            desc: This is a chain-agnostic repo
           - pkg: "github.com/go-gorm/gorm"
             desc: Use github.com/jmoiron/sqlx directly instead
           - pkg: "github.com/gofrs/uuid"

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9
 	github.com/pelletier/go-toml/v2 v2.1.1
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/riferrei/srclient v0.5.4
 	github.com/shopspring/decimal v1.3.1
@@ -65,6 +64,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect

--- a/pkg/assets/link.go
+++ b/pkg/assets/link.go
@@ -2,14 +2,14 @@ package assets
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
-
-	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
 )
 
 var ErrNoQuotesForCurrency = errors.New("cannot unmarshal json.Number into currency")
@@ -128,12 +128,12 @@ func (l *Link) UnmarshalText(text []byte) error {
 		s = strings.TrimSuffix(s, " ")
 		d, err := decimal.NewFromString(s)
 		if err != nil {
-			return errors.Wrapf(err, "assets: cannot unmarshal %q into a *assets.Link", text)
+			return fmt.Errorf("assets: cannot unmarshal %q into a *assets.Link: %w", text, err)
 		}
 		d = d.Mul(decimal.New(1, 18))
 		if !d.IsInteger() {
 			err := errors.New("maximum precision is juels")
-			return errors.Wrapf(err, "assets: cannot unmarshal %q into a *assets.Link", text)
+			return fmt.Errorf("assets: cannot unmarshal %q into a *assets.Link: %w", text, err)
 		}
 		l.Set((*Link)(d.Rat().Num()))
 		return nil
@@ -143,7 +143,7 @@ func (l *Link) UnmarshalText(text []byte) error {
 		s = strings.TrimSuffix(s, " ")
 	}
 	if _, ok := l.SetString(s, 10); !ok {
-		return errors.Errorf("assets: cannot unmarshal %q into a *assets.Link", text)
+		return fmt.Errorf("assets: cannot unmarshal %q into a *assets.Link", text)
 	}
 	return nil
 }

--- a/pkg/config/duration.go
+++ b/pkg/config/duration.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Duration is a non-negative time duration.
@@ -88,7 +86,7 @@ func (d *Duration) Scan(v interface{}) (err error) {
 		*d, err = NewDuration(time.Duration(tv))
 		return err
 	default:
-		return errors.Errorf(`don't know how to parse "%s" of type %T as a `+
+		return fmt.Errorf(`don't know how to parse "%s" of type %T as a `+
 			`models.Duration`, tv, tv)
 	}
 }

--- a/pkg/fee/models.go
+++ b/pkg/fee/models.go
@@ -1,9 +1,9 @@
 package fee
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
-
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/chains/label"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -47,15 +47,15 @@ func CalculateBumpedFee(
 	bumpedFeePrice = maxFee(lggr, currentfeePrice, bumpedFeePrice, maxFeePrice, "fee price", toChainUnit)
 
 	if bumpedFeePrice.Cmp(maxFeePrice) > 0 {
-		return maxFeePrice, errors.Wrapf(ErrBumpFeeExceedsLimit, "bumped fee price of %s would exceed configured max fee price of %s (original price was %s). %s",
-			toChainUnit(bumpedFeePrice), toChainUnit(maxFeePrice), toChainUnit(originalfeePrice), label.NodeConnectivityProblemWarning)
+		return maxFeePrice, fmt.Errorf("bumped fee price of %s would exceed configured max fee price of %s (original price was %s). %s: %w",
+			toChainUnit(bumpedFeePrice), toChainUnit(maxFeePrice), toChainUnit(originalfeePrice), label.NodeConnectivityProblemWarning, ErrBumpFeeExceedsLimit)
 	} else if bumpedFeePrice.Cmp(originalfeePrice) == 0 {
 		// NOTE: This really shouldn't happen since we enforce minimums for
 		// FeeEstimator.BumpPercent and FeeEstimator.BumpMin in the config validation,
 		// but it's here anyway for a "belts and braces" approach
-		return bumpedFeePrice, errors.Wrapf(ErrBump, "bumped fee price of %s is equal to original fee price of %s."+
+		return bumpedFeePrice, fmt.Errorf("bumped fee price of %s is equal to original fee price of %s."+
 			" ACTION REQUIRED: This is a configuration error, you must increase either "+
-			"FeeEstimator.BumpPercent or FeeEstimator.BumpMin", toChainUnit(bumpedFeePrice), toChainUnit(bumpedFeePrice))
+			"FeeEstimator.BumpPercent or FeeEstimator.BumpMin: %w", toChainUnit(bumpedFeePrice), toChainUnit(bumpedFeePrice), ErrBump)
 	}
 	return bumpedFeePrice, nil
 }

--- a/pkg/fee/utils.go
+++ b/pkg/fee/utils.go
@@ -1,10 +1,10 @@
 package fee
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 
-	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
 )
 
@@ -12,7 +12,7 @@ func ApplyMultiplier(feeLimit uint32, multiplier float32) (uint32, error) {
 	result := decimal.NewFromBigInt(big.NewInt(0).SetUint64(uint64(feeLimit)), 0).Mul(decimal.NewFromFloat32(multiplier)).IntPart()
 
 	if result > math.MaxUint32 {
-		return 0, errors.Errorf("integer overflow when applying multiplier of %f to fee limit of %d", multiplier, feeLimit)
+		return 0, fmt.Errorf("integer overflow when applying multiplier of %f to fee limit of %d", multiplier, feeLimit)
 	}
 	return uint32(result), nil
 }

--- a/pkg/services/state.go
+++ b/pkg/services/state.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-
-	pkgerrors "github.com/pkg/errors"
 )
 
 // defaultErrorBufferCap is the default cap on the errors an error buffer can store at any time
@@ -80,7 +78,7 @@ func (once *StateMachine) StartOnce(name string, fn func() error) error {
 	success := once.state.CompareAndSwap(int32(stateUnstarted), int32(stateStarting))
 
 	if !success {
-		return pkgerrors.Errorf("%v has already been started once; state=%v", name, state(once.state.Load()))
+		return fmt.Errorf("%v has already been started once; state=%v", name, state(once.state.Load()))
 	}
 
 	once.Lock()
@@ -119,11 +117,11 @@ func (once *StateMachine) StopOnce(name string, fn func() error) error {
 		s := once.loadState()
 		switch s {
 		case stateStopped:
-			return pkgerrors.Wrapf(ErrAlreadyStopped, "%s has already been stopped", name)
+			return fmt.Errorf("%s has already been stopped: %w", name, ErrAlreadyStopped)
 		case stateUnstarted:
-			return pkgerrors.Wrapf(ErrCannotStopUnstarted, "%s has not been started", name)
+			return fmt.Errorf("%s has not been started: %w", name, ErrCannotStopUnstarted)
 		default:
-			return pkgerrors.Errorf("%v cannot be stopped from this state; state=%v", name, s)
+			return fmt.Errorf("%v cannot be stopped from this state; state=%v", name, s)
 		}
 	}
 

--- a/pkg/types/ccip/offramp.go
+++ b/pkg/types/ccip/offramp.go
@@ -2,11 +2,10 @@ package ccip
 
 import (
 	"context"
+	"errors"
 	"io"
 	"math/big"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 )

--- a/pkg/utils/jsonserializable/json_serializable.go
+++ b/pkg/utils/jsonserializable/json_serializable.go
@@ -5,12 +5,12 @@ import (
 	"database/sql/driver"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"reflect"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
-	pkgerrors "github.com/pkg/errors"
 )
 
 type JSONSerializable struct {
@@ -94,7 +94,7 @@ func (js *JSONSerializable) Scan(value interface{}) error {
 	}
 	bytes, ok := value.([]byte)
 	if !ok {
-		return pkgerrors.Errorf("JSONSerializable#Scan received a value of type %T", value)
+		return fmt.Errorf("JSONSerializable#Scan received a value of type %T", value)
 	}
 	if js == nil {
 		*js = JSONSerializable{}
@@ -199,7 +199,7 @@ func getJSONNumberValue(value json.Number) (interface{}, error) {
 	} else {
 		f, err := value.Float64()
 		if err != nil {
-			return nil, pkgerrors.Errorf("failed to parse json.Value: %v", err)
+			return nil, fmt.Errorf("failed to parse json.Value: %w", err)
 		}
 		result = f
 	}

--- a/pkg/utils/jsonserializable/json_serializable_test.go
+++ b/pkg/utils/jsonserializable/json_serializable_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -66,7 +65,7 @@ func TestMarshalJSONSerializable_replaceBytesWithHex(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			bytes, err := test.input.MarshalJSON()
 			assert.Equal(t, test.expected, string(bytes))
-			assert.Equal(t, test.err, errors.Cause(err))
+			assert.ErrorIs(t, test.err, err)
 		})
 	}
 }


### PR DESCRIPTION
I forgot to explicitly enable `depguard` when I added the config in #423.