### PR TITLE
BCI-2953: Added Report Format for Aptos

### DIFF
--- a/pkg/types/llo/types.go
+++ b/pkg/types/llo/types.go
@@ -32,6 +32,7 @@ const (
 	ReportFormatSolana   = 3
 	ReportFormatCosmos   = 4
 	ReportFormatStarknet = 5
+	ReportFormatAptos    = 6
 
 	_ ReportFormat = math.MaxUint32 // reserved
 )
@@ -42,6 +43,7 @@ var ReportFormats = []ReportFormat{
 	ReportFormatSolana,
 	ReportFormatCosmos,
 	ReportFormatStarknet,
+	ReportFormatAptos,
 }
 
 func (rf ReportFormat) String() string {
@@ -56,6 +58,8 @@ func (rf ReportFormat) String() string {
 		return "cosmos"
 	case ReportFormatStarknet:
 		return "starknet"
+	case ReportFormatAptos:
+		return "aptos"
 	default:
 		return fmt.Sprintf("unknown(%d)", rf)
 	}
@@ -73,6 +77,8 @@ func ReportFormatFromString(s string) (ReportFormat, error) {
 		return ReportFormatCosmos, nil
 	case "starknet":
 		return ReportFormatStarknet, nil
+	case "aptos":
+		return ReportFormatAptos, nil
 	default:
 		return 0, fmt.Errorf("unknown report format: %s", s)
 	}


### PR DESCRIPTION
Parent Ticket: https://smartcontract-it.atlassian.net/browse/BCI-2953
Parent PR: https://github.com/smartcontractkit/chainlink/pull/13564

Context:
* Aptos Keystore Integration is blocked by this addition ([CI](https://github.com/smartcontractkit/chainlink/pull/13564/checks)) for LLO integration tests. The integration tests checks `chainlink-common` for report format based on chaintypes. 
* Therefore adding `ReportFormatAptos` is necessary 

Changes: 
* Adding `ReportFormatAptos` and String functions

core ref: 83b25926682729610f768aa93f43ce1063d4336b