### PR TITLE
KS-376 cross thread usage of non-thread safe Validator

### DIFF
--- a/pkg/capabilities/consensus/ocr3/capability.go
+++ b/pkg/capabilities/consensus/ocr3/capability.go
@@ -59,13 +59,12 @@ type capability struct {
 
 var _ capabilityIface = (*capability)(nil)
 var _ capabilities.ConsensusCapability = (*capability)(nil)
-var ocr3CapabilityValidator = capabilities.NewValidator[config, inputs, requests.Response](capabilities.ValidatorArgs{Info: info})
 
 func newCapability(s *requests.Store, clock clockwork.Clock, requestTimeout time.Duration, aggregatorFactory types.AggregatorFactory, encoderFactory types.EncoderFactory, lggr logger.Logger,
 	callbackChannelBufferSize int) *capability {
 	o := &capability{
 		CapabilityInfo:    info,
-		Validator:         ocr3CapabilityValidator,
+		Validator:         capabilities.NewValidator[config, inputs, requests.Response](capabilities.ValidatorArgs{Info: info}),
 		reqHandler:        requests.NewHandler(lggr, s, clock, requestTimeout),
 		clock:             clock,
 		requestTimeout:    requestTimeout,

--- a/pkg/capabilities/triggers/mercury_trigger.go
+++ b/pkg/capabilities/triggers/mercury_trigger.go
@@ -38,8 +38,6 @@ type inputs struct {
 	TriggerID string `json:"triggerId"`
 }
 
-var mercuryTriggerValidator = capabilities.NewValidator[config, inputs, capabilities.TriggerEvent](capabilities.ValidatorArgs{Info: capInfo})
-
 // This Trigger Service allows for the registration and deregistration of triggers. You can also send reports to the service.
 type MercuryTriggerService struct {
 	capabilities.Validator[config, inputs, capabilities.TriggerEvent]
@@ -70,7 +68,7 @@ func NewMercuryTriggerService(tickerResolutionMs int64, lggr logger.Logger) *Mer
 		tickerResolutionMs = defaultTickerResolutionMs
 	}
 	return &MercuryTriggerService{
-		Validator:          mercuryTriggerValidator,
+		Validator:          capabilities.NewValidator[config, inputs, capabilities.TriggerEvent](capabilities.ValidatorArgs{Info: capInfo}),
 		CapabilityInfo:     capInfo,
 		tickerResolutionMs: tickerResolutionMs,
 		subscribers:        make(map[string]*subscriber),

--- a/pkg/capabilities/triggers/on_demand_trigger.go
+++ b/pkg/capabilities/triggers/on_demand_trigger.go
@@ -29,21 +29,13 @@ type OnDemand struct {
 
 var _ capabilities.TriggerCapability = (*OnDemand)(nil)
 
-// Somewhat useless usage of validator, since
-// the types we're validating against are essentially `any`.
-//
-// Leaving it in for completeness sake.
-//
-// Consider looking at MercuryTrigger for a more complete example.
-var onDemandValidator = capabilities.NewValidator[onDemandTriggerConfig, any, capabilities.CapabilityResponse](capabilities.ValidatorArgs{Info: info})
-
 // NewOnDemand creates a new on-demand trigger. The sendChannelBufferSize should be sized to ensure each client has sufficient
 // time to process events, once this buffer is full new events for the client will be dropped.
 func NewOnDemand(log logger.Logger) *OnDemand {
 	return &OnDemand{
 		log:            log,
 		CapabilityInfo: info,
-		Validator:      onDemandValidator,
+		Validator:      capabilities.NewValidator[onDemandTriggerConfig, any, capabilities.CapabilityResponse](capabilities.ValidatorArgs{Info: info}),
 		chans:          map[workflowID]chan<- capabilities.CapabilityResponse{},
 	}
 }


### PR DESCRIPTION
issue described here-> https://smartcontract-it.atlassian.net/browse/KS-376

The fix here is simple but has the downside of there now being a schema instance per capability instance instead of a schema instance per capability type.   I suspect in practice this does not matter?  Possible to solve in other ways if it does