### PR TITLE
fix keyvalue store grpc server implementation

### DIFF
--- a/pkg/loop/internal/core/services/keyvalue/store.go
+++ b/pkg/loop/internal/core/services/keyvalue/store.go
@@ -50,14 +50,14 @@ func NewServer(impl core.KeyValueStore) *Server {
 	return &Server{impl: impl}
 }
 
-func (s Server) Store(ctx context.Context, req *pb.StoreKeyValueRequest) (*emptypb.Empty, error) {
+func (s Server) StoreKeyValue(ctx context.Context, req *pb.StoreKeyValueRequest) (*emptypb.Empty, error) {
 	if err := s.impl.Store(ctx, req.Key, req.Value); err != nil {
 		return nil, fmt.Errorf("failed to store bytes for key: %s: %w", req.Key, err)
 	}
 	return &emptypb.Empty{}, nil
 }
 
-func (s Server) Get(ctx context.Context, req *pb.GetValueForKeyRequest) (*pb.GetValueForKeyResponse, error) {
+func (s Server) GetValueForKey(ctx context.Context, req *pb.GetValueForKeyRequest) (*pb.GetValueForKeyResponse, error) {
 	bytes, err := s.impl.Get(ctx, req.Key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get bytes for key: %s: %w ", req.Key, err)

--- a/pkg/loop/internal/core/services/keyvalue/store_test.go
+++ b/pkg/loop/internal/core/services/keyvalue/store_test.go
@@ -29,9 +29,9 @@ func Test_KeyValueStoreServer(t *testing.T) {
 	// Setup
 	server := Server{impl: &testKeyValueStore{store: make(map[string][]byte)}}
 
-	_, err := server.Store(context.Background(), &pb.StoreKeyValueRequest{Key: "key", Value: []byte(`{"A":"a","B":1}`)})
+	_, err := server.StoreKeyValue(context.Background(), &pb.StoreKeyValueRequest{Key: "key", Value: []byte(`{"A":"a","B":1}`)})
 	assert.NoError(t, err)
-	resp, err := server.Get(context.Background(), &pb.GetValueForKeyRequest{Key: "key"})
+	resp, err := server.GetValueForKey(context.Background(), &pb.GetValueForKeyRequest{Key: "key"})
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(`{"A":"a","B":1}`), resp.Value)
 }


### PR DESCRIPTION
BCF-3220 the implementation of the grpc server was not overriding the default method implementations