### PR TITLE
BCI-2953: Added Aptos network for keystore

### DIFF
--- a/pkg/types/relayer.go
+++ b/pkg/types/relayer.go
@@ -14,6 +14,7 @@ const (
 	NetworkCosmos   = "cosmos"
 	NetworkSolana   = "solana"
 	NetworkStarkNet = "starknet"
+	NetworkAptos    = "aptos"
 )
 
 var SupportedRelays = map[string]struct{}{
@@ -21,6 +22,7 @@ var SupportedRelays = map[string]struct{}{
 	NetworkCosmos:   {},
 	NetworkSolana:   {},
 	NetworkStarkNet: {},
+	NetworkAptos:    {},
 }
 
 type RelayID struct {


### PR DESCRIPTION
Ticket: 
* [Parent Ticket](https://smartcontract-it.atlassian.net/browse/BCI-2953)
* [Validate ORM for Aptos Keystore Ticket](https://smartcontract-it.atlassian.net/browse/BCI-3477)

Changes: 
* Really small change of adding aptos network. 
* This is to allow core to use the change in network