### PR TITLE
Flatten signatures in FeedReport

### DIFF
--- a/pkg/capabilities/datastreams/types.go
+++ b/pkg/capabilities/datastreams/types.go
@@ -56,9 +56,7 @@ func FeedIDFromBytes(b [FeedIDBytesLen]byte) FeedID {
 type FeedReport struct {
 	FeedID     string
 	FullReport []byte
-	Rs         [][]byte
-	Ss         [][]byte
-	Vs         []byte
+	Signatures [][]byte
 
 	// Fields below are derived from FullReport
 	// NOTE: BenchmarkPrice is a byte representation of big.Int. We can't use big.Int

--- a/pkg/capabilities/triggers/mercury_remote_aggregator_test.go
+++ b/pkg/capabilities/triggers/mercury_remote_aggregator_test.go
@@ -35,45 +35,35 @@ func (c testMercuryCodec) Wrap(reports []datastreams.FeedReport) (values.Value, 
 
 func TestMercuryRemoteAggregator(t *testing.T) {
 	agg := NewMercuryRemoteAggregator(testMercuryCodec{}, logger.Nop())
-	rs := [][]byte{{1, 2, 3}}
-	ss := [][]byte{{4, 5, 6}}
-	vs := []byte{7, 8, 9}
+	signatures := [][]byte{{1, 2, 3}}
 
 	feed1Old := datastreams.FeedReport{
 		FeedID:               feedOne,
 		BenchmarkPrice:       big.NewInt(100).Bytes(),
 		ObservationTimestamp: 100,
 		FullReport:           []byte(rawReport1),
-		Rs:                   rs,
-		Ss:                   ss,
-		Vs:                   vs,
+		Signatures:           signatures,
 	}
 	feed1New := datastreams.FeedReport{
 		FeedID:               feedOne,
 		BenchmarkPrice:       big.NewInt(200).Bytes(),
 		ObservationTimestamp: 200,
 		FullReport:           []byte(rawReport1),
-		Rs:                   rs,
-		Ss:                   ss,
-		Vs:                   vs,
+		Signatures:           signatures,
 	}
 	feed2Old := datastreams.FeedReport{
 		FeedID:               feedTwo,
 		BenchmarkPrice:       big.NewInt(300).Bytes(),
 		ObservationTimestamp: 300,
 		FullReport:           []byte(rawReport2),
-		Rs:                   rs,
-		Ss:                   ss,
-		Vs:                   vs,
+		Signatures:           signatures,
 	}
 	feed2New := datastreams.FeedReport{
 		FeedID:               feedTwo,
 		BenchmarkPrice:       big.NewInt(400).Bytes(),
 		ObservationTimestamp: 400,
 		FullReport:           []byte(rawReport2),
-		Rs:                   rs,
-		Ss:                   ss,
-		Vs:                   vs,
+		Signatures:           signatures,
 	}
 
 	node1Resp, err := wrapReports([]datastreams.FeedReport{feed1Old, feed2New}, eventId, 400)

--- a/pkg/capabilities/triggers/mercury_trigger_test.go
+++ b/pkg/capabilities/triggers/mercury_trigger_test.go
@@ -92,8 +92,7 @@ func TestMercuryTrigger(t *testing.T) {
 			FullReport:           []byte("0x1234"),
 			BenchmarkPrice:       big.NewInt(2).Bytes(),
 			ObservationTimestamp: 3,
-			Rs:                   [][]byte{},
-			Ss:                   [][]byte{},
+			Signatures:           [][]byte{},
 		},
 	}
 	err = ts.ProcessReport(mfr)
@@ -148,32 +147,28 @@ func TestMultipleMercuryTriggers(t *testing.T) {
 			FullReport:           []byte("0x1234"),
 			BenchmarkPrice:       big.NewInt(20).Bytes(),
 			ObservationTimestamp: 5,
-			Rs:                   [][]byte{},
-			Ss:                   [][]byte{},
+			Signatures:           [][]byte{},
 		},
 		{
 			FeedID:               feedThree,
 			FullReport:           []byte("0x1234"),
 			BenchmarkPrice:       big.NewInt(25).Bytes(),
 			ObservationTimestamp: 8,
-			Rs:                   [][]byte{},
-			Ss:                   [][]byte{},
+			Signatures:           [][]byte{},
 		},
 		{
 			FeedID:               feedTwo,
 			FullReport:           []byte("0x1234"),
 			BenchmarkPrice:       big.NewInt(30).Bytes(),
 			ObservationTimestamp: 10,
-			Rs:                   [][]byte{},
-			Ss:                   [][]byte{},
+			Signatures:           [][]byte{},
 		},
 		{
 			FeedID:               feedFour,
 			FullReport:           []byte("0x1234"),
 			BenchmarkPrice:       big.NewInt(40).Bytes(),
 			ObservationTimestamp: 15,
-			Rs:                   [][]byte{},
-			Ss:                   [][]byte{},
+			Signatures:           [][]byte{},
 		},
 	}
 


### PR DESCRIPTION
Instead of sending signatures as 3 arrays, we can flatten (r,s,v) into a single byte array of 65 bytes at the source.