### PR TITLE
[KS-196] Validate Signatures in Mercury Aggregator

### DIFF
--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -80,8 +80,9 @@ type TriggerEvent struct {
 	TriggerType string
 	ID          string
 	Timestamp   string
-	// Trigger-specific payload
-	Payload values.Value
+	// Trigger-specific payload+metadata
+	Metadata values.Value
+	Payload  values.Value
 }
 
 type RegisterToWorkflowRequest struct {

--- a/pkg/capabilities/consensus/ocr3/reporting_plugin.go
+++ b/pkg/capabilities/consensus/ocr3/reporting_plugin.go
@@ -188,7 +188,7 @@ func (r *reportingPlugin) Outcome(outctx ocr3types.OutcomeContext, query types.Q
 			continue
 		}
 
-		outcome, err2 := agg.Aggregate(workflowOutcome, obs)
+		outcome, err2 := agg.Aggregate(workflowOutcome, obs, r.config.F)
 		if err2 != nil {
 			r.lggr.Errorw("error aggregating outcome", "error", err, "workflowID", weid.WorkflowId)
 			return nil, err

--- a/pkg/capabilities/consensus/ocr3/reporting_plugin_test.go
+++ b/pkg/capabilities/consensus/ocr3/reporting_plugin_test.go
@@ -141,7 +141,7 @@ type aggregator struct {
 	outcome *pbtypes.AggregationOutcome
 }
 
-func (a *aggregator) Aggregate(pout *pbtypes.AggregationOutcome, observations map[commontypes.OracleID][]values.Value) (*pbtypes.AggregationOutcome, error) {
+func (a *aggregator) Aggregate(pout *pbtypes.AggregationOutcome, observations map[commontypes.OracleID][]values.Value, _ int) (*pbtypes.AggregationOutcome, error) {
 	a.gotObs = observations
 	nm, err := values.NewMap(
 		map[string]any{

--- a/pkg/capabilities/consensus/ocr3/types/aggregator.go
+++ b/pkg/capabilities/consensus/ocr3/types/aggregator.go
@@ -15,7 +15,7 @@ const (
 type Aggregator interface {
 	// Called by the Outcome() phase of OCR reporting.
 	// The inner array of observations corresponds to elements listed in "inputs.observations" section.
-	Aggregate(previousOutcome *AggregationOutcome, observations map[ocrcommon.OracleID][]values.Value) (*AggregationOutcome, error)
+	Aggregate(previousOutcome *AggregationOutcome, observations map[ocrcommon.OracleID][]values.Value, f int) (*AggregationOutcome, error)
 }
 
 func AppendWorkflowIDs(outcome *AggregationOutcome, workflowID string, workflowExecutionID string) (*AggregationOutcome, error) {

--- a/pkg/capabilities/datastreams/mocks/report_codec.go
+++ b/pkg/capabilities/datastreams/mocks/report_codec.go
@@ -14,29 +14,29 @@ type ReportCodec struct {
 	mock.Mock
 }
 
-// Unwrap provides a mock function with given fields: raw
-func (_m *ReportCodec) Unwrap(raw values.Value) ([]datastreams.FeedReport, error) {
-	ret := _m.Called(raw)
+// UnwrapValid provides a mock function with given fields: wrapped, allowedSigners, minRequiredSignatures
+func (_m *ReportCodec) UnwrapValid(wrapped values.Value, allowedSigners [][]byte, minRequiredSignatures int) ([]datastreams.FeedReport, error) {
+	ret := _m.Called(wrapped, allowedSigners, minRequiredSignatures)
 
 	if len(ret) == 0 {
-		panic("no return value specified for Unwrap")
+		panic("no return value specified for UnwrapValid")
 	}
 
 	var r0 []datastreams.FeedReport
 	var r1 error
-	if rf, ok := ret.Get(0).(func(values.Value) ([]datastreams.FeedReport, error)); ok {
-		return rf(raw)
+	if rf, ok := ret.Get(0).(func(values.Value, [][]byte, int) ([]datastreams.FeedReport, error)); ok {
+		return rf(wrapped, allowedSigners, minRequiredSignatures)
 	}
-	if rf, ok := ret.Get(0).(func(values.Value) []datastreams.FeedReport); ok {
-		r0 = rf(raw)
+	if rf, ok := ret.Get(0).(func(values.Value, [][]byte, int) []datastreams.FeedReport); ok {
+		r0 = rf(wrapped, allowedSigners, minRequiredSignatures)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]datastreams.FeedReport)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(values.Value) error); ok {
-		r1 = rf(raw)
+	if rf, ok := ret.Get(1).(func(values.Value, [][]byte, int) error); ok {
+		r1 = rf(wrapped, allowedSigners, minRequiredSignatures)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/capabilities/datastreams/types.go
+++ b/pkg/capabilities/datastreams/types.go
@@ -54,9 +54,10 @@ func FeedIDFromBytes(b [FeedIDBytesLen]byte) FeedID {
 }
 
 type FeedReport struct {
-	FeedID     string
-	FullReport []byte
-	Signatures [][]byte
+	FeedID        string
+	FullReport    []byte
+	ReportContext []byte
+	Signatures    [][]byte
 
 	// Fields below are derived from FullReport
 	// NOTE: BenchmarkPrice is a byte representation of big.Int. We can't use big.Int
@@ -65,11 +66,17 @@ type FeedReport struct {
 	ObservationTimestamp int64
 }
 
+// passed alongside Streams trigger events
+type SignersMetadata struct {
+	Signers               [][]byte
+	MinRequiredSignatures int
+}
+
 //go:generate mockery --quiet --name ReportCodec --output ./mocks/ --case=underscore
 type ReportCodec interface {
-	// validate each report and convert to a list of Mercury reports
-	Unwrap(raw values.Value) ([]FeedReport, error)
+	// unwrap and validate each report, then convert to a list of Feed reports
+	UnwrapValid(wrapped values.Value, allowedSigners [][]byte, minRequiredSignatures int) ([]FeedReport, error)
 
-	// validate each report and convert to Value
+	// convert back to Value
 	Wrap(reports []FeedReport) (values.Value, error)
 }

--- a/pkg/capabilities/triggers/mercury_trigger_test.go
+++ b/pkg/capabilities/triggers/mercury_trigger_test.go
@@ -293,7 +293,7 @@ func upwrapTriggerEvent(t *testing.T, wrappedEvent values.Value) (capabilities.T
 	err := wrappedEvent.UnwrapTo(&event)
 	require.NoError(t, err)
 	require.NotNil(t, event.Payload)
-	mercuryReports, err := testMercuryCodec{}.Unwrap(event.Payload)
+	mercuryReports, err := testMercuryCodec{}.UnwrapValid(event.Payload, nil, 0)
 	require.NoError(t, err)
 	return event, mercuryReports
 }

--- a/pkg/capabilities/triggers/testdata/fixtures/mercury/schema.json
+++ b/pkg/capabilities/triggers/testdata/fixtures/mercury/schema.json
@@ -47,6 +47,7 @@
         "Timestamp": {
           "type": "string"
         },
+        "Metadata": true,
         "Payload": true
       },
       "additionalProperties": false,
@@ -55,6 +56,7 @@
         "TriggerType",
         "ID",
         "Timestamp",
+        "Metadata",
         "Payload"
       ]
     }

--- a/pkg/capabilities/triggers/testdata/fixtures/mercury/test.yaml
+++ b/pkg/capabilities/triggers/testdata/fixtures/mercury/test.yaml
@@ -8,6 +8,7 @@ outputs:
   TriggerType: "mercury"
   ID: "myid" 
   Timestamp:  ""
+  Metadata:
   Payload: 
 
 # yaml-language-server: $schema=./schema.json


### PR DESCRIPTION
1. Add Metadata field to TriggerEvent. Use it to pass Streams DON info ("SignersMetadata" struct) between trigger receiver and OCR aggregator.
2. Extend feeds OCR aggregator with an initial phase of agreeing on a set of valid signers and the F value.
3. Add ReportContext field to FeedReport - Streams DON signs both fields together so we need to pass them to validate sigantures.