### PR TITLE
feat(observability-lib): update uptime to be in hours instead of days

### DIFF
--- a/observability-lib/core-node/component.go
+++ b/observability-lib/core-node/component.go
@@ -131,18 +131,18 @@ func panelsGeneralClusterInfo(p Props) []cog.Builder[dashboard.Panel] {
 
 	panelsArray = append(panelsArray, utils.StatPanel(
 		p.MetricsDataSource,
-		"Uptime in days",
+		"Uptime",
 		"instance uptime",
 		4,
 		12,
-		1,
-		"",
+		2,
+		"s",
 		common.BigValueColorModeNone,
 		common.BigValueGraphModeNone,
 		common.BigValueTextModeValueAndName,
 		common.VizOrientationHorizontal,
 		utils.PrometheusQuery{
-			Query:  `uptime_seconds{` + p.PlatformOpts.LabelQuery + `} / 86400`,
+			Query:  `uptime_seconds{` + p.PlatformOpts.LabelQuery + `}`,
 			Legend: `{{` + p.PlatformOpts.LegendString + `}}`,
 		},
 	))


### PR DESCRIPTION
Update uptime to be in hours instead of days from :
<img width="1140" alt="image" src="https://github.com/smartcontractkit/chainlink-common/assets/16008249/ac898967-7ea8-4ecc-a6ba-7ec46e140abd">

to
<img width="697" alt="image" src="https://github.com/smartcontractkit/chainlink-common/assets/16008249/298de744-2715-496f-ac17-9e61003bed98">


