### PR TITLE
pkg/types/ccipocr3: fix incorrect comment

### DIFF
--- a/pkg/capabilities/consensus/ocr3/reporting_plugin_test.go
+++ b/pkg/capabilities/consensus/ocr3/reporting_plugin_test.go
@@ -2,6 +2,7 @@ package ocr3
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/google/uuid"
@@ -181,7 +182,11 @@ func TestReportingPlugin_Observation(t *testing.T) {
 	assert.Equal(t, fo.Id.WorkflowExecutionId, eid)
 	assert.Equal(t, fo.Id.WorkflowId, workflowTestID)
 	assert.Equal(t, o, values.FromListValueProto(fo.Observations))
-	assert.Equal(t, []string{workflowTestID, workflowTestID2}, obspb.RegisteredWorkflowIds)
+	expected := []string{workflowTestID, workflowTestID2}
+	actual := obspb.RegisteredWorkflowIds
+	sort.Slice(actual, func(i, j int) bool { return actual[i] < actual[j] })
+	sort.Slice(expected, func(i, j int) bool { return expected[i] < expected[j] })
+	assert.Equal(t, expected, actual)
 }
 
 func TestReportingPlugin_Observation_NoResults(t *testing.T) {

--- a/pkg/types/ccipocr3/generic_types.go
+++ b/pkg/types/ccipocr3/generic_types.go
@@ -91,7 +91,7 @@ type Message struct {
 	// This is always set on all CCIP messages.
 	Header RampMessageHeader `json:"header"`
 	// Sender address on the source chain.
-	// i.e if the source chain is EVM, this is an EVM address, so len(Sender) == 20 in that case.
+	// i.e if the source chain is EVM, this is an abi-encoded EVM address.
 	Sender Bytes `json:"sender"`
 	// Data is the arbitrary data payload supplied by the message sender.
 	Data Bytes `json:"data"`


### PR DESCRIPTION
* Fix an incorrect godoc comment on one of the fields of `Message`.
* Fix a flakey test `TestReportingPlugin_Observation` which was failing due to wrong order of the `RegisteredWorkflowIds` field which I assume does not require a specific order.