### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/workflows/build_external.yml
+++ b/.github/workflows/build_external.yml
@@ -32,8 +32,9 @@ jobs:
           fi
       - name: Collect Metrics
         id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@v2.2.0
+        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
         with:
+          id: build-chainlink
           basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
@@ -77,8 +78,9 @@ jobs:
           fi
       - name: Collect Metrics
         id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@v2.2.0
+        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
         with:
+          id: solana-build-relay
           basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
@@ -123,8 +125,9 @@ jobs:
           fi
       - name: Collect Metrics
         id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@v2.2.0
+        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
         with:
+          id: starknet-build-relay
           basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
@@ -162,8 +165,9 @@ jobs:
   #   steps:
   #     - name: Collect Metrics
   #       id: collect-gha-metrics
-  #       uses: smartcontractkit/push-gha-metrics-action@v2.2.0
+  #       uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
   #       with:
+  #         id: terra-build-relay
   #         basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
   #         hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
   #         org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}

--- a/.github/workflows/build_external.yml
+++ b/.github/workflows/build_external.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build the image
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@912bed7e07a1df4d06ea53a031e9773bb65dc7bd # v2.3.0
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
         env:
           GH_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/build_external.yml
+++ b/.github/workflows/build_external.yml
@@ -90,7 +90,7 @@ jobs:
           repository: smartcontractkit/chainlink-solana
           ref: ${{ env.CUSTOM_SOLANA_REF }}
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: "go.mod"
       - name: Replace chainlink-common deps
@@ -136,7 +136,7 @@ jobs:
           repository: smartcontractkit/chainlink-starknet
           ref: ${{ env.CUSTOM_STARKNET_REF }}
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: ./relayer/go.mod
       - name: Replace chainlink-common deps
@@ -174,7 +174,7 @@ jobs:
   #       with:
   #         repository: smartcontractkit/chainlink-terra
   #     - name: Setup Go
-  #       uses: actions/setup-go@v3
+  #       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
   #       with:
   #         go-version-file: "go.mod"
   #     - name: Replace chainlink-common deps

--- a/.github/workflows/build_external.yml
+++ b/.github/workflows/build_external.yml
@@ -40,7 +40,7 @@ jobs:
           this-job-name: Build Chainlink Image
         continue-on-error: true
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build the image
@@ -85,7 +85,7 @@ jobs:
           this-job-name: Solana Build Relay
         continue-on-error: true
       - name: Checkout the solana repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: smartcontractkit/chainlink-solana
           ref: ${{ env.CUSTOM_SOLANA_REF }}
@@ -131,7 +131,7 @@ jobs:
           this-job-name: Starknet Build Relay
         continue-on-error: true
       - name: Checkout the starknet repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: smartcontractkit/chainlink-starknet
           ref: ${{ env.CUSTOM_STARKNET_REF }}
@@ -170,7 +170,7 @@ jobs:
   #         this-job-name: Terra Build Relay
   #       continue-on-error: true
   #     - name: Checkout the terra repo
-  #       uses: actions/checkout@v3
+  #       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
   #       with:
   #         repository: smartcontractkit/chainlink-terra
   #     - name: Setup Go

--- a/.github/workflows/build_external.yml
+++ b/.github/workflows/build_external.yml
@@ -145,7 +145,7 @@ jobs:
             go get github.com/smartcontractkit/chainlink-common@${{ github.event.pull_request.head.sha }}
             go mod tidy
       - name: Install Nix
-        uses: cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590 # v17
+        uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Build

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: '1.21'
       

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Upload golangci-lint report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: golangci-lint-report
           path: |

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: "go.mod"
 
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: "go.mod"
       - name: Ensure "make gomodtidy" has been run

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -35,14 +35,14 @@ jobs:
 
       - name: Upload Fuzz Tests Failing Inputs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: failing-fuzz-inputs
           path: "**/testdata/fuzz/**"
 
       - name: Upload Go test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: go-test-results
           path: ./pkg_coverage.out

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
       - name: Wait for workflows
-        uses: smartcontractkit/chainlink-github-actions/utils/wait-for-workflows@main
+        uses: smartcontractkit/chainlink-github-actions/utils/wait-for-workflows@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
         with:
           max-timeout: "900"
           polling-interval: "30"

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Download Golangci-lint report
         if: always()
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
           workflow: golangci_lint.yml
           workflow_conclusion: ""
@@ -47,7 +47,7 @@ jobs:
 
       - name: Download Go PKG test reports
         if: always()
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
           workflow: pkg.yml
           workflow_conclusion: ""

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -65,7 +65,7 @@ jobs:
           
       - name: SonarQube Scan
         if: always()
-        uses: sonarsource/sonarqube-scan-action@v2.0.1
+        uses: sonarsource/sonarqube-scan-action@53c3e3207fe4b8d52e2f1ac9d6eb1d2506f626c0 # v2.0.2
         with:
           args: >
             -Dsonar.go.coverage.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_coverage_report_paths }}

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -9,7 +9,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
@@ -31,7 +31,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
 


### PR DESCRIPTION
## What

Updating Github Action references in all workflows.

## Why

Github Actions node16 deprecation. See [blog post (github.blog)](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
> Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). As a result we have started the deprecation process of Node16 for GitHub Actions. We plan to migrate all actions to run on Node20 by Spring 2024.
> Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 13th of May.

## Notes

RE-2531


Outdated Dependency Paths:

```
Workflow:Build External Repositories ---> Job:build-chainlink ---> actions/checkout@v3 ---> node16
Workflow:Build External Repositories ---> Job:build-chainlink ---> smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@912bed7e07a1df4d06ea53a031e9773bb65dc7bd ---> actions/setup-go@v3 ---> node16
Workflow:Build External Repositories ---> Job:build-chainlink ---> smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@912bed7e07a1df4d06ea53a031e9773bb65dc7bd ---> docker/setup-buildx-action@v2 ---> node16
Workflow:Build External Repositories ---> Job:build-chainlink ---> smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@912bed7e07a1df4d06ea53a031e9773bb65dc7bd ---> docker/build-push-action@v3 ---> node16
Workflow:Build External Repositories ---> Job:starknet-build-relay ---> cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590 ---> node12
Workflow:Golangci-lint ---> Job:golangci-lint ---> actions/setup-go@v4 ---> node16
Workflow:Golangci-lint ---> Job:golangci-lint ---> actions/upload-artifact@v3 ---> node16
Workflow:SonarQube Scan ---> Job:sonarqube ---> dawidd6/action-download-artifact@v2.27.0 ---> node16
```