### PR TITLE
golangci-lint autofix

### DIFF
--- a/pkg/capabilities/triggers/mercury_trigger_test.go
+++ b/pkg/capabilities/triggers/mercury_trigger_test.go
@@ -30,7 +30,6 @@ func registerTrigger(
 	<-chan capabilities.CapabilityResponse,
 	capabilities.CapabilityRequest,
 ) {
-
 	var unregisterRequest capabilities.CapabilityRequest
 
 	inputs, err := values.NewMap(map[string]interface{}{

--- a/pkg/capabilities/triggers/on_demand_trigger_test.go
+++ b/pkg/capabilities/triggers/on_demand_trigger_test.go
@@ -78,7 +78,7 @@ func TestOnDemandTrigger_GenerateSchema(t *testing.T) {
 	require.NotNil(t, schema)
 	require.NoError(t, err)
 
-	var shouldUpdate = true 
+	var shouldUpdate = true
 	if shouldUpdate {
 		err = os.WriteFile("./testdata/fixtures/ondemand/schema.json", []byte(schema), 0600)
 		require.NoError(t, err)

--- a/pkg/codec/encodings/binary/int_gen_test.go
+++ b/pkg/codec/encodings/binary/int_gen_test.go
@@ -666,7 +666,6 @@ func TestUint64(t *testing.T) {
 }
 
 func TestBuilderInt(t *testing.T) {
-
 	t.Run("Wraps encoding and decoding for 8 bytes", func(t *testing.T) {
 		codec, err := bi.Int(1)
 		require.NoError(t, err)
@@ -823,7 +822,6 @@ func TestBuilderInt(t *testing.T) {
 }
 
 func TestGetUintTypeCodecByByteSize(t *testing.T) {
-
 	t.Run("Wraps encoding and decoding for 8 bytes", func(t *testing.T) {
 		codec, err := bi.Uint(1)
 		require.NoError(t, err)

--- a/pkg/codec/utils_test.go
+++ b/pkg/codec/utils_test.go
@@ -239,7 +239,7 @@ func TestEpochToTimeHook(t *testing.T) {
 		assert.Equal(t, "foo", actual)
 	})
 
-	t.Run("pointers are maintained in non-converstion scenarios", func(t *testing.T) {
+	t.Run("pointers are maintained in non-conversion scenarios", func(t *testing.T) {
 		t.Run("*time.Time to *time.Time", func(t *testing.T) {
 			tp := reflect.PointerTo(reflect.TypeOf(testTime))
 			output, err := EpochToTimeHook(tp, tp, &testTime)

--- a/pkg/loop/internal/core/services/capability/capabilities_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_test.go
@@ -163,7 +163,6 @@ func newCapabilityPlugin(t *testing.T, capability capabilities.BaseCapability) (
 }
 
 func Test_Capabilities(t *testing.T) {
-
 	testContext := tests.Context(t)
 
 	t.Run("fetching a trigger capability and sending responses propagate to client", func(t *testing.T) {

--- a/pkg/loop/internal/relayerset/inprocessprovider/grpc_provider_server_test.go
+++ b/pkg/loop/internal/relayerset/inprocessprovider/grpc_provider_server_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
+	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/adapters/relay"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
-	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
 
 func TestProviderServer(t *testing.T) {

--- a/pkg/loop/internal/relayerset/inprocessprovider/standalone_provider_test.go
+++ b/pkg/loop/internal/relayerset/inprocessprovider/standalone_provider_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	ocr2test "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/ocr2/test"
+	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	ocr2test "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/ocr2/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayerset/inprocessprovider"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 )
 
 func TestRegisterStandAloneProvider_Median(t *testing.T) {

--- a/pkg/monitoring/manager_test.go
+++ b/pkg/monitoring/manager_test.go
@@ -168,5 +168,4 @@ func TestManager(t *testing.T) {
 		closeWG.Wait() // wait for managed funcs
 		subs.Wait()    // wait for manager
 	})
-
 }

--- a/pkg/values/bool_test.go
+++ b/pkg/values/bool_test.go
@@ -36,5 +36,4 @@ func Test_BoolUnwrapTo(t *testing.T) {
 	err = fa.UnwrapTo(&varAny)
 	require.NoError(t, err)
 	assert.False(t, varAny.(bool))
-
 }


### PR DESCRIPTION
I ran `make lint-workspace` after adding the `--fix` flag.