### PR TITLE
[Keystone] More aggressive default timeouts

### DIFF
--- a/pkg/capabilities/consensus/ocr3/capability.go
+++ b/pkg/capabilities/consensus/ocr3/capability.go
@@ -287,7 +287,7 @@ func (o *capability) expiryTimer(ctx context.Context, r *request) {
 				Value: nil,
 			},
 		}
-
+		o.lggr.Debugw("expiryTimer - expired request", "workflowExecutionID", r.WorkflowExecutionID)
 		o.transmitCh <- resp
 	}
 }

--- a/pkg/capabilities/consensus/ocr3/ocr3.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3.go
@@ -34,8 +34,8 @@ type Config struct {
 }
 
 const (
-	defaultRequestExpiry  time.Duration = 1 * time.Hour
-	defaultBatchSize                    = 1000
+	defaultRequestExpiry  time.Duration = 5 * time.Minute
+	defaultBatchSize                    = 20
 	defaultSendBufferSize               = 10
 )
 


### PR DESCRIPTION
1. Set default timeout to 5 minutes. It doesn't make sense to keep anything in the queue for as long as 1h.
2. Set batch size to 20. Unfortunately on large requests (e.g. ones containing many feed reports) we will get quickly limited by max observation size in bytes (1MB) so let's be conservative with batching.
3. Extra log line for timeout.