### PR TITLE
types: Modify ChainWriter's args param to not be a slice

### DIFF
--- a/pkg/types/chain_writer.go
+++ b/pkg/types/chain_writer.go
@@ -12,7 +12,7 @@ type ChainWriter interface {
 	//
 	// - `args` specifies input parameters to the contract call.
 	// - `transactionID` will be used by the underlying TXM as an idempotency key, and unique reference to track transaction attempts.
-	SubmitTransaction(ctx context.Context, contractName, method string, args []any, transactionID uuid.UUID, toAddress string, meta *TxMeta, value big.Int) error
+	SubmitTransaction(ctx context.Context, contractName, method string, args any, transactionID uuid.UUID, toAddress string, meta *TxMeta, value big.Int) error
 
 	// GetTransactionStatus returns the current status of a transaction in the underlying chain's TXM.
 	GetTransactionStatus(ctx context.Context, transactionID uuid.UUID) (TransactionStatus, error)


### PR DESCRIPTION
Refactor the `ChainWriter`'s `args` parameter to be `any` instead of `[]any`. This is is because neither `ChainWriter` nor the `codec` package can know the order in which the arguments are passed in, in order to map the fields to those of the ABI.
