### PR TITLE
fix install protoc

### DIFF
--- a/script/install-protoc.sh
+++ b/script/install-protoc.sh
@@ -13,7 +13,7 @@ os=$(uname)
 arch=$(uname -m)
 
 install_dir=$HOME/.local
-$install_dir/bin/protoc --version | grep $VERSION
+protoc --version | grep $VERSION
 rc=$?
 if [ $rc -eq 0 ]; then
     # we have the current VERSION


### PR DESCRIPTION
install-protoc.sh needs to check the `protoc` version that will exceute, rather than an explicit path to a particular binary.