### PR TITLE
[KS-433] Clarify interface requirement

### DIFF
--- a/pkg/capabilities/consensus/ocr3/ocr3.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3.go
@@ -11,9 +11,12 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins"
+	ocr3rp "github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins/ocr3"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
+
+var _ ocr3rp.ProviderServer[commontypes.PluginProvider] = (*Capability)(nil)
 
 type Capability struct {
 	loop.Plugin


### PR DESCRIPTION
### What

Assert that Capability matches the OCR3 Reporting Plugin interface. This will guard against any drift between the interface and the implementation.

### Why

<!--
 Why is this change needed?
-->

<!--
### Notes
- Notes are optional
- Note anything of importance here: such as explanations/reasoning, pull requests that block this one, or…
- TODO items…
-->
