### PR TITLE
Add json schemas for existing capabilities

### DIFF
--- a/pkg/capabilities/consensus/ocr3/ocr3_consensus-schema.json
+++ b/pkg/capabilities/consensus/ocr3/ocr3_consensus-schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/offchain_reporting@1.0.0",
+  "$defs": {
+    "SignedReport": {
+      "type": "object",
+      "properties": {
+        "WorkflowExecutionID": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "object",
+          "properties": {
+            "Underlying": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["Underlying"]
+        },
+        "Err": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["WorkflowExecutionID", "Value", "Err"]
+    },
+    "FeedValue": {
+      "type": "object",
+      "properties": {
+        "deviation": {
+          "type": "string",
+          "description": "The deviation that is required to generate a new report. Expressed as a percentage. For example, 0.01 is 1% deviation."
+        },
+        "heartbeat": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The interval in seconds after which a new report is generated, regardless of whether any deviations have occurred. New reports reset the timer."
+        },
+        "remappedID": {
+          "type": ["string", "null"],
+          "description": "An optional remapped ID for the feed."
+        }
+      },
+      "additionalProperties": false,
+      "required": ["deviation", "heartbeat"]
+    }
+  },
+  "properties": {
+    "config": {
+      "properties": {
+        "aggregation_method": {
+          "type": "string",
+          "enum": ["data_feeds"]
+        },
+        "aggregation_config": {
+          "type": "object",
+          "properties": {
+            "allowedPartialStaleness": {
+              "type": "string",
+              "description": "Allowed partial staleness as a number between 0 and 1."
+            },
+            "feeds": {
+              "type": "object",
+              "propertyNames": {
+                "$ref": "../../triggers/streams/streams_trigger-schema.json#/$defs/feedId"
+              },
+              "additionalProperties": {
+                "$ref": "#/$defs/FeedValue"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": ["allowedPartialStaleness", "feeds"]
+        },
+        "encoder": {
+          "type": "string",
+          "enum": ["EVM"]
+        },
+        "encoder_config": {
+          "type": "object",
+          "properties": {
+            "abi": {
+              "type": "string",
+              "description": "The ABI for report encoding.",
+              "examples": [
+                "(bytes32 FeedID, uint224 Price, uint32 Timestamp)[] Reports"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["abi"]
+        },
+        "report_id": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{4}$",
+          "examples": ["0x0001"]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "aggregation_method",
+        "aggregation_config",
+        "encoder",
+        "encoder_config",
+        "report_id"
+      ]
+    },
+    "inputs": {
+      "properties": {
+        "observations": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "../../triggers/streams/streams_trigger-schema.json#/$defs/Feed"
+            }
+          }
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["observations"]
+    },
+    "outputs": {
+      "$ref": "#/$defs/SignedReport"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["config", "inputs", "outputs"],
+  "description": "OCR3 consensus exposed as a capability."
+}

--- a/pkg/capabilities/targets/chainwriter/chainwriter_target-schema.json
+++ b/pkg/capabilities/targets/chainwriter/chainwriter_target-schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/smartcontractkit/chainlink-common/pkg/capabilities/targets/chainwriter/interface",
+  "description": "Writes to a blockchain",
+  "properties": {
+    "config": {
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "The address to write to."
+        },
+        "deltaStage": {
+          "type": "string",
+          "pattern": "^[0-9]+[smhd]$",
+          "description": "The delta stage which must be a number followed by a time symbol (s for seconds, m for minutes, h for hours, d for days)."
+        },
+        "schedule": {
+          "type": "string",
+          "enum": ["oneAtATime", "allAtOnce"],
+          "description": "The schedule which must be the string 'oneAtATime'."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "address",
+        "deltaStage",
+        "schedule"
+      ]
+    },
+    "inputs": {
+      "properties": {
+        "signed_report": {
+          "$ref": "../../consensus/ocr3/ocr3_consensus-schema.json#/$defs/SignedReport"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["signed_report"]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["config", "inputs"]
+}

--- a/pkg/capabilities/triggers/streams/streams_trigger-schema.json
+++ b/pkg/capabilities/triggers/streams/streams_trigger-schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/smartcontractkit/chainlink-common/pkg/capabilities/triggers/streams/streams-trigger@1.0.0",
+  "description": "Streams Trigger",
+  "$defs": {
+    "feedId": {
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$",
+      "description": "The ID of the data feed."
+    },
+    "Feed": {
+      "type": "object",
+      "properties": {
+        "feedId": {
+          "$ref": "#/$defs/feedId"
+        },
+        "fullReport": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "Full report represented as bytes encoded as base64 string."
+        },
+        "reportContext": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "Report context represented as bytes encoded as base64 string. This is required to validate the signatures."
+        },
+        "signatures": {
+          "type": "array",
+          "description": "Signature over full report and report context represented as bytes encoded as base64 string.",
+          "items": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "minItems": 1
+        },
+        "benchmarkPrice": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "This value is extracted from the fullReport. Benchmark price represented as bytes encoded as base64 string."
+        },
+        "observationTimestamp": {
+          "type": "integer",
+          "maximum": 9223372036854775807,
+          "minimum": 0,
+          "description": "This value is extracted from the fullReport. A unix timestamp represented as an int64 value. Timestamp is captured at the time of report creation."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "feedId",
+        "fullReport",
+        "reportContext",
+        "signatures",
+        "benchmarkPrice",
+        "observationTimestamp"
+      ]
+    }
+  },
+  "properties": {
+    "config": {
+      "properties": {
+        "feedIds": {
+          "type": "array",
+          "description": "The IDs of the data feeds that will have their reports included in the trigger event.",
+          "items": {
+            "$ref": "#/$defs/feedId"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "maxFrequencyMs": {
+          "type": "integer",
+          "description": "The interval in seconds after which a new trigger event is generated.",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["feedIds", "maxFrequencyMs"]
+    },
+    "outputs": {
+      "items": {
+        "$ref": "#/$defs/Feed"
+      },
+      "additionalProperties": false,
+      "type": "array"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["config"]
+}


### PR DESCRIPTION
This is part of a larger effort to allow workflow specs to be created in code with the assistance of a CLI that creates helpers for building them.

To see in its full context, visit [this PR](https://github.com/smartcontractkit/chainlink-common/pull/695/files)