### PR TITLE
QueryKey Should Return Empty Set

### DIFF
--- a/pkg/loop/internal/relayer/pluginprovider/chainreader/chain_reader_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/chainreader/chain_reader_test.go
@@ -289,7 +289,7 @@ func (f *fakeChainReader) QueryKey(_ context.Context, _ string, filter query.Key
 		f.lock.Lock()
 		defer f.lock.Unlock()
 		if len(f.triggers) == 0 {
-			return nil, types.ErrNotFound
+			return []types.Sequence{}, nil
 		}
 
 		var sequences []types.Sequence

--- a/pkg/types/interfacetests/chain_reader_interface_tests.go
+++ b/pkg/types/interfacetests/chain_reader_interface_tests.go
@@ -216,11 +216,13 @@ func RunQueryKeyInterfaceTests(t *testing.T, tester ChainReaderInterfaceTester) 
 			test: func(t *testing.T) {
 				ctx := tests.Context(t)
 				cr := tester.GetChainReader(t)
+
 				require.NoError(t, cr.Bind(ctx, tester.GetBindings(t)))
 
-				sequenceDataType := &TestStruct{}
-				_, err := cr.QueryKey(ctx, AnyContractName, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, &sequenceDataType)
-				assert.True(t, errors.Is(err, types.ErrNotFound))
+				logs, err := cr.QueryKey(ctx, AnyContractName, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, &TestStruct{})
+
+				require.NoError(t, err)
+				assert.Len(t, logs, 0)
 			},
 		},
 		{


### PR DESCRIPTION
On querying an empty set of values, the return should also be an empty set of values with no error. This replicates the existing behavior of EVM LogPoller.