### PR TITLE
KS 318 - name owner in wf yaml

### DIFF
--- a/pkg/capabilities/consensus/ocr3/types/aggregator.go
+++ b/pkg/capabilities/consensus/ocr3/types/aggregator.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"strings"
+
 	ocrcommon "github.com/smartcontractkit/libocr/commontypes"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -21,6 +23,16 @@ type Metadata struct {
 	ReportID         string //  2 hex bytes
 }
 
+// the contract requires exactly 10 bytes for the workflow name
+// the json schema allows for a variable length string <= len(10)
+// pad with trailing spaces to meet the contract requirements
+func (m *Metadata) padWorkflowName() {
+	if len(m.WorkflowName) < 10 {
+		suffix := strings.Repeat(" ", 10-len(m.WorkflowName))
+		m.WorkflowName += suffix
+	}
+}
+
 type Aggregator interface {
 	// Called by the Outcome() phase of OCR reporting.
 	// The inner array of observations corresponds to elements listed in "inputs.observations" section.
@@ -28,6 +40,7 @@ type Aggregator interface {
 }
 
 func AppendMetadata(outcome *AggregationOutcome, meta *Metadata) (*AggregationOutcome, error) {
+	meta.padWorkflowName()
 	metaWrapped, err := values.Wrap(meta)
 	if err != nil {
 		return nil, err

--- a/pkg/capabilities/consensus/ocr3/types/aggregator_test.go
+++ b/pkg/capabilities/consensus/ocr3/types/aggregator_test.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetadata_padWorkflowName(t *testing.T) {
+	type fields struct {
+		WorkflowName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "padWorkflowName 1",
+			fields: fields{
+				WorkflowName: "123456789",
+			},
+			want: "123456789 ",
+		},
+		{
+			name: "padWorkflowName 0",
+			fields: fields{
+				WorkflowName: "1234567890",
+			},
+			want: "1234567890",
+		},
+		{
+			name: "padWorkflowName 10",
+			fields: fields{
+				WorkflowName: "",
+			},
+			want: "          ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Metadata{
+				WorkflowName: tt.fields.WorkflowName,
+			}
+			m.padWorkflowName()
+			assert.Equal(t, tt.want, m.WorkflowName, tt.name)
+		})
+	}
+}

--- a/pkg/workflows/dependency_graph.go
+++ b/pkg/workflows/dependency_graph.go
@@ -29,6 +29,9 @@ type StepDefinition struct {
 
 // WorkflowSpec is the parsed representation of a workflow.
 type WorkflowSpec struct {
+	CID       string           `json:"cid" jsonschema:"required"` // content of the original workflow yaml spec
+	Name      string           `json:"name,omitempty"`
+	Owner     string           `json:"owner,,omitempty"`
 	Triggers  []StepDefinition `json:"triggers" jsonschema:"required"`
 	Actions   []StepDefinition `json:"actions,omitempty"`
 	Consensus []StepDefinition `json:"consensus" jsonschema:"required"`

--- a/pkg/workflows/dependency_graph.go
+++ b/pkg/workflows/dependency_graph.go
@@ -30,8 +30,8 @@ type StepDefinition struct {
 // WorkflowSpec is the parsed representation of a workflow.
 type WorkflowSpec struct {
 	CID       string           `json:"cid" jsonschema:"required"` // content of the original workflow yaml spec
-	Name      string           `json:"name,omitempty"`
-	Owner     string           `json:"owner,,omitempty"`
+	Name      string           `json:"name,omitempty"`            // empty name allowed for anonymous workflows
+	Owner     string           `json:"owner,omitempty"`           // empty owner allowed for anonymous workflows
 	Triggers  []StepDefinition `json:"triggers" jsonschema:"required"`
 	Actions   []StepDefinition `json:"actions,omitempty"`
 	Consensus []StepDefinition `json:"consensus" jsonschema:"required"`

--- a/pkg/workflows/dependency_graph_test.go
+++ b/pkg/workflows/dependency_graph_test.go
@@ -20,6 +20,8 @@ func TestParseDependencyGraph(t *testing.T) {
 		{
 			name: "basic example",
 			yaml: `
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567      
 triggers:
   - id: "a-trigger@1.0.0"
     config: {}
@@ -63,6 +65,8 @@ targets:
 		{
 			name: "circular relationship",
 			yaml: `
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567  
 triggers:
   - id: "a-trigger@1.0.0"
     config: {}
@@ -100,6 +104,8 @@ targets:
 		{
 			name: "indirect circular relationship",
 			yaml: `
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567  
 triggers:
   - id: "a-trigger@1.0.0"
     config: {}
@@ -142,6 +148,8 @@ targets:
 		{
 			name: "relationship doesn't exist",
 			yaml: `
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567  
 triggers:
   - id: "a-trigger@1.0.0"
     config: {}
@@ -173,6 +181,8 @@ targets:
 		{
 			name: "two trigger nodes",
 			yaml: `
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567  
 triggers:
   - id: "a-trigger@1.0.0"
     config: {}
@@ -216,6 +226,8 @@ targets:
 		{
 			name: "non-trigger step with no dependent refs",
 			yaml: `
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567  
 triggers:
   - id: "a-trigger@1.0.0"
     config: {}
@@ -246,6 +258,8 @@ targets:
 		{
 			name: "duplicate refs in a step",
 			yaml: `
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567  
 triggers:
   - id: "a-trigger@1.0.0"
     config: {}

--- a/pkg/workflows/models_yaml.go
+++ b/pkg/workflows/models_yaml.go
@@ -117,6 +117,8 @@ func (w workflowSpecYaml) toWorkflowSpec() WorkflowSpec {
 		Consensus: consensus,
 		Targets:   targets,
 		CID:       w.cid,
+		Name:      w.Name,
+		Owner:     w.Owner,
 	}
 }
 

--- a/pkg/workflows/models_yaml.go
+++ b/pkg/workflows/models_yaml.go
@@ -62,9 +62,9 @@ func ParseWorkflowSpecYaml(data string) (WorkflowSpec, error) {
 // It allows for multiple ways of defining a workflow spec, which we later
 // convert to a single representation, `WorkflowSpec`.
 type workflowSpecYaml struct {
-	Name string `json:"name,omitempty" jsonschema:"minLength=10,maxLength=10"` // plain text string
+	Name string `json:"name,omitempty" jsonschema:"minLength=10,maxLength=10"` // plain text string exactly 10 characters long, or  empty name allowed for anonymous workflows
 	//Name nameYaml `json:"name"`
-	Owner string `json:"owner,omitempty" jsonschema:"pattern=^0x[0-9a-f]{40}$"` // 20 bytes represented as hex string with 0x prefix
+	Owner string `json:"owner,omitempty" jsonschema:"pattern=^0x[0-9a-f]{40}$"` // 20 bytes represented as hex string with 0x prefix, or empty owner allowed for anonymous workflows
 	// Triggers define a starting condition for the workflow, based on specific events or conditions.
 	Triggers []stepDefinitionYaml `json:"triggers" jsonschema:"required"`
 	// Actions represent a discrete operation within the workflow, potentially transforming input data.
@@ -390,5 +390,3 @@ func (s stepDefinitionTableID) String() string {
 
 	return fmt.Sprintf("%s:%s@%s", s.Name, strings.Join(labels, ":"), s.Version)
 }
-
-type nameYaml string

--- a/pkg/workflows/models_yaml.go
+++ b/pkg/workflows/models_yaml.go
@@ -62,9 +62,11 @@ func ParseWorkflowSpecYaml(data string) (WorkflowSpec, error) {
 // It allows for multiple ways of defining a workflow spec, which we later
 // convert to a single representation, `WorkflowSpec`.
 type workflowSpecYaml struct {
-	Name string `json:"name,omitempty" jsonschema:"minLength=10,maxLength=10"` // plain text string exactly 10 characters long, or  empty name allowed for anonymous workflows
+	// NOTE: Name and Owner are constrained the onchain representation in [github.com/smartcontractkit/chainlink-common/blob/main/pkg/capabilities/consensus/ocr3/types/Metadata]
+
+	Name string `json:"name,omitempty" jsonschema:"pattern=^[0-9A-Za-z_\\-]+$,maxLength=10"` // plain text string exactly 10 characters long, or  empty name allowed for anonymous workflows
 	//Name nameYaml `json:"name"`
-	Owner string `json:"owner,omitempty" jsonschema:"pattern=^0x[0-9a-f]{40}$"` // 20 bytes represented as hex string with 0x prefix, or empty owner allowed for anonymous workflows
+	Owner string `json:"owner,omitempty" jsonschema:"pattern=^0x[0-9a-fA-F]{40}$"` // 20 bytes represented as hex string with 0x prefix, or empty owner allowed for anonymous workflows
 	// Triggers define a starting condition for the workflow, based on specific events or conditions.
 	Triggers []stepDefinitionYaml `json:"triggers" jsonschema:"required"`
 	// Actions represent a discrete operation within the workflow, potentially transforming input data.

--- a/pkg/workflows/models_yaml_test.go
+++ b/pkg/workflows/models_yaml_test.go
@@ -27,7 +27,6 @@ func yamlFixtureReaderObj(t *testing.T, testCase string) func(name string) any {
 		var testFileYaml any
 		err := yaml.Unmarshal(testFileBytes, &testFileYaml)
 		require.NoError(t, err)
-		fmt.Sprintf("%s", &testFileBytes)
 		return testFileYaml
 	}
 }
@@ -163,11 +162,9 @@ func TestWorkflowSpecMarshalling(t *testing.T) {
 			t.FailNow()
 		}
 	})
-
 }
 
 func TestJsonSchema(t *testing.T) {
-
 	t.Parallel()
 	t.Run("GenerateJsonSchema", func(t *testing.T) {
 		expectedSchemaPath := fixtureDir + "workflow_schema.json"
@@ -300,7 +297,6 @@ func TestJsonSchema(t *testing.T) {
 			})
 		}
 	})
-
 }
 
 func TestMappingCustomType(t *testing.T) {

--- a/pkg/workflows/models_yaml_test.go
+++ b/pkg/workflows/models_yaml_test.go
@@ -245,14 +245,19 @@ func TestJsonSchema(t *testing.T) {
 				owner: "0x0123456789abcdef0123456789abcdef01234567",
 			},
 			{
-				testName: "invalid: name to long",
-				name:     "more than ten digits",
+				testName: "valid: short name",
+				name:     "abc",
+				owner:    "0x0123456789abcdef0123456789abcdef01234567",
+			},
+			{
+				testName: "invalid: name too long",
+				name:     "wf_name_too_long_for_schema_validation",
 				owner:    "0x0123456789abcdef0123456789abcdef01234567",
 				wantErr:  true,
 			},
 			{
-				testName: "invalid: name to short",
-				name:     "only_nine",
+				testName: "invalid: name characters",
+				name:     "abc def",
 				owner:    "0x0123456789abcdef0123456789abcdef01234567",
 				wantErr:  true,
 			},
@@ -260,6 +265,11 @@ func TestJsonSchema(t *testing.T) {
 				testName: "valid: no owner",
 				name:     "ten_digits",
 				// the helper function will omit the owner field, which not the same as an empty string for an owner
+			},
+			{
+				testName: "valid: capital letters",
+				name:     "ten_digits",
+				owner:    "0x0123456789ABCDEF0123456789ABCDEF01234567",
 			},
 			{
 				testName: "invalid: owner too short",

--- a/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_1.yaml
@@ -1,3 +1,5 @@
+ name: length_ten # exactly 10 characters
+ owner: 0x0123456789abcdef0123456789abcdef01234567
  triggers:
    - id: mercury-trigger@1.0.0
      ref: report_data

--- a/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2.yaml
@@ -1,3 +1,5 @@
+ name: length_ten # exactly 10 characters
+ owner: 0x0123456789abcdef0123456789abcdef01234567
  triggers:
    - id: on_mercury_report@1.0.0
      ref: report_data

--- a/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2_spec.json
+++ b/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2_spec.json
@@ -1,5 +1,7 @@
 {
   "cid": "dd270cfbd7a3b1b64df7de4e10ff9307f9ce298fffece4c5897924084e812992",
+  "name": "length_ten",
+  "owner": "0x0123456789abcdef0123456789abcdef01234567",
   "triggers": [
     {
       "id": "on_mercury_report@1.0.0",

--- a/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2_spec.json
+++ b/pkg/workflows/testdata/fixtures/workflows/marshalling/workflow_2_spec.json
@@ -1,4 +1,5 @@
 {
+  "cid": "dd270cfbd7a3b1b64df7de4e10ff9307f9ce298fffece4c5897924084e812992",
   "triggers": [
     {
       "id": "on_mercury_report@1.0.0",

--- a/pkg/workflows/testdata/fixtures/workflows/references/failing_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/references/failing_1.yaml
@@ -1,3 +1,5 @@
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567
 triggers:
 - id: trigger_test@1.0.0
   config: {}

--- a/pkg/workflows/testdata/fixtures/workflows/references/passing_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/references/passing_1.yaml
@@ -1,3 +1,5 @@
+name: wf_name_00 # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567
 triggers:
 - id: trigger_test@1.0.0
   config: {}

--- a/pkg/workflows/testdata/fixtures/workflows/versioning/failing_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/versioning/failing_1.yaml
@@ -1,3 +1,5 @@
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567
 triggers:
   - id: trigger_test@1.0
     config: {}

--- a/pkg/workflows/testdata/fixtures/workflows/versioning/failing_2.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/versioning/failing_2.yaml
@@ -1,4 +1,5 @@
-
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567
 triggers:
   - id: trigger_test@1
     config: {}

--- a/pkg/workflows/testdata/fixtures/workflows/versioning/failing_3.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/versioning/failing_3.yaml
@@ -1,3 +1,5 @@
+name: length_ten # exactly 10 characters
+owner: 0x0123456789abcdef0123456789abcdef01234567
 triggers:
   - id: trigger_test@1.0.0
     config: {}

--- a/pkg/workflows/testdata/fixtures/workflows/versioning/passing_1.yaml
+++ b/pkg/workflows/testdata/fixtures/workflows/versioning/passing_1.yaml
@@ -1,3 +1,5 @@
+ name: length_ten # exactly 10 characters
+ owner: 0x0123456789abcdef0123456789abcdef01234567
  triggers:
   - id: trigger_test@1.0.0
     config: {}

--- a/pkg/workflows/testdata/fixtures/workflows/workflow_schema.json
+++ b/pkg/workflows/testdata/fixtures/workflows/workflow_schema.json
@@ -67,11 +67,11 @@
         "name": {
           "type": "string",
           "maxLength": 10,
-          "minLength": 10
+          "pattern": "^[0-9A-Za-z_\\-]+$"
         },
         "owner": {
           "type": "string",
-          "pattern": "^0x[0-9a-f]{40}$"
+          "pattern": "^0x[0-9a-fA-F]{40}$"
         },
         "triggers": {
           "items": {

--- a/pkg/workflows/testdata/fixtures/workflows/workflow_schema.json
+++ b/pkg/workflows/testdata/fixtures/workflows/workflow_schema.json
@@ -64,6 +64,15 @@
     },
     "workflowSpecYaml": {
       "properties": {
+        "name": {
+          "type": "string",
+          "maxLength": 10,
+          "minLength": 10
+        },
+        "owner": {
+          "type": "string",
+          "pattern": "^0x[0-9a-f]{40}$"
+        },
         "triggers": {
           "items": {
             "$ref": "#/$defs/stepDefinitionYaml"

--- a/pkg/workflows/testutils.go
+++ b/pkg/workflows/testutils.go
@@ -1,0 +1,46 @@
+package workflows
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+)
+
+// WFYamlSpec generates a validate yaml spec for a workflow for the given name and owner
+func WFYamlSpec(t *testing.T, name, owner string) string {
+	t.Helper()
+	// we use a template to generate the yaml spec so that we can omitting the name and owner fields as needed
+	var wfTmpl = `
+{{if .Name}}
+name: {{.Name}}
+{{end}}
+{{if .Owner}}
+owner: {{.Owner}}
+{{end}}
+triggers:
+- id: trigger_test@1.0.0
+  config: {}
+
+consensus:
+  - id: offchain_reporting@1.0.0
+    ref: offchain_reporting_1
+    config: {}
+
+targets:
+  - id: write_polygon_mainnet@1.0.0
+    ref: write_polygon_mainnet_1 
+    config: {}
+`
+	type cfg struct {
+		Name, Owner string
+	}
+	c := cfg{Name: name, Owner: owner}
+
+	tm := template.Must(template.New("yaml").Parse(wfTmpl))
+
+	buf := new(bytes.Buffer)
+	require.NoError(t, tm.Execute(buf, c))
+	return buf.String()
+}


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/KS-318

Moves the name and owner fields into the YAML spec.
- adds validation via jsonschema

Adds CID (content hash), name and owner to the parse WorkflowSpec struct
- this enables reuse of validation logic in both core and clo


Supports:
- https://github.com/smartcontractkit/chainlink/pull/13522
