### PR TITLE
Validate keystone workflows + Enforce full semver on capabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.18.0
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
-	golang.org/x/mod v0.14.0
 	gonum.org/v1/gonum v0.14.0
 	google.golang.org/grpc v1.58.3
 	google.golang.org/protobuf v1.31.0

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -205,7 +205,7 @@ func (c CapabilityInfo) Info(ctx context.Context) (CapabilityInfo, error) {
 //
 // The difference between the regex within the link above and this one is that we do not use double backslashes, since
 // we only needed those for JSON schema regex validation.
-var idRegex = regexp.MustCompile(`^[a-z0-9_\-:]+@(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+var idRegex = regexp.MustCompile(`^[a-z0-9_\-:]+@(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 const (
 	// TODO: this length was largely picked arbitrarily.

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
-
-	"golang.org/x/mod/semver"
 
 	p2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
@@ -182,8 +181,12 @@ type CapabilityInfo struct {
 	ID             string
 	CapabilityType CapabilityType
 	Description    string
-	Version        string
 	DON            *DON
+}
+
+// Parse out the version from the ID.
+func (c CapabilityInfo) Version() string {
+	return c.ID[strings.Index(c.ID, "@")+1:]
 }
 
 // Info returns the info of the capability.
@@ -191,7 +194,18 @@ func (c CapabilityInfo) Info(ctx context.Context) (CapabilityInfo, error) {
 	return c, nil
 }
 
-var idRegex = regexp.MustCompile(`[a-z0-9_\-:]`)
+// This regex allows for the following format:
+//
+// {name}:{label1_key}_{labe1_value}:{label2_key}_{label2_value}@{version}
+//
+// The version regex is taken from https://semver.org/, but has been modified to support only major versions.
+//
+// It is also validated when a workflow is being ingested. See the following link for more details:
+// https://github.com/smartcontractkit/chainlink/blob/a0d1ce5e9cddc540bba8eb193865646cf0ebc0a8/core/services/workflows/models_yaml.go#L309
+//
+// The difference between the regex within the link above and this one is that we do not use double backslashes, since
+// we only needed those for JSON schema regex validation.
+var idRegex = regexp.MustCompile(`^[a-z0-9_\-:]+@(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 const (
 	// TODO: this length was largely picked arbitrarily.
@@ -205,9 +219,8 @@ func NewCapabilityInfo(
 	id string,
 	capabilityType CapabilityType,
 	description string,
-	version string,
 ) (CapabilityInfo, error) {
-	return NewRemoteCapabilityInfo(id, capabilityType, description, version, nil)
+	return NewRemoteCapabilityInfo(id, capabilityType, description, nil)
 }
 
 // NewRemoteCapabilityInfo returns a new CapabilityInfo for remote capabilities.
@@ -218,7 +231,6 @@ func NewRemoteCapabilityInfo(
 	id string,
 	capabilityType CapabilityType,
 	description string,
-	version string,
 	don *DON,
 ) (CapabilityInfo, error) {
 	if len(id) > idMaxLength {
@@ -226,10 +238,6 @@ func NewRemoteCapabilityInfo(
 	}
 	if !idRegex.MatchString(id) {
 		return CapabilityInfo{}, fmt.Errorf("invalid id: %s. Allowed: %s", id, idRegex)
-	}
-
-	if ok := semver.IsValid(version); !ok {
-		return CapabilityInfo{}, fmt.Errorf("invalid version: %+v", version)
 	}
 
 	if err := capabilityType.IsValid(); err != nil {
@@ -240,7 +248,6 @@ func NewRemoteCapabilityInfo(
 		ID:             id,
 		CapabilityType: capabilityType,
 		Description:    description,
-		Version:        version,
 		DON:            don,
 	}, nil
 }
@@ -251,9 +258,8 @@ func MustNewCapabilityInfo(
 	id string,
 	capabilityType CapabilityType,
 	description string,
-	version string,
 ) CapabilityInfo {
-	return MustNewRemoteCapabilityInfo(id, capabilityType, description, version, nil)
+	return MustNewRemoteCapabilityInfo(id, capabilityType, description, nil)
 }
 
 // MustNewRemoteCapabilityInfo returns a new CapabilityInfo,
@@ -262,10 +268,9 @@ func MustNewRemoteCapabilityInfo(
 	id string,
 	capabilityType CapabilityType,
 	description string,
-	version string,
 	don *DON,
 ) CapabilityInfo {
-	c, err := NewRemoteCapabilityInfo(id, capabilityType, description, version, don)
+	c, err := NewRemoteCapabilityInfo(id, capabilityType, description, don)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -15,24 +15,49 @@ import (
 
 func Test_CapabilityInfo(t *testing.T) {
 	ci, err := NewCapabilityInfo(
-		"capability-id",
+		"capability-id@1",
 		CapabilityTypeAction,
 		"This is a mock capability that doesn't do anything.",
-		"v1.0.0",
 	)
 	require.NoError(t, err)
 
 	gotCi, err := ci.Info(tests.Context(t))
 	require.NoError(t, err)
+	require.Equal(t, ci.Version(), "1")
+	assert.Equal(t, ci, gotCi)
+
+	ci, err = NewCapabilityInfo(
+		// add build metadata and sha
+		"capability-id@1+build.1234.sha-5678",
+		CapabilityTypeAction,
+		"This is a mock capability that doesn't do anything.",
+	)
+	require.NoError(t, err)
+
+	gotCi, err = ci.Info(tests.Context(t))
+	require.NoError(t, err)
+	require.Equal(t, ci.Version(), "1+build.1234.sha-5678")
+	assert.Equal(t, ci, gotCi)
+
+	// prerelease
+	ci, err = NewCapabilityInfo(
+		"capability-id@1-beta",
+		CapabilityTypeAction,
+		"This is a mock capability that doesn't do anything.",
+	)
+	require.NoError(t, err)
+
+	gotCi, err = ci.Info(tests.Context(t))
+	require.NoError(t, err)
+	require.Equal(t, ci.Version(), "1-beta")
 	assert.Equal(t, ci, gotCi)
 }
 
 func Test_CapabilityInfo_Invalid(t *testing.T) {
 	_, err := NewCapabilityInfo(
-		"capability-id",
+		"capability-id@2",
 		CapabilityType(5),
 		"This is a mock capability that doesn't do anything.",
-		"v1.0.0",
 	)
 	assert.ErrorContains(t, err, "invalid capability type")
 
@@ -40,23 +65,34 @@ func Test_CapabilityInfo_Invalid(t *testing.T) {
 		"&!!!",
 		CapabilityTypeAction,
 		"This is a mock capability that doesn't do anything.",
-		"v1.0.0",
 	)
 	assert.ErrorContains(t, err, "invalid id")
 
 	_, err = NewCapabilityInfo(
-		"mock-capability",
+		"mock-capability@v1",
 		CapabilityTypeAction,
 		"This is a mock capability that doesn't do anything.",
-		"hello",
 	)
-	assert.ErrorContains(t, err, "invalid version")
+	assert.ErrorContains(t, err, "invalid id")
 
+	_, err = NewCapabilityInfo(
+		"mock-capability@1.0",
+		CapabilityTypeAction,
+		"This is a mock capability that doesn't do anything.",
+	)
+	assert.ErrorContains(t, err, "invalid id")
+
+	_, err = NewCapabilityInfo(
+		"mock-capability@1.0.1",
+		CapabilityTypeAction,
+		"This is a mock capability that doesn't do anything.",
+	)
+
+	assert.ErrorContains(t, err, "invalid id")
 	_, err = NewCapabilityInfo(
 		strings.Repeat("n", 256),
 		CapabilityTypeAction,
 		"This is a mock capability that doesn't do anything.",
-		"hello",
 	)
 	assert.ErrorContains(t, err, "exceeds max length 128")
 }
@@ -187,7 +223,6 @@ func Test_MustNewCapabilityInfo(t *testing.T) {
 			"capability-id",
 			CapabilityTypeAction,
 			"This is a mock capability that doesn't do anything.",
-			"should-panic",
 		)
 	})
 }

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -15,7 +15,7 @@ import (
 
 func Test_CapabilityInfo(t *testing.T) {
 	ci, err := NewCapabilityInfo(
-		"capability-id@1",
+		"capability-id@1.0.0",
 		CapabilityTypeAction,
 		"This is a mock capability that doesn't do anything.",
 	)
@@ -23,12 +23,12 @@ func Test_CapabilityInfo(t *testing.T) {
 
 	gotCi, err := ci.Info(tests.Context(t))
 	require.NoError(t, err)
-	require.Equal(t, ci.Version(), "1")
+	require.Equal(t, ci.Version(), "1.0.0")
 	assert.Equal(t, ci, gotCi)
 
 	ci, err = NewCapabilityInfo(
 		// add build metadata and sha
-		"capability-id@1+build.1234.sha-5678",
+		"capability-id@1.0.0+build.1234.sha-5678",
 		CapabilityTypeAction,
 		"This is a mock capability that doesn't do anything.",
 	)
@@ -36,12 +36,12 @@ func Test_CapabilityInfo(t *testing.T) {
 
 	gotCi, err = ci.Info(tests.Context(t))
 	require.NoError(t, err)
-	require.Equal(t, ci.Version(), "1+build.1234.sha-5678")
+	require.Equal(t, ci.Version(), "1.0.0+build.1234.sha-5678")
 	assert.Equal(t, ci, gotCi)
 
 	// prerelease
 	ci, err = NewCapabilityInfo(
-		"capability-id@1-beta",
+		"capability-id@1.0.0-beta",
 		CapabilityTypeAction,
 		"This is a mock capability that doesn't do anything.",
 	)
@@ -49,13 +49,13 @@ func Test_CapabilityInfo(t *testing.T) {
 
 	gotCi, err = ci.Info(tests.Context(t))
 	require.NoError(t, err)
-	require.Equal(t, ci.Version(), "1-beta")
+	require.Equal(t, ci.Version(), "1.0.0-beta")
 	assert.Equal(t, ci, gotCi)
 }
 
 func Test_CapabilityInfo_Invalid(t *testing.T) {
 	_, err := NewCapabilityInfo(
-		"capability-id@2",
+		"capability-id@2.0.0",
 		CapabilityType(5),
 		"This is a mock capability that doesn't do anything.",
 	)
@@ -69,7 +69,7 @@ func Test_CapabilityInfo_Invalid(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid id")
 
 	_, err = NewCapabilityInfo(
-		"mock-capability@v1",
+		"mock-capability@v1.0.0",
 		CapabilityTypeAction,
 		"This is a mock capability that doesn't do anything.",
 	)
@@ -83,7 +83,7 @@ func Test_CapabilityInfo_Invalid(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid id")
 
 	_, err = NewCapabilityInfo(
-		"mock-capability@1.0.1",
+		"mock-capability@1",
 		CapabilityTypeAction,
 		"This is a mock capability that doesn't do anything.",
 	)

--- a/pkg/capabilities/consensus/ocr3/capability.go
+++ b/pkg/capabilities/consensus/ocr3/capability.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	ocrCapabilityID = "offchain_reporting@1"
+	ocrCapabilityID = "offchain_reporting@1.0.0"
 
 	methodStartRequest = "start_request"
 	methodSendResponse = "send_response"

--- a/pkg/capabilities/consensus/ocr3/capability.go
+++ b/pkg/capabilities/consensus/ocr3/capability.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	ocrCapabilityID = "offchain_reporting"
+	ocrCapabilityID = "offchain_reporting@1"
 
 	methodStartRequest = "start_request"
 	methodSendResponse = "send_response"
@@ -28,7 +28,6 @@ var info = capabilities.MustNewCapabilityInfo(
 	ocrCapabilityID,
 	capabilities.CapabilityTypeConsensus,
 	"OCR3 consensus exposed as a capability.",
-	"v1.0.0",
 )
 
 type capability struct {

--- a/pkg/capabilities/consensus/ocr3/testdata/fixtures/capability/schema.json
+++ b/pkg/capabilities/consensus/ocr3/testdata/fixtures/capability/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/offchain_reporting@1/root",
+  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/offchain_reporting@1.0.0/root",
   "properties": {
     "config": {
       "properties": {

--- a/pkg/capabilities/consensus/ocr3/testdata/fixtures/capability/schema.json
+++ b/pkg/capabilities/consensus/ocr3/testdata/fixtures/capability/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/offchain_reporting/root",
+  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/offchain_reporting@1/root",
   "properties": {
     "config": {
       "properties": {

--- a/pkg/capabilities/testdata/fixtures/validator/schema.json
+++ b/pkg/capabilities/testdata/fixtures/validator/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/test@1/root",
+  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/test@1.0.0/root",
   "properties": {
     "config": {
       "properties": {

--- a/pkg/capabilities/testdata/fixtures/validator/schema.json
+++ b/pkg/capabilities/testdata/fixtures/validator/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/test/root",
+  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/test@1/root",
   "properties": {
     "config": {
       "properties": {

--- a/pkg/capabilities/triggers/mercury_trigger.go
+++ b/pkg/capabilities/triggers/mercury_trigger.go
@@ -14,13 +14,12 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 )
 
-const triggerID = "streams-trigger"
+const triggerID = "streams-trigger@1.0.0"
 
 var capInfo = capabilities.MustNewCapabilityInfo(
 	triggerID,
 	capabilities.CapabilityTypeTrigger,
 	"Streams Trigger",
-	"v1.0.0",
 )
 
 const defaultTickerResolutionMs = 1000

--- a/pkg/capabilities/triggers/on_demand_trigger.go
+++ b/pkg/capabilities/triggers/on_demand_trigger.go
@@ -10,10 +10,9 @@ import (
 )
 
 var info = capabilities.MustNewCapabilityInfo(
-	"on-demand-trigger",
+	"on-demand-trigger@1",
 	capabilities.CapabilityTypeTrigger,
 	"An example on-demand trigger.",
-	"v1.0.0",
 )
 
 type workflowID string

--- a/pkg/capabilities/triggers/on_demand_trigger.go
+++ b/pkg/capabilities/triggers/on_demand_trigger.go
@@ -10,7 +10,7 @@ import (
 )
 
 var info = capabilities.MustNewCapabilityInfo(
-	"on-demand-trigger@1",
+	"on-demand-trigger@1.0.0",
 	capabilities.CapabilityTypeTrigger,
 	"An example on-demand trigger.",
 )

--- a/pkg/capabilities/triggers/testdata/fixtures/mercury/schema.json
+++ b/pkg/capabilities/triggers/testdata/fixtures/mercury/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/streams-trigger/root",
+  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/streams-trigger@1/root",
   "properties": {
     "config": {
       "properties": {

--- a/pkg/capabilities/triggers/testdata/fixtures/mercury/schema.json
+++ b/pkg/capabilities/triggers/testdata/fixtures/mercury/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/streams-trigger@1/root",
+  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/streams-trigger@1.0.0/root",
   "properties": {
     "config": {
       "properties": {

--- a/pkg/capabilities/triggers/testdata/fixtures/ondemand/schema.json
+++ b/pkg/capabilities/triggers/testdata/fixtures/ondemand/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/on-demand-trigger/root",
+  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/on-demand-trigger@1/root",
   "properties": {
     "config": {
       "properties": {},

--- a/pkg/capabilities/triggers/testdata/fixtures/ondemand/schema.json
+++ b/pkg/capabilities/triggers/testdata/fixtures/ondemand/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/on-demand-trigger@1/root",
+  "$id": "https://github.com/smartcontractkit/chainlink/capabilities/on-demand-trigger@1.0.0/root",
   "properties": {
     "config": {
       "properties": {},

--- a/pkg/capabilities/validate_test.go
+++ b/pkg/capabilities/validate_test.go
@@ -200,7 +200,7 @@ func TestValidator_ValidateOutputs(t *testing.T) {
 
 func TestValidator_GenerateSchema(t *testing.T) {
 	capInfo := CapabilityInfo{
-		ID:             "test@1",
+		ID:             "test@1.0.0",
 		CapabilityType: CapabilityTypeTrigger,
 		Description:    "test description",
 	}

--- a/pkg/capabilities/validate_test.go
+++ b/pkg/capabilities/validate_test.go
@@ -200,10 +200,9 @@ func TestValidator_ValidateOutputs(t *testing.T) {
 
 func TestValidator_GenerateSchema(t *testing.T) {
 	capInfo := CapabilityInfo{
-		ID:             "test",
+		ID:             "test@1",
 		CapabilityType: CapabilityTypeTrigger,
 		Description:    "test description",
-		Version:        "1.0.0",
 	}
 	v := NewValidator[TestConfig, TestInputs, TestOutputs](ValidatorArgs{Info: capInfo})
 	schema, err := v.Schema()

--- a/pkg/loop/internal/core/services/capability/capabilities.go
+++ b/pkg/loop/internal/core/services/capability/capabilities.go
@@ -140,7 +140,6 @@ func capabilityInfoToCapabilityInfoReply(info capabilities.CapabilityInfo) *capa
 		Id:             info.ID,
 		CapabilityType: ct,
 		Description:    info.Description,
-		Version:        info.Version,
 	}
 }
 
@@ -183,7 +182,6 @@ func capabilityInfoReplyToCapabilityInfo(resp *capabilitiespb.CapabilityInfoRepl
 		ID:             resp.Id,
 		CapabilityType: ct,
 		Description:    resp.Description,
-		Version:        resp.Version,
 	}, nil
 }
 

--- a/pkg/loop/internal/core/services/capability/capabilities_registry_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_registry_test.go
@@ -176,7 +176,7 @@ func TestCapabilitiesRegistry(t *testing.T) {
 
 	// Add capability Trigger
 	triggerInfo := capabilities.CapabilityInfo{
-		ID:             "trigger-1@1",
+		ID:             "trigger-1@1.0.0",
 		CapabilityType: capabilities.CapabilityTypeTrigger,
 		Description:    "trigger-1-description",
 	}
@@ -190,8 +190,8 @@ func TestCapabilitiesRegistry(t *testing.T) {
 	err = rc.Add(tests.Context(t), testTrigger)
 	require.NoError(t, err)
 
-	reg.On("GetTrigger", mock.Anything, "trigger-1").Return(testTrigger, nil)
-	triggerCap, err := rc.GetTrigger(tests.Context(t), "trigger-1")
+	reg.On("GetTrigger", mock.Anything, "trigger-1@1.0.0").Return(testTrigger, nil)
+	triggerCap, err := rc.GetTrigger(tests.Context(t), "trigger-1@1.0.0")
 	require.NoError(t, err)
 
 	// Test trigger Info()
@@ -216,7 +216,7 @@ func TestCapabilitiesRegistry(t *testing.T) {
 
 	// Add capability Trigger
 	actionInfo := capabilities.CapabilityInfo{
-		ID:             "action-1@2",
+		ID:             "action-1@2.0.0",
 		CapabilityType: capabilities.CapabilityTypeAction,
 		Description:    "action-1-description",
 	}
@@ -226,8 +226,8 @@ func TestCapabilitiesRegistry(t *testing.T) {
 		mockBaseCapability:     &mockBaseCapability{info: actionInfo},
 		mockCallbackExecutable: &mockCallbackExecutable{callback: actionCallbackChan},
 	}
-	reg.On("GetAction", mock.Anything, "action-1").Return(testAction, nil)
-	actionCap, err := rc.GetAction(tests.Context(t), "action-1")
+	reg.On("GetAction", mock.Anything, "action-1@2.0.0").Return(testAction, nil)
+	actionCap, err := rc.GetAction(tests.Context(t), "action-1@2.0.0")
 	require.NoError(t, err)
 
 	testCapabilityInfo(t, actionInfo, actionCap)
@@ -252,7 +252,7 @@ func TestCapabilitiesRegistry(t *testing.T) {
 
 	// Add capability Consensus
 	consensusInfo := capabilities.CapabilityInfo{
-		ID:             "consensus-1@3",
+		ID:             "consensus-1@3.0.0",
 		CapabilityType: capabilities.CapabilityTypeConsensus,
 		Description:    "consensus-1-description",
 	}
@@ -260,15 +260,15 @@ func TestCapabilitiesRegistry(t *testing.T) {
 		mockBaseCapability:     &mockBaseCapability{info: consensusInfo},
 		mockCallbackExecutable: &mockCallbackExecutable{},
 	}
-	reg.On("GetConsensus", mock.Anything, "consensus-1").Return(testConsensus, nil)
-	consensusCap, err := rc.GetConsensus(tests.Context(t), "consensus-1")
+	reg.On("GetConsensus", mock.Anything, "consensus-1@3.0.0").Return(testConsensus, nil)
+	consensusCap, err := rc.GetConsensus(tests.Context(t), "consensus-1@3.0.0")
 	require.NoError(t, err)
 
 	testCapabilityInfo(t, consensusInfo, consensusCap)
 
 	// Add capability Target
 	targetInfo := capabilities.CapabilityInfo{
-		ID:             "target-1@1",
+		ID:             "target-1@1.0.0",
 		CapabilityType: capabilities.CapabilityTypeTarget,
 		Description:    "target-1-description",
 	}
@@ -276,8 +276,8 @@ func TestCapabilitiesRegistry(t *testing.T) {
 		mockBaseCapability:     &mockBaseCapability{info: targetInfo},
 		mockCallbackExecutable: &mockCallbackExecutable{},
 	}
-	reg.On("GetTarget", mock.Anything, "target-1").Return(testTarget, nil)
-	targetCap, err := rc.GetTarget(tests.Context(t), "target-1")
+	reg.On("GetTarget", mock.Anything, "target-1@1.0.0").Return(testTarget, nil)
+	targetCap, err := rc.GetTarget(tests.Context(t), "target-1@1.0.0")
 	require.NoError(t, err)
 
 	testCapabilityInfo(t, targetInfo, targetCap)

--- a/pkg/loop/internal/core/services/capability/capabilities_registry_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_registry_test.go
@@ -176,10 +176,9 @@ func TestCapabilitiesRegistry(t *testing.T) {
 
 	// Add capability Trigger
 	triggerInfo := capabilities.CapabilityInfo{
-		ID:             "trigger-1",
+		ID:             "trigger-1@1",
 		CapabilityType: capabilities.CapabilityTypeTrigger,
 		Description:    "trigger-1-description",
-		Version:        "trigger-1-version",
 	}
 	testTrigger := mockTriggerCapability{
 		mockBaseCapability:    &mockBaseCapability{info: triggerInfo},
@@ -217,10 +216,9 @@ func TestCapabilitiesRegistry(t *testing.T) {
 
 	// Add capability Trigger
 	actionInfo := capabilities.CapabilityInfo{
-		ID:             "action-1",
+		ID:             "action-1@2",
 		CapabilityType: capabilities.CapabilityTypeAction,
 		Description:    "action-1-description",
-		Version:        "action-1-version",
 	}
 
 	actionCallbackChan := make(chan capabilities.CapabilityResponse, 10)
@@ -254,10 +252,9 @@ func TestCapabilitiesRegistry(t *testing.T) {
 
 	// Add capability Consensus
 	consensusInfo := capabilities.CapabilityInfo{
-		ID:             "consensus-1",
+		ID:             "consensus-1@3",
 		CapabilityType: capabilities.CapabilityTypeConsensus,
 		Description:    "consensus-1-description",
-		Version:        "consensus-1-version",
 	}
 	testConsensus := mockConsensusCapability{
 		mockBaseCapability:     &mockBaseCapability{info: consensusInfo},
@@ -271,10 +268,9 @@ func TestCapabilitiesRegistry(t *testing.T) {
 
 	// Add capability Target
 	targetInfo := capabilities.CapabilityInfo{
-		ID:             "target-1",
+		ID:             "target-1@1",
 		CapabilityType: capabilities.CapabilityTypeTarget,
 		Description:    "target-1-description",
-		Version:        "target-1-version",
 	}
 	testTarget := mockTargetCapability{
 		mockBaseCapability:     &mockBaseCapability{info: targetInfo},
@@ -293,5 +289,5 @@ func testCapabilityInfo(t *testing.T, expectedInfo capabilities.CapabilityInfo, 
 	require.Equal(t, expectedInfo.ID, gotInfo.ID)
 	require.Equal(t, expectedInfo.CapabilityType, gotInfo.CapabilityType)
 	require.Equal(t, expectedInfo.Description, gotInfo.Description)
-	require.Equal(t, expectedInfo.Version, gotInfo.Version)
+	require.Equal(t, expectedInfo.Version(), gotInfo.Version())
 }

--- a/pkg/loop/internal/core/services/capability/capabilities_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_test.go
@@ -101,7 +101,7 @@ func (m *mockCallback) Execute(ctx context.Context, request capabilities.Capabil
 
 func mustMockCallback(t *testing.T, _type capabilities.CapabilityType) *mockCallback {
 	return &mockCallback{
-		BaseCapability: capabilities.MustNewCapabilityInfo(fmt.Sprintf("callback %s", _type), _type, fmt.Sprintf("a mock %s", _type)),
+		BaseCapability: capabilities.MustNewCapabilityInfo(fmt.Sprintf("callback-%s@1.0.0", _type), _type, fmt.Sprintf("a mock %s", _type)),
 		callback:       make(chan capabilities.CapabilityResponse),
 	}
 }
@@ -505,7 +505,7 @@ func (m *synchronousCallback) Execute(ctx context.Context, request capabilities.
 
 func mustSynchronousCallback(t *testing.T, _type capabilities.CapabilityType) *synchronousCallback {
 	return &synchronousCallback{
-		BaseCapability: capabilities.MustNewCapabilityInfo(fmt.Sprintf("callback %s", _type), _type, fmt.Sprintf("a mock %s", _type)),
+		BaseCapability: capabilities.MustNewCapabilityInfo(fmt.Sprintf("callback-%s@1.0.0", _type), _type, fmt.Sprintf("a mock %s", _type)),
 		callback:       make(chan capabilities.CapabilityResponse, 0),
 		executeCalled:  false,
 	}

--- a/pkg/loop/internal/core/services/capability/capabilities_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_test.go
@@ -71,7 +71,7 @@ func (m *mockTrigger) Stop() {
 
 func mustMockTrigger(t *testing.T) *mockTrigger {
 	return &mockTrigger{
-		BaseCapability:  capabilities.MustNewCapabilityInfo("trigger", capabilities.CapabilityTypeTrigger, "a mock trigger", "v0.0.1"),
+		BaseCapability:  capabilities.MustNewCapabilityInfo("trigger@1.0.0", capabilities.CapabilityTypeTrigger, "a mock trigger"),
 		callback:        make(chan capabilities.CapabilityResponse, 10),
 		unregisterCalls: make(chan bool, 10),
 		registerCalls:   make(chan bool, 10),
@@ -101,7 +101,7 @@ func (m *mockCallback) Execute(ctx context.Context, request capabilities.Capabil
 
 func mustMockCallback(t *testing.T, _type capabilities.CapabilityType) *mockCallback {
 	return &mockCallback{
-		BaseCapability: capabilities.MustNewCapabilityInfo(fmt.Sprintf("callback %s", _type), _type, fmt.Sprintf("a mock %s", _type), "v0.0.1"),
+		BaseCapability: capabilities.MustNewCapabilityInfo(fmt.Sprintf("callback %s", _type), _type, fmt.Sprintf("a mock %s", _type)),
 		callback:       make(chan capabilities.CapabilityResponse),
 	}
 }
@@ -505,7 +505,7 @@ func (m *synchronousCallback) Execute(ctx context.Context, request capabilities.
 
 func mustSynchronousCallback(t *testing.T, _type capabilities.CapabilityType) *synchronousCallback {
 	return &synchronousCallback{
-		BaseCapability: capabilities.MustNewCapabilityInfo(fmt.Sprintf("callback %s", _type), _type, fmt.Sprintf("a mock %s", _type), "v0.0.1"),
+		BaseCapability: capabilities.MustNewCapabilityInfo(fmt.Sprintf("callback %s", _type), _type, fmt.Sprintf("a mock %s", _type)),
 		callback:       make(chan capabilities.CapabilityResponse, 0),
 		executeCalled:  false,
 	}

--- a/pkg/loop/internal/core/services/capability/test/standard_capabilities.go
+++ b/pkg/loop/internal/core/services/capability/test/standard_capabilities.go
@@ -16,14 +16,12 @@ func (t StandardCapabilitiesService) Infos(ctx context.Context) ([]capabilities.
 			ID:             "1",
 			CapabilityType: capabilities.CapabilityTypeAction,
 			Description:    "",
-			Version:        "",
 			DON:            nil,
 		},
 		{
 			ID:             "2",
 			CapabilityType: capabilities.CapabilityTypeTarget,
 			Description:    "",
-			Version:        "",
 			DON:            nil,
 		},
 	}, nil

--- a/pkg/loop/internal/test/test.go
+++ b/pkg/loop/internal/test/test.go
@@ -19,10 +19,9 @@ var (
 	GetConsensusID = "get-consensus-id"
 	GetTargetID    = "get-target-id"
 	CapabilityInfo = capabilities.CapabilityInfo{
-		ID:             "capability-info-id",
+		ID:             "capability-info-id@1",
 		CapabilityType: 2,
 		Description:    "capability-info-description",
-		Version:        "capability-info-version",
 	}
 )
 

--- a/pkg/loop/internal/test/test.go
+++ b/pkg/loop/internal/test/test.go
@@ -19,7 +19,7 @@ var (
 	GetConsensusID = "get-consensus-id"
 	GetTargetID    = "get-target-id"
 	CapabilityInfo = capabilities.CapabilityInfo{
-		ID:             "capability-info-id@1",
+		ID:             "capability-info-id@1.0.0",
 		CapabilityType: 2,
 		Description:    "capability-info-description",
 	}

--- a/pkg/workflows/dependency_graph_test.go
+++ b/pkg/workflows/dependency_graph_test.go
@@ -21,23 +21,27 @@ func TestParseDependencyGraph(t *testing.T) {
 			name: "basic example",
 			yaml: `
 triggers:
-  - id: "a-trigger"
+  - id: "a-trigger@1.0.0"
+    config: {}
 
 actions:
-  - id: "an-action"
+  - id: "an-action@1.0.0"
+    config: {}
     ref: "an-action"
     inputs:
       trigger_output: $(trigger.outputs)
 
 consensus:
-  - id: "a-consensus"
+  - id: "a-consensus@1.0.0"
+    config: {}
     ref: "a-consensus"
     inputs:
       trigger_output: $(trigger.outputs)
       an-action_output: $(an-action.outputs)
 
 targets:
-  - id: "a-target"
+  - id: "a-target@1.0.0"
+    config: {}
     ref: "a-target"
     inputs: 
       consensus_output: $(a-consensus.outputs)
@@ -60,28 +64,33 @@ targets:
 			name: "circular relationship",
 			yaml: `
 triggers:
-  - id: "a-trigger"
+  - id: "a-trigger@1.0.0"
+    config: {}
 
 actions:
-  - id: "an-action"
+  - id: "an-action@1.0.0"
+    config: {}
     ref: "an-action"
     inputs:
       trigger_output: $(trigger.outputs)
       output: $(a-second-action.outputs)
-  - id: "a-second-action"
+  - id: "a-second-action@1.0.0"
+    config: {}
     ref: "a-second-action"
     inputs:
       output: $(an-action.outputs)
 
 consensus:
-  - id: "a-consensus"
+  - id: "a-consensus@1.0.0"
+    config: {}
     ref: "a-consensus"
     inputs:
       trigger_output: $(trigger.outputs)
       an-action_output: $(an-action.outputs)
 
 targets:
-  - id: "a-target"
+  - id: "a-target@1.0.0"
+    config: {}
     ref: "a-target"
     inputs: 
       consensus_output: $(a-consensus.outputs)
@@ -92,32 +101,38 @@ targets:
 			name: "indirect circular relationship",
 			yaml: `
 triggers:
-  - id: "a-trigger"
+  - id: "a-trigger@1.0.0"
+    config: {}
 
 actions:
-  - id: "an-action"
+  - id: "an-action@1.0.0"
+    config: {}
     ref: "an-action"
     inputs:
       trigger_output: $(trigger.outputs)
       action_output: $(a-third-action.outputs)
-  - id: "a-second-action"
+  - id: "a-second-action@1.0.0"
+    config: {}
     ref: "a-second-action"
     inputs:
       output: $(an-action.outputs)
-  - id: "a-third-action"
+  - id: "a-third-action@1.0.0"
+    config: {}
     ref: "a-third-action"
     inputs:
       output: $(a-second-action.outputs)
 
 consensus:
-  - id: "a-consensus"
+  - id: "a-consensus@1.0.0"
+    config: {}
     ref: "a-consensus"
     inputs:
       trigger_output: $(trigger.outputs)
       an-action_output: $(an-action.outputs)
 
 targets:
-  - id: "a-target"
+  - id: "a-target@1.0.0"
+    config: {}
     ref: "a-target"
     inputs: 
       consensus_output: $(a-consensus.outputs)
@@ -128,23 +143,27 @@ targets:
 			name: "relationship doesn't exist",
 			yaml: `
 triggers:
-  - id: "a-trigger"
+  - id: "a-trigger@1.0.0"
+    config: {}
 
 actions:
-  - id: "an-action"
+  - id: "an-action@1.0.0"
+    config: {}
     ref: "an-action"
     inputs:
       trigger_output: $(trigger.outputs)
       action_output: $(missing-action.outputs)
 
 consensus:
-  - id: "a-consensus"
+  - id: "a-consensus@1.0.0"
+    config: {}
     ref: "a-consensus"
     inputs:
       an-action_output: $(an-action.outputs)
 
 targets:
-  - id: "a-target"
+  - id: "a-target@1.0.0"
+    config: {}
     ref: "a-target"
     inputs: 
       consensus_output: $(a-consensus.outputs)
@@ -155,24 +174,29 @@ targets:
 			name: "two trigger nodes",
 			yaml: `
 triggers:
-  - id: "a-trigger"
-  - id: "a-second-trigger"
+  - id: "a-trigger@1.0.0"
+    config: {}
+  - id: "a-second-trigger@1.0.0"
+    config: {}
 
 actions:
-  - id: "an-action"
+  - id: "an-action@1.0.0"
+    config: {}
     ref: "an-action"
     inputs:
       trigger_output: $(trigger.outputs)
 
 consensus:
-  - id: "a-consensus"
+  - id: "a-consensus@1.0.0"
+    config: {}
     ref: "a-consensus"
     inputs:
       an-action_output: $(an-action.outputs)
 
 targets:
-  - id: "a-target"
+  - id: "a-target@1.0.0"
     ref: "a-target"
+    config: {}
     inputs:
       consensus_output: $(a-consensus.outputs)
 `,
@@ -193,21 +217,26 @@ targets:
 			name: "non-trigger step with no dependent refs",
 			yaml: `
 triggers:
-  - id: "a-trigger"
-  - id: "a-second-trigger"
+  - id: "a-trigger@1.0.0"
+    config: {}
+  - id: "a-second-trigger@1.0.0"
+    config: {}
 actions:
-  - id: "an-action"
+  - id: "an-action@1.0.0"
+    config: {}
     ref: "an-action"
     inputs:
       hello: "world"
 consensus:
-  - id: "a-consensus"
+  - id: "a-consensus@1.0.0"
     ref: "a-consensus"
+    config: {}
     inputs:
       trigger_output: $(trigger.outputs)
       action_output: $(an-action.outputs)
 targets:
-  - id: "a-target"
+  - id: "a-target@1.0.0"
+    config: {}
     ref: "a-target"
     inputs:
       consensus_output: $(a-consensus.outputs)
@@ -218,21 +247,26 @@ targets:
 			name: "duplicate refs in a step",
 			yaml: `
 triggers:
-  - id: "a-trigger"
-  - id: "a-second-trigger"
+  - id: "a-trigger@1.0.0"
+    config: {}
+  - id: "a-second-trigger@1.0.0"
+    config: {}
 actions:
-  - id: "an-action"
+  - id: "an-action@1.0.0"
     ref: "an-action"
+    config: {}
     inputs:
       trigger_output: $(trigger.outputs)
 consensus:
-  - id: "a-consensus"
+  - id: "a-consensus@1.0.0"
+    config: {}
     ref: "a-consensus"
     inputs:
       action_output: $(an-action.outputs)
 targets:
-  - id: "a-target"
+  - id: "a-target@1.0.0"
     ref: "a-target"
+    config: {}
     inputs:
       consensus_output: $(a-consensus.outputs)
       consensus_output: $(a-consensus.outputs)

--- a/pkg/workflows/models_yaml.go
+++ b/pkg/workflows/models_yaml.go
@@ -332,7 +332,7 @@ func (s *stepDefinitionID) MarshalJSON() ([]byte, error) {
 // The schema is a oneOf schema that allows either a string or a table.
 func (stepDefinitionID) JSONSchema() *jsonschema.Schema {
 	reflector := jsonschema.Reflector{DoNotReference: true, ExpandedStruct: true}
-	tableSchema := reflector.Reflect(&StepDefinitionTableID{})
+	tableSchema := reflector.Reflect(&stepDefinitionTableID{})
 	stringSchema := &jsonschema.Schema{
 		ID: "string",
 		// Allow for a-z, 0-9, _, -, and : characters as the capability type, follwed by a semver regex allowing only major versions.

--- a/pkg/workflows/models_yaml.go
+++ b/pkg/workflows/models_yaml.go
@@ -304,7 +304,7 @@ func (s *stepDefinitionID) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// If the JSON data is a table, unmarshal it into a StepDefinitionTableID
+	// If the JSON data is a table, unmarshal it into a stepDefinitionTableID
 	var table stepDefinitionTableID
 	err = json.Unmarshal(data, &table)
 	if err != nil {

--- a/pkg/workflows/models_yaml.go
+++ b/pkg/workflows/models_yaml.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/invopop/jsonschema"
+	validate "github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/shopspring/decimal"
 	"sigs.k8s.io/yaml"
 
@@ -21,16 +22,40 @@ func GenerateJSONSchema() ([]byte, error) {
 }
 
 func ParseWorkflowSpecYaml(data string) (WorkflowSpec, error) {
+	var url = "https://github.com/smartcontractkit/chainlink/"
 	w := workflowSpecYaml{}
 	err := yaml.Unmarshal([]byte(data), &w)
+	if err != nil {
+		return WorkflowSpec{}, err
+	}
+	schemaStr, err := GenerateJSONSchema()
+	if err != nil {
+		return WorkflowSpec{}, err
+	}
 
-	return w.toWorkflowSpec(), err
+	schema, err := validate.CompileString(url, string(schemaStr))
+	if err != nil {
+		return WorkflowSpec{}, err
+	}
+
+	var jsonToValidate any
+	err = yaml.Unmarshal([]byte(data), &jsonToValidate)
+	if err != nil {
+		return WorkflowSpec{}, err
+	}
+
+	err = schema.Validate(jsonToValidate)
+	if err != nil {
+		return WorkflowSpec{}, err
+	}
+
+	return w.toWorkflowSpec(), nil
 }
 
 // workflowSpecYaml is the YAML representation of a workflow spec.
 //
 // It allows for multiple ways of defining a workflow spec, which we later
-// convert to a single representation, `workflowSpec`.
+// convert to a single representation, `WorkflowSpec`.
 type workflowSpecYaml struct {
 	// Triggers define a starting condition for the workflow, based on specific events or conditions.
 	Triggers []stepDefinitionYaml `json:"triggers" jsonschema:"required"`
@@ -42,7 +67,7 @@ type workflowSpecYaml struct {
 	Targets []stepDefinitionYaml `json:"targets" jsonschema:"required"`
 }
 
-// toWorkflowSpec converts a workflowSpecYaml to a workflowSpec.
+// toWorkflowSpec converts a workflowSpecYaml to a WorkflowSpec.
 //
 // We support multiple ways of defining a workflow spec yaml,
 // but internally we want to work with a single representation.
@@ -105,6 +130,11 @@ func (m *mapping) UnmarshalJSON(b []byte) error {
 	return err
 }
 
+// convertNumber detects if a json.Number is an integer or a decimal and converts it to the appropriate type.
+//
+// Supported type conversions:
+// - json.Number -> int64
+// - json.Number -> float64 -> decimal.Decimal
 func convertNumber(el any) (any, error) {
 	switch elv := el.(type) {
 	case json.Number:
@@ -164,7 +194,7 @@ func (m mapping) MarshalJSON() ([]byte, error) {
 // stepDefinitionYaml is the YAML representation of a step in a workflow.
 //
 // It allows for multiple ways of defining a step, which we later
-// convert to a single representation, `stepDefinition`.
+// convert to a single representation, `StepDefinition`.
 type stepDefinitionYaml struct {
 	// A universally unique name for a capability will be defined under the “id” property. The uniqueness will, eventually, be enforced in the Capability Registry.
 	//
@@ -244,9 +274,9 @@ type stepDefinitionYaml struct {
 	Config mapping `json:"config" jsonschema:"required"`
 }
 
-// toStepDefinition converts a stepDefinitionYaml to a stepDefinition.
+// toStepDefinition converts a stepDefinitionYaml to a StepDefinition.
 //
-// `stepDefinition` is the converged representation of a step in a workflow.
+// `StepDefinition` is the converged representation of a step in a workflow.
 func (s stepDefinitionYaml) toStepDefinition() StepDefinition {
 	return StepDefinition{
 		Ref:    s.Ref,
@@ -256,7 +286,7 @@ func (s stepDefinitionYaml) toStepDefinition() StepDefinition {
 	}
 }
 
-// stepDefinitionID represents both the string and table representations of the "id" field in a stepDefinition.
+// stepDefinitionID represents both the string and table representations of the "id" field in a StepDefinition.
 type stepDefinitionID struct {
 	idStr   string
 	idTable *stepDefinitionTableID
@@ -279,7 +309,7 @@ func (s *stepDefinitionID) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// If the JSON data is a table, unmarshal it into a stepDefinitionTableID
+	// If the JSON data is a table, unmarshal it into a StepDefinitionTableID
 	var table stepDefinitionTableID
 	err = json.Unmarshal(data, &table)
 	if err != nil {
@@ -302,9 +332,15 @@ func (s *stepDefinitionID) MarshalJSON() ([]byte, error) {
 // The schema is a oneOf schema that allows either a string or a table.
 func (stepDefinitionID) JSONSchema() *jsonschema.Schema {
 	reflector := jsonschema.Reflector{DoNotReference: true, ExpandedStruct: true}
-	tableSchema := reflector.Reflect(&stepDefinitionTableID{})
+	tableSchema := reflector.Reflect(&StepDefinitionTableID{})
 	stringSchema := &jsonschema.Schema{
-		ID:      "string",
+		ID: "string",
+		// Allow for a-z, 0-9, _, -, and : characters as the capability type, follwed by a semver regex allowing only major versions.
+		//
+		// Prereleases and build metadata are also allowed
+		//
+		// Ex. read_chain:chain_ethereum:network_mainnet@1
+		// Ex. read_chain:chain_ethereum:network_mainnet@1-rc1.1+build1
 		Pattern: "^[a-z0-9_\\-:]+@(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
 	}
 
@@ -319,12 +355,15 @@ func (stepDefinitionID) JSONSchema() *jsonschema.Schema {
 
 // stepDefinitionTableID is the structured representation of a stepDefinitionID.
 type stepDefinitionTableID struct {
-	Name    string            `json:"name"`
+	Name string `json:"name"`
+	// Version is a semver supporting only major versions.
+	//
+	// Prereleases and build metadata are also allowed
 	Version string            `json:"version" jsonschema:"pattern=(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"`
 	Labels  map[string]string `json:"labels"`
 }
 
-// String returns the string representation of a stepDefinitionTableID.
+// String returns the string representation of a StepDefinitionTableID.
 //
 // It follows the format:
 //

--- a/pkg/workflows/models_yaml_test.go
+++ b/pkg/workflows/models_yaml_test.go
@@ -176,7 +176,7 @@ func TestJsonSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		// change this to update golden file
-		shouldUpdateSchema := true
+		shouldUpdateSchema := false
 		if shouldUpdateSchema {
 			err = os.WriteFile(expectedSchemaPath, generatedSchema, 0600)
 			require.NoError(t, err)

--- a/pkg/workflows/models_yaml_test.go
+++ b/pkg/workflows/models_yaml_test.go
@@ -176,7 +176,7 @@ func TestJsonSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		// change this to update golden file
-		shouldUpdateSchema := false
+		shouldUpdateSchema := true
 		if shouldUpdateSchema {
 			err = os.WriteFile(expectedSchemaPath, generatedSchema, 0600)
 			require.NoError(t, err)
@@ -195,12 +195,11 @@ func TestJsonSchema(t *testing.T) {
 		generatedSchema, err := GenerateJSONSchema()
 		require.NoError(t, err)
 
-		// test version regex
-		// for keystone, we should support major versions only along with prereleases and build metadata
 		t.Run("version", func(t *testing.T) {
 			readVersionFixture := yamlFixtureReaderObj(t, "versioning")
 			failingFixture1 := readVersionFixture("failing_1")
 			failingFixture2 := readVersionFixture("failing_2")
+			failingFixture3 := readVersionFixture("failing_3")
 			passingFixture1 := readVersionFixture("passing_1")
 			jsonSchema, err := jsonschema.CompileString("github.com/smartcontractkit/chainlink", string(generatedSchema))
 			require.NoError(t, err)
@@ -209,6 +208,9 @@ func TestJsonSchema(t *testing.T) {
 			require.Error(t, err)
 
 			err = jsonSchema.Validate(failingFixture2)
+			require.Error(t, err)
+
+			err = jsonSchema.Validate(failingFixture3)
 			require.Error(t, err)
 
 			err = jsonSchema.Validate(passingFixture1)

--- a/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_1.yaml
@@ -1,5 +1,5 @@
  triggers:
-   - id: mercury-trigger@1
+   - id: mercury-trigger@1.0.0
      ref: report_data
      config:
        boolean_coercion:
@@ -54,7 +54,7 @@
  # no actions
 
  consensus:
-   - id: offchain_reporting@1
+   - id: offchain_reporting@1.0.0
      inputs:
        observations:
          - triggers.report_data.outputs
@@ -76,7 +76,7 @@
            abi: "mercury_reports bytes[]"
 
  targets:
-   - id: write_polygon_mainnet@1
+   - id: write_polygon_mainnet@1.0.0
      inputs:
        report:
          - consensus.evm_median.outputs.report

--- a/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2.yaml
@@ -1,5 +1,5 @@
  triggers:
-   - id: on_mercury_report@1
+   - id: on_mercury_report@1.0.0
      ref: report_data
      config: {}
 
@@ -8,7 +8,7 @@
  consensus:
    - id: 
       name: trigger_test
-      version: "2"
+      version: "2.0.0"
       labels:
         chain: ethereum
         aaShouldBeFirst: "true"
@@ -19,7 +19,7 @@
          - triggers.report_data.outputs
 
  targets:
-   - id: write_polygon_mainnet@1
+   - id: write_polygon_mainnet@1.0.0
      config: {}
      inputs:
        report:

--- a/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2_spec.json
+++ b/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2_spec.json
@@ -1,14 +1,14 @@
 {
   "triggers": [
     {
-      "id": "on_mercury_report@1",
+      "id": "on_mercury_report@1.0.0",
       "ref": "report_data",
       "config": {}
     }
   ],
   "consensus": [
     {
-      "id": "trigger_test:aaShouldBeFirst_true:chain_ethereum:network_mainnet@2",
+      "id": "trigger_test:aaShouldBeFirst_true:chain_ethereum:network_mainnet@2.0.0",
       "inputs": {
         "observations": [
           "triggers.report_data.outputs"
@@ -19,7 +19,7 @@
   ],
   "targets": [
     {
-      "id": "write_polygon_mainnet@1",
+      "id": "write_polygon_mainnet@1.0.0",
       "inputs": {
         "report": [
           "consensus.evm_median.outputs.report"

--- a/pkg/workflows/testdata/fixtures/workflows/references/failing_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/references/failing_1.yaml
@@ -1,14 +1,14 @@
 triggers:
-- id: trigger_test@1
+- id: trigger_test@1.0.0
   config: {}
 
 consensus:
-  - id: offchain_reporting@1
+  - id: offchain_reporting@1.0.0
     ref: offchain_reporting=1
     config: {}
 
 targets:
-  - id: write_polygon_mainnet@1
+  - id: write_polygon_mainnet@1.0.0
     ref: write_polygon_mainnet_1 
     config: {}
 

--- a/pkg/workflows/testdata/fixtures/workflows/references/passing_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/references/passing_1.yaml
@@ -1,14 +1,14 @@
 triggers:
-- id: trigger_test@1
+- id: trigger_test@1.0.0
   config: {}
 
 consensus:
-  - id: offchain_reporting@1
+  - id: offchain_reporting@1.0.0
     ref: offchain_reporting_1
     config: {}
 
 targets:
-  - id: write_polygon_mainnet@1
+  - id: write_polygon_mainnet@1.0.0
     ref: write_polygon_mainnet_1 
     config: {}
 

--- a/pkg/workflows/testdata/fixtures/workflows/versioning/failing_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/versioning/failing_1.yaml
@@ -1,4 +1,3 @@
-# Should fail since version is more specific than major
 triggers:
   - id: trigger_test@1.0
     config: {}
@@ -9,7 +8,7 @@ consensus:
      config: {}
 
 targets:
-   - id: write_polygon_mainnet@1
+   - id: write_polygon_mainnet@1.0.0
      ref: write_polygon_mainnet_1 
      config: {}
 

--- a/pkg/workflows/testdata/fixtures/workflows/versioning/failing_2.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/versioning/failing_2.yaml
@@ -1,16 +1,15 @@
 
-# Should fail since version is more specific than major
 triggers:
-  - id: trigger_test@1.0.0
+  - id: trigger_test@1
     config: {}
 
 consensus:
-   - id: offchain_reporting@1
+   - id: offchain_reporting@1.0
      ref: offchain_reporting_1
      config: {}
 
 targets:
-   - id: write_polygon_mainnet@1
+   - id: write_polygon_mainnet@1.0.0
      ref: write_polygon_mainnet_1 
      config: {}
 

--- a/pkg/workflows/testdata/fixtures/workflows/versioning/failing_3.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/versioning/failing_3.yaml
@@ -1,0 +1,18 @@
+triggers:
+  - id: trigger_test@1.0.0
+    config: {}
+
+consensus:
+  - id:
+      version: "1.0" 
+      name: asdfas
+      labels:
+        - key: value
+    ref: offchain_reporting_1
+    config: {}
+
+targets:
+  - id: write_polygon_mainnet@1.0.0-alpha+sha246er3
+    ref: write_polygon_mainnet_1
+    config: {}
+# yaml-language-server: $schema=../workflow_schema.json

--- a/pkg/workflows/testdata/fixtures/workflows/versioning/passing_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/versioning/passing_1.yaml
@@ -1,14 +1,20 @@
  triggers:
-  - id: trigger_test@1
+  - id: trigger_test@1.0.0
     config: {}
   
  consensus:
-   - id: offchain_reporting@1-beta.1
+   - id: offchain_reporting@1.0.0-beta.1
      ref: offchain_reporting_1
      config: {}
-
+   - id:
+      version: "1.0.0" 
+      name: asdfas
+      labels:
+        key: value
+     ref: offchain_reporting_1
+     config: {}
  targets:
-   - id: write_polygon_mainnet@1-alpha+sha246er3
+   - id: write_polygon_mainnet@1.0.0-alpha+sha246er3
      ref: write_polygon_mainnet_1 
      config: {}
 

--- a/pkg/workflows/testdata/fixtures/workflows/workflow_schema.json
+++ b/pkg/workflows/testdata/fixtures/workflows/workflow_schema.json
@@ -9,19 +9,17 @@
     "stepDefinitionID": {
       "oneOf": [
         {
-          "$id": "string",
-          "pattern": "^[a-z0-9_\\-:]+@(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+          "type": "string",
+          "pattern": "^[a-z0-9_\\-:]+@(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
         },
         {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "$id": "https://github.com/smartcontractkit/chainlink-common/pkg/workflows/step-definition-table-id",
           "properties": {
             "name": {
               "type": "string"
             },
             "version": {
               "type": "string",
-              "pattern": "(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+              "pattern": "(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
             },
             "labels": {
               "additionalProperties": {


### PR DESCRIPTION
This PR contains the following changes:
- Workflow definitions now enforce that a full capability semver must be specified. No version ranges are allowed.
- Validation for workflow YAMLs is now enabled.
- The `CapabilityInfo` struct now embeds the version as part of the ID itself, rather than having it as a separate field.

Related PR: https://github.com/smartcontractkit/chainlink/pull/13328