### PR TITLE
remove grpc-proxy replace; use directly instead

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,11 +20,11 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/linkedin/goavro/v2 v2.12.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9
 	github.com/pelletier/go-toml/v2 v2.2.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/riferrei/srclient v0.5.4
 	github.com/shopspring/decimal v1.3.1
+	github.com/smartcontractkit/grpc-proxy v0.0.0-20240717201340-615db53deaf6 // using fork until merged upstream: https://github.com/mwitkow/grpc-proxy/pull/69
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0
@@ -92,7 +92,4 @@ replace (
 
 	// until merged upstream: https://github.com/mitchellh/mapstructure/pull/343
 	github.com/mitchellh/mapstructure v1.5.0 => github.com/nolag/mapstructure v1.5.2-0.20240625151721-90ea83a3f479
-
-	// until merged upstream: https://github.com/mwitkow/grpc-proxy/pull/69
-	github.com/mwitkow/grpc-proxy => github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f
 )

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16 h1:TFe+FvzxClblt6qRfqEhUfa4kFQx5UobuoFGO2W4mMo=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16/go.mod h1:lBS5MtSSBZk0SHc66KACcjjlU6WzEVP/8pwz68aMkCI=
-github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f h1:hgJif132UCdjo8u43i7iPN1/MFnu49hv7lFGFftCHKU=
-github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f/go.mod h1:MvMXoufZAtqExNexqi4cjrNYE9MefKddKylxjS+//n0=
+github.com/smartcontractkit/grpc-proxy v0.0.0-20240717201340-615db53deaf6 h1:n2AyIDzWNqp6JIBQOuAfIEW70hH18TOoyBnu03FRr2M=
+github.com/smartcontractkit/grpc-proxy v0.0.0-20240717201340-615db53deaf6/go.mod h1:FX7/bVdoep147QQhsOPkYsPEXhGZjeYx6lBSaSXtZOA=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c h1:lIyMbTaF2H0Q71vkwZHX/Ew4KF2BxiKhqEXwF8rn+KI=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c/go.mod h1:fb1ZDVXACvu4frX3APHZaEBp0xi1DIm34DcA0CwTsZM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/loop/internal/core/services/reportingplugin/ocr2/reporting_plugin_service.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr2/reporting_plugin_service.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
+
+	"github.com/smartcontractkit/grpc-proxy/proxy"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/keyvalue"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayerset"

--- a/pkg/loop/internal/core/services/reportingplugin/ocr3/reporting_plugin_service.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr3/reporting_plugin_service.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
+
+	"github.com/smartcontractkit/grpc-proxy/proxy"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/keyvalue"
 	relayersetpb "github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb/relayerset"

--- a/pkg/loop/internal/relayerset/server.go
+++ b/pkg/loop/internal/relayerset/server.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/smartcontractkit/grpc-proxy/proxy"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net"

--- a/pkg/loop/internal/reportingplugin/ccip/commit.go
+++ b/pkg/loop/internal/reportingplugin/ccip/commit.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
+
+	"github.com/smartcontractkit/grpc-proxy/proxy"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/reportingplugin/ocr2"

--- a/pkg/loop/internal/reportingplugin/ccip/execution.go
+++ b/pkg/loop/internal/reportingplugin/ccip/execution.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
+
+	"github.com/smartcontractkit/grpc-proxy/proxy"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/reportingplugin/ocr2"

--- a/pkg/loop/internal/reportingplugin/median/median.go
+++ b/pkg/loop/internal/reportingplugin/median/median.go
@@ -3,9 +3,10 @@ package median
 import (
 	"context"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
-	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 	"google.golang.org/grpc"
+
+	"github.com/smartcontractkit/grpc-proxy/proxy"
+	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/errorlog"

--- a/pkg/loop/internal/reportingplugin/mercury/mercury.go
+++ b/pkg/loop/internal/reportingplugin/mercury/mercury.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
+
+	"github.com/smartcontractkit/grpc-proxy/proxy"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin"


### PR DESCRIPTION
If possible, we should pair up with other replace updates.

Requires:
- https://github.com/smartcontractkit/grpc-proxy/pull/2