### PR TITLE
Bring execution ID creation util into workflows package

### DIFF
--- a/pkg/workflows/utils.go
+++ b/pkg/workflows/utils.go
@@ -1,0 +1,21 @@
+package workflows
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+func EncodeExecutionID(workflowID, eventID string) (string, error) {
+	s := sha256.New()
+	_, err := s.Write([]byte(workflowID))
+	if err != nil {
+		return "", err
+	}
+
+	_, err = s.Write([]byte(eventID))
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(s.Sum(nil)), nil
+}


### PR DESCRIPTION
Moved from Chainlink repo into common and renamed to `EncodeExecutionID`