### PR TITLE
Test CI

### DIFF
--- a/fail_test.go
+++ b/fail_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestFail(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Fatal("fake failure")
+}
+
+func TestRace(t *testing.T) {
+	var v int
+	var wg sync.WaitGroup
+	wg.Add(100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer wg.Done()
+			v++
+			v--
+		}()
+	}
+	wg.Wait()
+	t.Log(v)
+}
+
+func TestLint(t *testing.T) {
+	const ALL_CAPS = 10 // should be AllCaps
+	err := os.ErrNotExist
+	if err == os.ErrNotExist { // should use errors.Is
+		err := errors.New("fake error") // shadowed variable
+		t.Log(err)
+	}
+}

--- a/pkg/utils/tests/logs.go
+++ b/pkg/utils/tests/logs.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// AssertLogEventually waits until at least one log message containing the
+// specified msg is emitted.
+// NOTE: This does not "pop" messages so it cannot be used multiple times to
+// check for new instances of the same msg. See AssertLogCountEventually instead.
+//
+// Get a *observer.ObservedLogs like so:
+//
+//	observedZapCore, observedLogs := observer.New(zap.DebugLevel)
+//	lggr := logger.TestLogger(t, observedZapCore)
+func AssertLogEventually(t *testing.T, observedLogs *observer.ObservedLogs, msg string) {
+	AssertLogCountEventually(t, observedLogs, msg, 1)
+}
+
+// AssertLogCountEventually waits until at least count log message containing the
+// specified msg is emitted
+func AssertLogCountEventually(t *testing.T, observedLogs *observer.ObservedLogs, msg string, count int) {
+	AssertEventually(t, func() bool {
+		i := 0
+		for _, l := range observedLogs.All() {
+			if strings.Contains(l.Message, msg) {
+				i++
+				if i >= count {
+					return true
+				}
+			}
+		}
+		return false
+	})
+}
+
+// RequireLogMessage fails the test if emitted logs don't contain the given message
+func RequireLogMessage(t *testing.T, observedLogs *observer.ObservedLogs, msg string) {
+	for _, l := range observedLogs.All() {
+		if strings.Contains(l.Message, msg) {
+			return
+		}
+	}
+	t.Log("observed logs", observedLogs.All())
+	t.Fatalf("expected observed logs to contain msg %q, but it didn't", msg)
+}

--- a/pkg/utils/tests/tests.go
+++ b/pkg/utils/tests/tests.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Context(t *testing.T) context.Context {
@@ -32,4 +34,23 @@ func WaitTimeout(t *testing.T) time.Duration {
 		return time.Until(d) * 9 / 10
 	}
 	return DefaultWaitTimeout
+}
+
+// TestInterval is just a sensible poll interval that gives fast tests without
+// risk of spamming
+const TestInterval = 100 * time.Millisecond
+
+// AssertEventually waits for f to return true
+func AssertEventually(t *testing.T, f func() bool) {
+	assert.Eventually(t, f, WaitTimeout(t), TestInterval/2)
+}
+
+// RequireSignal waits for the channel to close (or receive anything) and
+// fatals the test if the default wait timeout is exceeded
+func RequireSignal(t *testing.T, ch <-chan struct{}, failMsg string) {
+	select {
+	case <-ch:
+	case <-time.After(WaitTimeout(t)):
+		t.Fatal(failMsg)
+	}
 }


### PR DESCRIPTION
This draft adds a test file designed to flag the unit tests, the race detector, and the linter, in order to ensure that they are all operating correctly.