### PR TITLE
embeddable implementation of contract reader

### DIFF
--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go
@@ -43,14 +43,15 @@ const DefaultEncodingVersion = CBOREncodingVersion
 type ClientOpt func(*Client)
 
 type Client struct {
-	*goplugin.ServiceClient
-	grpc       pb.ContractReaderClient
-	encodeWith EncodingVersion
+	types.UnimplementedContractReader
+	serviceClient *goplugin.ServiceClient
+	grpc          pb.ContractReaderClient
+	encodeWith    EncodingVersion
 }
 
 func NewClient(b *net.BrokerExt, cc grpc.ClientConnInterface, opts ...ClientOpt) *Client {
 	client := &Client{
-		ServiceClient: goplugin.NewServiceClient(b, cc),
+		serviceClient: goplugin.NewServiceClient(b, cc),
 		grpc:          pb.NewContractReaderClient(cc),
 		encodeWith:    DefaultEncodingVersion,
 	}
@@ -225,6 +226,30 @@ func (c *Client) Unbind(ctx context.Context, bindings []types.BoundContract) err
 	_, err := c.grpc.Unbind(ctx, &pb.UnbindRequest{Bindings: pbBindings})
 
 	return net.WrapRPCErr(err)
+}
+
+func (c *Client) ClientConn() grpc.ClientConnInterface {
+	return c.serviceClient.ClientConn()
+}
+
+func (c *Client) Close() error {
+	return c.serviceClient.Close()
+}
+
+func (c *Client) HealthReport() map[string]error {
+	return c.serviceClient.HealthReport()
+}
+
+func (c *Client) Name() string {
+	return c.serviceClient.Name()
+}
+
+func (c *Client) Ready() error {
+	return c.serviceClient.Ready()
+}
+
+func (c *Client) Start(ctx context.Context) error {
+	return c.serviceClient.Start(ctx)
 }
 
 var _ pb.ContractReaderServer = (*Server)(nil)

--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader_test.go
@@ -339,6 +339,7 @@ type eventConfidencePair struct {
 }
 
 type fakeContractReader struct {
+	types.UnimplementedContractReader
 	fakeTypeProvider
 	vals        []valConfidencePair
 	triggers    []eventConfidencePair
@@ -605,6 +606,7 @@ func (f *fakeContractReader) GenerateBlocksTillConfidenceLevel(_ *testing.T, _, 
 }
 
 type errContractReader struct {
+	types.UnimplementedContractReader
 	err error
 }
 
@@ -639,6 +641,7 @@ func (e *errContractReader) QueryKey(_ context.Context, _ types.BoundContract, _
 }
 
 type protoConversionTestContractReader struct {
+	types.UnimplementedContractReader
 	expectedBindings     types.BoundContract
 	expectedQueryFilter  query.KeyFilter
 	expectedLimitAndSort query.LimitAndSort

--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/test/contract_reader.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/test/contract_reader.go
@@ -26,6 +26,7 @@ var (
 
 // staticContractReader is a static implementation of ContractReaderTester
 type staticContractReader struct {
+	types.UnimplementedContractReader
 	address        string
 	contractName   string
 	contractMethod string

--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -60,6 +60,8 @@ type ContractReader interface {
 
 	// QueryKey provides fetching chain agnostic events (Sequence) with general querying capability.
 	QueryKey(ctx context.Context, contract BoundContract, filter query.KeyFilter, limitAndSort query.LimitAndSort, sequenceDataType any) ([]Sequence, error)
+
+	mustEmbedUnimplementedContractReaderServer()
 }
 
 // BatchGetLatestValuesRequest string is contract name.
@@ -162,3 +164,5 @@ func (UnimplementedContractReader) Name() string {
 func (UnimplementedContractReader) Ready() error {
 	return UnimplementedError("ContractReader.Ready unimplemented")
 }
+
+func (UnimplementedContractReader) mustEmbedUnimplementedContractReaderServer() {}

--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -118,3 +118,46 @@ func (bc BoundContract) ReadIdentifier(readName string) string {
 func (bc BoundContract) String() string {
 	return bc.Address + "-" + bc.Name
 }
+
+type UnimplementedContractReader struct{}
+
+var _ ContractReader = UnimplementedContractReader{}
+
+func (_ UnimplementedContractReader) GetLatestValue(ctx context.Context, contractName, method string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) error {
+	return UnimplementedError("ContractReader.GetLatestValue unimplemented")
+}
+
+func (_ UnimplementedContractReader) BatchGetLatestValues(ctx context.Context, request BatchGetLatestValuesRequest) (BatchGetLatestValuesResult, error) {
+	return nil, UnimplementedError("ContractReader.BatchGetLatestValues unimplemented")
+}
+
+// Bind will override current bindings for the same contract, if one has been set and will return an error if the
+// contract is not known by the ChainReader, or if the Address is invalid
+func (_ UnimplementedContractReader) Bind(ctx context.Context, bindings []BoundContract) error {
+	return UnimplementedError("ContractReader.Bind unimplemented")
+}
+
+// QueryKey provides fetching chain agnostic events (Sequence) with general querying capability.
+func (_ UnimplementedContractReader) QueryKey(ctx context.Context, contractName string, filter query.KeyFilter, limitAndSort query.LimitAndSort, sequenceDataType any) ([]Sequence, error) {
+	return nil, UnimplementedError("ContractReader.QueryKey unimplemented")
+}
+
+func (_ UnimplementedContractReader) Start(context.Context) error {
+	return UnimplementedError("ContractReader.Start unimplemented")
+}
+
+func (_ UnimplementedContractReader) Close() error {
+	return UnimplementedError("ContractReader.Close unimplemented")
+}
+
+func (_ UnimplementedContractReader) HealthReport() map[string]error {
+	panic(UnimplementedError("ContractReader.HealthReport unimplemented"))
+}
+
+func (_ UnimplementedContractReader) Name() string {
+	panic(UnimplementedError("ContractReader.Name unimplemented"))
+}
+
+func (_ UnimplementedContractReader) Ready() error {
+	return UnimplementedError("ContractReader.Ready unimplemented")
+}

--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -123,41 +123,42 @@ type UnimplementedContractReader struct{}
 
 var _ ContractReader = UnimplementedContractReader{}
 
-func (_ UnimplementedContractReader) GetLatestValue(ctx context.Context, contractName, method string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) error {
+func (UnimplementedContractReader) GetLatestValue(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) error {
 	return UnimplementedError("ContractReader.GetLatestValue unimplemented")
 }
 
-func (_ UnimplementedContractReader) BatchGetLatestValues(ctx context.Context, request BatchGetLatestValuesRequest) (BatchGetLatestValuesResult, error) {
+func (UnimplementedContractReader) BatchGetLatestValues(ctx context.Context, request BatchGetLatestValuesRequest) (BatchGetLatestValuesResult, error) {
 	return nil, UnimplementedError("ContractReader.BatchGetLatestValues unimplemented")
 }
 
-// Bind will override current bindings for the same contract, if one has been set and will return an error if the
-// contract is not known by the ChainReader, or if the Address is invalid
-func (_ UnimplementedContractReader) Bind(ctx context.Context, bindings []BoundContract) error {
+func (UnimplementedContractReader) Bind(ctx context.Context, bindings []BoundContract) error {
 	return UnimplementedError("ContractReader.Bind unimplemented")
 }
 
-// QueryKey provides fetching chain agnostic events (Sequence) with general querying capability.
-func (_ UnimplementedContractReader) QueryKey(ctx context.Context, contractName string, filter query.KeyFilter, limitAndSort query.LimitAndSort, sequenceDataType any) ([]Sequence, error) {
+func (UnimplementedContractReader) Unbind(ctx context.Context, bindings []BoundContract) error {
+	return UnimplementedError("ContractReader.Unbind unimplemented")
+}
+
+func (UnimplementedContractReader) QueryKey(ctx context.Context, boundContract BoundContract, filter query.KeyFilter, limitAndSort query.LimitAndSort, sequenceDataType any) ([]Sequence, error) {
 	return nil, UnimplementedError("ContractReader.QueryKey unimplemented")
 }
 
-func (_ UnimplementedContractReader) Start(context.Context) error {
+func (UnimplementedContractReader) Start(context.Context) error {
 	return UnimplementedError("ContractReader.Start unimplemented")
 }
 
-func (_ UnimplementedContractReader) Close() error {
+func (UnimplementedContractReader) Close() error {
 	return UnimplementedError("ContractReader.Close unimplemented")
 }
 
-func (_ UnimplementedContractReader) HealthReport() map[string]error {
+func (UnimplementedContractReader) HealthReport() map[string]error {
 	panic(UnimplementedError("ContractReader.HealthReport unimplemented"))
 }
 
-func (_ UnimplementedContractReader) Name() string {
+func (UnimplementedContractReader) Name() string {
 	panic(UnimplementedError("ContractReader.Name unimplemented"))
 }
 
-func (_ UnimplementedContractReader) Ready() error {
+func (UnimplementedContractReader) Ready() error {
 	return UnimplementedError("ContractReader.Ready unimplemented")
 }


### PR DESCRIPTION
When updates are made to a core interface and committed to common, builds break on core or relay repos due to not matching interfaces. This change proposes using 'unimplemented' versions of an interface to embed in downstream implementations to allow interface additions to be added without breaking downstream builds.

Usage:
```
type ImplementedContractReader struct {
    types.UnimplementedContractReader
}

// ... actual interface implementation below
```