### PR TITLE
Fix a bug with big.Int and values.Value, and allow same backing type to be encoded and decoded

### DIFF
--- a/pkg/values/big_int.go
+++ b/pkg/values/big_int.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/values/pb"
 )
@@ -45,6 +46,10 @@ func (b *BigInt) UnwrapTo(to any) error {
 		}
 		*tb = b.Underlying
 	default:
+		rto := reflect.ValueOf(to)
+		if rto.CanConvert(reflect.TypeOf(new(big.Int))) {
+			return b.UnwrapTo(rto.Convert(reflect.TypeOf(new(big.Int))).Interface())
+		}
 		return fmt.Errorf("cannot unwrap to value of type: %T", to)
 	}
 

--- a/pkg/values/decimal.go
+++ b/pkg/values/decimal.go
@@ -9,15 +9,15 @@ import (
 )
 
 type Decimal struct {
-	Underlying *decimal.Decimal
+	Underlying decimal.Decimal
 }
 
 func NewDecimal(d decimal.Decimal) *Decimal {
-	return &Decimal{Underlying: &d}
+	return &Decimal{Underlying: d}
 }
 
 func (d *Decimal) proto() *pb.Value {
-	return pb.NewDecimalValue(*d.Underlying)
+	return pb.NewDecimalValue(d.Underlying)
 }
 
 func (d *Decimal) Unwrap() (any, error) {
@@ -29,13 +29,12 @@ func (d *Decimal) UnwrapTo(to any) error {
 	if d == nil {
 		return errors.New("could not unwrap nil values.Decimal")
 	}
-	return unwrapTo(*d.Underlying, to)
+	return unwrapTo(d.Underlying, to)
 }
 
 func (d *Decimal) Copy() Value {
 	if d == nil {
 		return nil
 	}
-	cpy := d.Underlying.Copy()
-	return &Decimal{Underlying: &cpy}
+	return &Decimal{Underlying: d.Underlying.Copy()}
 }

--- a/pkg/values/decimal.go
+++ b/pkg/values/decimal.go
@@ -9,15 +9,15 @@ import (
 )
 
 type Decimal struct {
-	Underlying decimal.Decimal
+	Underlying *decimal.Decimal
 }
 
 func NewDecimal(d decimal.Decimal) *Decimal {
-	return &Decimal{Underlying: d}
+	return &Decimal{Underlying: &d}
 }
 
 func (d *Decimal) proto() *pb.Value {
-	return pb.NewDecimalValue(d.Underlying)
+	return pb.NewDecimalValue(*d.Underlying)
 }
 
 func (d *Decimal) Unwrap() (any, error) {
@@ -29,12 +29,13 @@ func (d *Decimal) UnwrapTo(to any) error {
 	if d == nil {
 		return errors.New("could not unwrap nil values.Decimal")
 	}
-	return unwrapTo(d.Underlying, to)
+	return unwrapTo(*d.Underlying, to)
 }
 
 func (d *Decimal) Copy() Value {
 	if d == nil {
 		return nil
 	}
-	return &Decimal{Underlying: d.Underlying.Copy()}
+	cpy := d.Underlying.Copy()
+	return &Decimal{Underlying: &cpy}
 }

--- a/pkg/values/int.go
+++ b/pkg/values/int.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/values/pb"
 )
@@ -88,6 +89,24 @@ func (i *Int64) UnwrapTo(to any) error {
 	case *any:
 		*tv = i.Underlying
 		return nil
+	}
+
+	rv := reflect.ValueOf(to)
+	if rv.Kind() == reflect.Ptr {
+		switch rv.Elem().Kind() {
+		case reflect.Int64:
+			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(int64(0)))).Interface())
+		case reflect.Int32:
+			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(int32(0)))).Interface())
+		case reflect.Int:
+			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(int(0)))).Interface())
+		case reflect.Uint64:
+			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(uint64(0)))).Interface())
+		case reflect.Uint32:
+			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(uint32(0)))).Interface())
+		case reflect.Uint:
+			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(uint(0)))).Interface())
+		}
 	}
 
 	return fmt.Errorf("cannot unwrap to type %T", to)

--- a/pkg/values/map.go
+++ b/pkg/values/map.go
@@ -123,7 +123,6 @@ func mapValueToMap(f reflect.Type, t reflect.Type, data any) (any, error) {
 	if f != reflect.TypeOf(map[string]Value{}) {
 		return data, nil
 	}
-
 	switch t {
 	// If the destination type is `map[string]any` or `any`,
 	// fully unwrap the values.Map.
@@ -143,6 +142,7 @@ func mapValueToMap(f reflect.Type, t reflect.Type, data any) (any, error) {
 
 		return d, nil
 	}
+
 	return data, nil
 }
 
@@ -185,7 +185,9 @@ func unwrapsValues(f reflect.Type, t reflect.Type, data any) (any, error) {
 		n := reflect.New(t).Interface()
 		err := dv.UnwrapTo(n)
 		if err != nil {
-			return nil, err
+			// Do not return the error to allow mapstructure to retry with different types
+			// Eg: mapstructure will attempt **big.Int before *big.Int if the field is a *big.Int.
+			return data, nil
 		}
 
 		if reflect.TypeOf(n).Elem() == t {

--- a/pkg/values/value_test.go
+++ b/pkg/values/value_test.go
@@ -228,6 +228,63 @@ func Test_Value(t *testing.T) {
 	}
 }
 
+func Test_StructWrapUnwrap(t *testing.T) {
+	// TODO: https://smartcontract-it.atlassian.net/browse/KS-439 decimal.Decimal is broken when encoded.
+	type sStruct struct {
+		Str string
+		I   int
+		Bi  *big.Int
+		// D  decimal.Decimal
+	}
+	expected := sStruct{
+		Str: "hi",
+		I:   10,
+		Bi:  big.NewInt(1),
+		// D:  decimal.NewFromFloat(24.3),
+	}
+
+	wrapped, err := Wrap(expected)
+	require.NoError(t, err)
+
+	unwrapped := sStruct{}
+	err = wrapped.UnwrapTo(&unwrapped)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, unwrapped)
+}
+
+func Test_SameUnderlyingTypes(t *testing.T) {
+	type str string
+	type i int
+	type bi big.Int
+	// TODO https://smartcontract-it.atlassian.net/browse/KS-439 decimal.Decimal is broken when encoded.
+	// type d decimal.Decimal
+	type sStruct struct {
+		Str str
+		I   i
+		Bi  *bi
+		// D   d
+	}
+	expected := sStruct{
+		Str: "hi",
+		I:   10,
+		Bi:  (*bi)(big.NewInt(1)),
+		// D:   d(decimal.NewFromFloat(24.3)),
+	}
+
+	wrapped, err := Wrap(expected)
+	require.NoError(t, err)
+
+	unwrapped := sStruct{}
+	err = wrapped.UnwrapTo(&unwrapped)
+	require.NoError(t, err)
+
+	// big ints don't pass assert equal because pointer isn't the same
+	assert.Equal(t, 0, (*big.Int)(expected.Bi).Cmp((*big.Int)(unwrapped.Bi)))
+	expected.Bi = unwrapped.Bi
+	assert.Equal(t, expected, unwrapped)
+}
+
 func Test_WrapMap(t *testing.T) {
 	a := struct{ A string }{A: "foo"}
 	am, err := WrapMap(a)


### PR DESCRIPTION
Same backing types are used to ensure marshalling, for example json shcema can generate code like

type FeedId string

`func (f *FeedId) UnmarshalJson(...)... `

that verifies the feed id has the right length etc.