### PR TITLE
[KS-241] Include report ID in transmitter outputs

### DIFF
--- a/pkg/capabilities/consensus/ocr3/capability.go
+++ b/pkg/capabilities/consensus/ocr3/capability.go
@@ -21,6 +21,7 @@ const (
 	methodStartRequest = "start_request"
 	methodSendResponse = "send_response"
 	methodHeader       = "method"
+	transmissionHeader = "transmission"
 )
 
 var info = capabilities.MustNewCapabilityInfo(
@@ -155,7 +156,8 @@ func (o *capability) UnregisterFromWorkflow(ctx context.Context, request capabil
 // registry and calls Execute with the response, setting "method = `methodSendResponse`".
 func (o *capability) Execute(ctx context.Context, r capabilities.CapabilityRequest) (<-chan capabilities.CapabilityResponse, error) {
 	m := struct {
-		Method string
+		Method       string
+		Transmission map[string]any
 	}{
 		Method: methodStartRequest,
 	}
@@ -166,18 +168,7 @@ func (o *capability) Execute(ctx context.Context, r capabilities.CapabilityReque
 
 	switch m.Method {
 	case methodSendResponse:
-		unwrapped, err := r.Inputs.Unwrap()
-		if err != nil {
-			return nil, fmt.Errorf("failed to unwrap response inputs: %w", err)
-		}
-
-		withoutHeader := map[string]any{}
-		for k, v := range unwrapped.(map[string]any) {
-			if k != methodHeader {
-				withoutHeader[k] = v
-			}
-		}
-		inputs, err := values.NewMap(withoutHeader)
+		inputs, err := values.NewMap(m.Transmission)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create map for response inputs: %w", err)
 		}

--- a/pkg/capabilities/consensus/ocr3/reporting_plugin.go
+++ b/pkg/capabilities/consensus/ocr3/reporting_plugin.go
@@ -244,14 +244,15 @@ func (r *reportingPlugin) Reports(seqNr uint64, outcome ocr3types.Outcome) ([]oc
 		var report []byte
 		if info.ShouldReport {
 			meta := &pbtypes.Metadata{
-				Version:       1,
-				ExecutionID:   id.WorkflowExecutionId,
-				Timestamp:     0, // TODO include timestamp in consensus phase
-				DONID:         id.WorkflowDonId,
-				WorkflowID:    id.WorkflowId,
-				WorkflowName:  id.WorkflowName,
-				WorkflowOwner: id.WorkflowOwner,
-				ReportID:      id.ReportId,
+				Version:          1,
+				ExecutionID:      id.WorkflowExecutionId,
+				Timestamp:        0, // TODO include timestamp in consensus phase
+				DONID:            id.WorkflowDonId,
+				DONConfigVersion: 0, // TODO include when Syncer is ready
+				WorkflowID:       id.WorkflowId,
+				WorkflowName:     id.WorkflowName,
+				WorkflowOwner:    id.WorkflowOwner,
+				ReportID:         id.ReportId,
 			}
 			newOutcome, err := pbtypes.AppendMetadata(outcome, meta)
 			if err != nil {

--- a/pkg/capabilities/consensus/ocr3/reporting_plugin_test.go
+++ b/pkg/capabilities/consensus/ocr3/reporting_plugin_test.go
@@ -347,14 +347,15 @@ func TestReportingPlugin_Reports_ShouldReportTrue(t *testing.T) {
 
 	// The workflow ID and execution ID get added to the report.
 	nm.Underlying[pbtypes.MetadataFieldName], err = values.NewMap(map[string]any{
-		"Version":       1,
-		"ExecutionID":   weid,
-		"Timestamp":     0,
-		"DONID":         donId,
-		"WorkflowID":    workflowTestID,
-		"WorkflowName":  workflowTestName,
-		"WorkflowOwner": wowner,
-		"ReportID":      reportTestId,
+		"Version":          1,
+		"ExecutionID":      weid,
+		"Timestamp":        0,
+		"DONID":            donId,
+		"DONConfigVersion": 0,
+		"WorkflowID":       workflowTestID,
+		"WorkflowName":     workflowTestName,
+		"WorkflowOwner":    wowner,
+		"ReportID":         reportTestId,
 	})
 	require.NoError(t, err)
 	fp := values.FromProto(rep)

--- a/pkg/capabilities/consensus/ocr3/types/aggregator.go
+++ b/pkg/capabilities/consensus/ocr3/types/aggregator.go
@@ -10,14 +10,15 @@ import (
 const MetadataFieldName = "INTERNAL_METADATA"
 
 type Metadata struct {
-	Version       uint32 // 1 byte
-	ExecutionID   string // 32 hex bytes
-	Timestamp     uint32 //  4 bytes
-	DONID         string //  4 hex bytes
-	WorkflowID    string // 32 hex bytes
-	WorkflowName  string // 10 hex bytes
-	WorkflowOwner string // 20 hex bytes
-	ReportID      string //  2 hex bytes
+	Version          uint32 //  1 byte
+	ExecutionID      string // 32 hex bytes
+	Timestamp        uint32 //  4 bytes
+	DONID            string //  4 hex bytes
+	DONConfigVersion uint32 //  4 bytes
+	WorkflowID       string // 32 hex bytes
+	WorkflowName     string // 10 hex bytes
+	WorkflowOwner    string // 20 hex bytes
+	ReportID         string //  2 hex bytes
 }
 
 type Aggregator interface {

--- a/pkg/capabilities/consensus/ocr3/types/encoder.go
+++ b/pkg/capabilities/consensus/ocr3/types/encoder.go
@@ -11,3 +11,15 @@ type Encoder interface {
 }
 
 type EncoderFactory func(config *values.Map) (Encoder, error)
+
+type SignedReport struct {
+	Report []byte
+	// Report context is appended to the report before signing by libOCR.
+	// It contains config digest + round/epoch/sequence numbers (currently 96 bytes).
+	// Has to be appended to the report before validating signatures.
+	Context []byte
+	// Always exactly F+1 signatures.
+	Signatures [][]byte
+	// Report ID defined in the workflow spec (2 bytes).
+	ID []byte
+}


### PR DESCRIPTION
1. Pass report ID.
2. Add a type for convenient unwrapping.
3. Extend Metadata with missing DONConfigVersion (set to zero for now).