### PR TITLE
ChainReader Loop Interface Test Matrix

### DIFF
--- a/pkg/loop/internal/relayer/pluginprovider/chainreader/chain_reader_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/chainreader/chain_reader_test.go
@@ -66,7 +66,7 @@ func TestVersionedBytesFunctions(t *testing.T) {
 func TestChainReaderInterfaceTests(t *testing.T) {
 	t.Parallel()
 
-	chainreadertest.LoopEncodingTestMatrix(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
+	chainreadertest.TestAllEncodings(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Parallel()
 
@@ -85,7 +85,7 @@ func TestChainReaderInterfaceTests(t *testing.T) {
 func TestBind(t *testing.T) {
 	t.Parallel()
 
-	chainreadertest.LoopEncodingTestMatrix(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
+	chainreadertest.TestAllEncodings(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Parallel()
 
@@ -113,7 +113,7 @@ func TestBind(t *testing.T) {
 func TestGetLatestValue(t *testing.T) {
 	t.Parallel()
 
-	chainreadertest.LoopEncodingTestMatrix(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
+	chainreadertest.TestAllEncodings(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Parallel()
 
@@ -162,7 +162,7 @@ func TestGetLatestValue(t *testing.T) {
 func TestQueryKey(t *testing.T) {
 	t.Parallel()
 
-	chainreadertest.LoopEncodingTestMatrix(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
+	chainreadertest.TestAllEncodings(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Parallel()
 
@@ -177,7 +177,6 @@ func TestQueryKey(t *testing.T) {
 			chainReader := errTester.GetChainReader(t)
 
 			t.Run("nil reader should return unimplemented", func(t *testing.T) {
-				t.Parallel()
 				ctx := tests.Context(t)
 
 				nilTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: nil})

--- a/pkg/loop/internal/relayer/pluginprovider/chainreader/chain_reader_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/chainreader/chain_reader_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/chainreader"
-	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/chainreader/test"
+	chainreadertest "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/chainreader/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
@@ -64,99 +64,148 @@ func TestVersionedBytesFunctions(t *testing.T) {
 }
 
 func TestChainReaderInterfaceTests(t *testing.T) {
-	fake := &fakeChainReader{}
-	RunChainReaderInterfaceTests(t, chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: fake}))
+	t.Parallel()
+
+	chainreadertest.LoopEncodingTestMatrix(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeChainReader{}
+			RunChainReaderInterfaceTests(
+				t,
+				chainreadertest.WrapChainReaderTesterForLoop(
+					&fakeChainReaderInterfaceTester{impl: fake},
+					chainreadertest.WithChainReaderLoopEncoding(version),
+				),
+			)
+		}
+	})
 }
 
 func TestBind(t *testing.T) {
-	es := &errChainReader{}
-	errTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: es})
-	errTester.Setup(t)
-	chainReader := errTester.GetChainReader(t)
+	t.Parallel()
 
-	for _, errorType := range errorTypes {
-		es.err = errorType
-		t.Run("Bind unwraps errors from server "+errorType.Error(), func(t *testing.T) {
-			ctx := tests.Context(t)
-			err := chainReader.Bind(ctx, []types.BoundContract{{Name: "Name", Address: "address"}})
-			assert.True(t, errors.Is(err, errorType))
-		})
-	}
+	chainreadertest.LoopEncodingTestMatrix(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Parallel()
+
+			es := &errChainReader{}
+			errTester := chainreadertest.WrapChainReaderTesterForLoop(
+				&fakeChainReaderInterfaceTester{impl: es},
+				chainreadertest.WithChainReaderLoopEncoding(version),
+			)
+
+			errTester.Setup(t)
+			chainReader := errTester.GetChainReader(t)
+
+			for _, errorType := range errorTypes {
+				es.err = errorType
+				t.Run("Bind unwraps errors from server "+errorType.Error(), func(t *testing.T) {
+					ctx := tests.Context(t)
+					err := chainReader.Bind(ctx, []types.BoundContract{{Name: "Name", Address: "address"}})
+					assert.True(t, errors.Is(err, errorType))
+				})
+			}
+		}
+	})
 }
 
 func TestGetLatestValue(t *testing.T) {
-	es := &errChainReader{}
-	errTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: es})
-	errTester.Setup(t)
-	chainReader := errTester.GetChainReader(t)
+	t.Parallel()
 
-	t.Run("nil reader should return unimplemented", func(t *testing.T) {
-		ctx := tests.Context(t)
+	chainreadertest.LoopEncodingTestMatrix(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Parallel()
 
-		nilTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: nil})
-		nilTester.Setup(t)
-		nilCr := nilTester.GetChainReader(t)
+			es := &errChainReader{}
+			errTester := chainreadertest.WrapChainReaderTesterForLoop(
+				&fakeChainReaderInterfaceTester{impl: es},
+				chainreadertest.WithChainReaderLoopEncoding(version),
+			)
 
-		err := nilCr.GetLatestValue(ctx, "", "method", "anything", "anything")
-		assert.Equal(t, codes.Unimplemented, status.Convert(err).Code())
-	})
+			errTester.Setup(t)
+			chainReader := errTester.GetChainReader(t)
 
-	for _, errorType := range errorTypes {
-		es.err = errorType
-		t.Run("GetLatestValue unwraps errors from server "+errorType.Error(), func(t *testing.T) {
-			ctx := tests.Context(t)
-			err := chainReader.GetLatestValue(ctx, "", "method", nil, "anything")
-			assert.True(t, errors.Is(err, errorType))
-		})
-	}
+			t.Run("nil reader should return unimplemented", func(t *testing.T) {
+				t.Parallel()
 
-	// make sure that errors come from client directly
-	es.err = nil
-	t.Run("GetLatestValue returns error if type cannot be encoded in the wire format", func(t *testing.T) {
-		ctx := tests.Context(t)
-		err := chainReader.GetLatestValue(ctx, "", "method", &cannotEncode{}, &TestStruct{})
-		assert.True(t, errors.Is(err, types.ErrInvalidType))
+				ctx := tests.Context(t)
+
+				nilTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: nil})
+				nilTester.Setup(t)
+				nilCr := nilTester.GetChainReader(t)
+
+				err := nilCr.GetLatestValue(ctx, "", "method", "anything", "anything")
+				assert.Equal(t, codes.Unimplemented, status.Convert(err).Code())
+			})
+
+			for _, errorType := range errorTypes {
+				es.err = errorType
+				t.Run("GetLatestValue unwraps errors from server "+errorType.Error(), func(t *testing.T) {
+					ctx := tests.Context(t)
+					err := chainReader.GetLatestValue(ctx, "", "method", nil, "anything")
+					assert.True(t, errors.Is(err, errorType))
+				})
+			}
+
+			// make sure that errors come from client directly
+			es.err = nil
+			t.Run("GetLatestValue returns error if type cannot be encoded in the wire format", func(t *testing.T) {
+				ctx := tests.Context(t)
+				err := chainReader.GetLatestValue(ctx, "", "method", &cannotEncode{}, &TestStruct{})
+				assert.True(t, errors.Is(err, types.ErrInvalidType))
+			})
+		}
 	})
 }
 
 func TestQueryKey(t *testing.T) {
-	impl := &protoConversionTestChainReader{}
-	crTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: impl})
-	crTester.Setup(t)
-	cr := crTester.GetChainReader(t)
+	t.Parallel()
 
-	es := &errChainReader{}
-	errTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: es})
-	errTester.Setup(t)
-	chainReader := errTester.GetChainReader(t)
+	chainreadertest.LoopEncodingTestMatrix(t, func(version chainreader.EncodingVersion) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("nil reader should return unimplemented", func(t *testing.T) {
-		ctx := tests.Context(t)
+			impl := &protoConversionTestChainReader{}
+			crTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: impl}, chainreadertest.WithChainReaderLoopEncoding(version))
+			crTester.Setup(t)
+			cr := crTester.GetChainReader(t)
 
-		nilTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: nil})
-		nilTester.Setup(t)
-		nilCr := nilTester.GetChainReader(t)
+			es := &errChainReader{}
+			errTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: es})
+			errTester.Setup(t)
+			chainReader := errTester.GetChainReader(t)
 
-		_, err := nilCr.QueryKey(ctx, "", query.KeyFilter{}, query.LimitAndSort{}, &[]interface{}{nil})
-		assert.Equal(t, codes.Unimplemented, status.Convert(err).Code())
-	})
+			t.Run("nil reader should return unimplemented", func(t *testing.T) {
+				t.Parallel()
+				ctx := tests.Context(t)
 
-	for _, errorType := range errorTypes {
-		es.err = errorType
-		t.Run("QueryKey unwraps errors from server "+errorType.Error(), func(t *testing.T) {
-			ctx := tests.Context(t)
-			_, err := chainReader.QueryKey(ctx, "", query.KeyFilter{}, query.LimitAndSort{}, &[]interface{}{nil})
-			assert.True(t, errors.Is(err, errorType))
-		})
-	}
+				nilTester := chainreadertest.WrapChainReaderTesterForLoop(&fakeChainReaderInterfaceTester{impl: nil})
+				nilTester.Setup(t)
+				nilCr := nilTester.GetChainReader(t)
 
-	t.Run("test QueryKey proto conversion", func(t *testing.T) {
-		for _, tc := range generateQueryFilterTestCases(t) {
-			impl.expectedQueryFilter = tc
-			filter, err := query.Where(tc.Key, tc.Expressions...)
-			require.NoError(t, err)
-			_, err = cr.QueryKey(tests.Context(t), "", filter, query.LimitAndSort{}, &[]interface{}{nil})
-			require.NoError(t, err)
+				_, err := nilCr.QueryKey(ctx, "", query.KeyFilter{}, query.LimitAndSort{}, &[]interface{}{nil})
+				assert.Equal(t, codes.Unimplemented, status.Convert(err).Code())
+			})
+
+			for _, errorType := range errorTypes {
+				es.err = errorType
+				t.Run("QueryKey unwraps errors from server "+errorType.Error(), func(t *testing.T) {
+					ctx := tests.Context(t)
+					_, err := chainReader.QueryKey(ctx, "", query.KeyFilter{}, query.LimitAndSort{}, &[]interface{}{nil})
+					assert.True(t, errors.Is(err, errorType))
+				})
+			}
+
+			t.Run("test QueryKey proto conversion", func(t *testing.T) {
+				for _, tc := range generateQueryFilterTestCases(t) {
+					impl.expectedQueryFilter = tc
+					filter, err := query.Where(tc.Key, tc.Expressions...)
+					require.NoError(t, err)
+					_, err = cr.QueryKey(tests.Context(t), "", filter, query.LimitAndSort{}, &[]interface{}{nil})
+					require.NoError(t, err)
+				}
+			})
 		}
 	})
 }

--- a/pkg/loop/internal/relayer/pluginprovider/chainreader/test/chain_reader_loop_tester.go
+++ b/pkg/loop/internal/relayer/pluginprovider/chainreader/test/chain_reader_loop_tester.go
@@ -8,33 +8,73 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/chainreader"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+
 	. "github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests" //nolint common practice to import test mods with .
 )
 
+func LoopEncodingTestMatrix(t *testing.T, test func(chainreader.EncodingVersion) func(t *testing.T)) {
+	t.Helper()
+
+	encodings := []struct {
+		Name    string
+		Version chainreader.EncodingVersion
+	}{
+		{Name: "JSONv1", Version: chainreader.JSONEncodingVersion1},
+		{Name: "JSONv2", Version: chainreader.JSONEncodingVersion2},
+		{Name: "CBOR", Version: chainreader.CBOREncodingVersion},
+	}
+
+	for idx := range encodings {
+		encoding := encodings[idx]
+
+		t.Run(encoding.Name, test(encoding.Version))
+	}
+}
+
+type LoopTesterOpt func(*contractReaderLoopTester)
+
 // WrapChainReaderTesterForLoop allows you to test a [types.ContractReader] implementation behind a LOOP server
-func WrapChainReaderTesterForLoop(wrapped ChainReaderInterfaceTester[*testing.T]) ChainReaderInterfaceTester[*testing.T] {
-	return &contractReaderLoopTester{ChainReaderInterfaceTester: wrapped}
+func WrapChainReaderTesterForLoop(wrapped ChainReaderInterfaceTester[*testing.T], opts ...LoopTesterOpt) ChainReaderInterfaceTester[*testing.T] {
+	tester := &contractReaderLoopTester{
+		ChainReaderInterfaceTester: wrapped,
+		encodeWith:                 chainreader.DefaultEncodingVersion,
+	}
+
+	for _, opt := range opts {
+		opt(tester)
+	}
+
+	return tester
+}
+
+func WithChainReaderLoopEncoding(version chainreader.EncodingVersion) LoopTesterOpt {
+	return func(tester *contractReaderLoopTester) {
+		tester.encodeWith = version
+	}
 }
 
 type contractReaderLoopTester struct {
 	ChainReaderInterfaceTester[*testing.T]
-	lst loopServerTester
+	lst        loopServerTester
+	encodeWith chainreader.EncodingVersion
 }
 
 func (c *contractReaderLoopTester) Setup(t *testing.T) {
 	c.ChainReaderInterfaceTester.Setup(t)
 	chainReader := c.ChainReaderInterfaceTester.GetChainReader(t)
+
 	c.lst.registerHook = func(server *grpc.Server) {
 		if chainReader != nil {
-			impl := chainreader.NewServer(chainReader)
+			impl := chainreader.NewServer(chainReader, chainreader.WithServerEncoding(c.encodeWith))
 			pb.RegisterChainReaderServer(server, impl)
 		}
 	}
+
 	c.lst.Setup(t)
 }
 
 func (c *contractReaderLoopTester) GetChainReader(t *testing.T) types.ContractReader {
-	return chainreader.NewClient(nil, c.lst.GetConn(t))
+	return chainreader.NewClient(nil, c.lst.GetConn(t), chainreader.WithClientEncoding(c.encodeWith))
 }
 
 func (c *contractReaderLoopTester) Name() string {

--- a/pkg/loop/internal/relayer/pluginprovider/chainreader/test/chain_reader_loop_tester.go
+++ b/pkg/loop/internal/relayer/pluginprovider/chainreader/test/chain_reader_loop_tester.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests" //nolint common practice to import test mods with .
 )
 
-func LoopEncodingTestMatrix(t *testing.T, test func(chainreader.EncodingVersion) func(t *testing.T)) {
+func TestAllEncodings(t *testing.T, test func(chainreader.EncodingVersion) func(t *testing.T)) {
 	t.Helper()
 
 	encodings := []struct {

--- a/pkg/types/interfacetests/chain_reader_interface_tests.go
+++ b/pkg/types/interfacetests/chain_reader_interface_tests.go
@@ -55,9 +55,9 @@ func runChainReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester Chain
 			name: "Gets the latest value",
 			test: func(t T) {
 				ctx := tests.Context(t)
-				firstItem := CreateTestStruct[T](0, tester)
+				firstItem := CreateTestStruct(0, tester)
 				tester.SetLatestValue(t, &firstItem)
-				secondItem := CreateTestStruct[T](1, tester)
+				secondItem := CreateTestStruct(1, tester)
 				tester.SetLatestValue(t, &secondItem)
 
 				cr := tester.GetChainReader(t)
@@ -137,7 +137,7 @@ func runChainReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester Chain
 			name: "Get latest value wraps config with modifiers using its own mapstructure overrides",
 			test: func(t T) {
 				ctx := tests.Context(t)
-				testStruct := CreateTestStruct[T](0, tester)
+				testStruct := CreateTestStruct(0, tester)
 				testStruct.BigField = nil
 				testStruct.Account = nil
 				cr := tester.GetChainReader(t)
@@ -148,7 +148,7 @@ func runChainReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester Chain
 
 				expected := &TestStructWithExtraField{
 					ExtraField: AnyExtraValue,
-					TestStruct: CreateTestStruct[T](0, tester),
+					TestStruct: CreateTestStruct(0, tester),
 				}
 
 				assert.Equal(t, expected, actual)
@@ -190,9 +190,9 @@ func runChainReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester Chain
 				ctx := tests.Context(t)
 				cr := tester.GetChainReader(t)
 				require.NoError(t, cr.Bind(ctx, tester.GetBindings(t)))
-				ts0 := CreateTestStruct[T](0, tester)
+				ts0 := CreateTestStruct(0, tester)
 				tester.TriggerEvent(t, &ts0)
-				ts1 := CreateTestStruct[T](1, tester)
+				ts1 := CreateTestStruct(1, tester)
 				tester.TriggerEvent(t, &ts1)
 
 				filterParams := &FilterEventParams{Field: *ts0.Field}


### PR DESCRIPTION
Client and Server ChainReader LOOP interfaces can accept options that configure the encoding version for client-server communication. A test matrix helper function is included for running tests as a test matrix.