### PR TITLE
[CAPPL-42] SDK logger

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"io"
 	"reflect"
 	"testing"
 
@@ -63,6 +64,12 @@ func NewWith(cfgFn func(*zap.Config)) (Logger, error) {
 		return nil, err
 	}
 	return &logger{core.Sugar()}, nil
+}
+
+// NewWithSync returns a new Logger with a given SyncWriter.
+func NewWithSync(w io.Writer) Logger {
+	core := zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), zapcore.AddSync(w), zapcore.InfoLevel)
+	return &logger{zap.New(core).Sugar()}
 }
 
 // Test returns a new test Logger for tb.

--- a/pkg/workflows/wasm/host/test/log/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/log/cmd/main.go
@@ -1,0 +1,35 @@
+//go:build wasip1
+
+package main
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/cli/cmd/testdata/fixtures/capabilities/basictrigger"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
+)
+
+func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
+	workflow := sdk.NewWorkflowSpecFactory(
+		sdk.NewWorkflowParams{
+			Name:  "tester",
+			Owner: "ryan",
+		},
+	)
+
+	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
+	_ = triggerCfg.New(workflow)
+
+	return workflow
+}
+
+func main() {
+	runner := wasm.NewRunner()
+	runner.SDK.Logger.Infow("building workflow...", []interface{}{
+		"test-string-field-key", "this is a test field content",
+		"test-numeric-field-key", 6400000,
+	}...)
+	workflow := BuildWorkflow(runner.Config())
+	runner.SDK.Logger.Info("running workflow...")
+	runner.Run(workflow)
+}

--- a/pkg/workflows/wasm/runner.go
+++ b/pkg/workflows/wasm/runner.go
@@ -26,6 +26,7 @@ var _ sdk.Runner = (*Runner)(nil)
 
 type Runner struct {
 	sendResponse func(payload *wasmpb.Response)
+	SDK          Runtime
 	args         []string
 	req          *wasmpb.Request
 }
@@ -149,14 +150,12 @@ func (r *Runner) handleComputeRequest(factory *sdk.WorkflowSpecFactory, id strin
 		return nil, fmt.Errorf("invalid compute request: could not find compute function for id %s", req.Metadata.ReferenceId)
 	}
 
-	sdk := &Runtime{}
-
 	creq, err := capabilitiespb.CapabilityRequestFromProto(req)
 	if err != nil {
 		return nil, fmt.Errorf("invalid compute request: could not translate proto into capability request")
 	}
 
-	resp, err := fn(sdk, creq)
+	resp, err := fn(r.SDK, creq)
 	if err != nil {
 		return nil, fmt.Errorf("error executing custom compute: %w", err)
 	}

--- a/pkg/workflows/wasm/runner_wasip1.go
+++ b/pkg/workflows/wasm/runner_wasip1.go
@@ -6,11 +6,15 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	wasmpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/pb"
 )
 
 //go:wasmimport env sendResponse
 func sendResponse(respptr unsafe.Pointer, respptrlen int32) (errno int32)
+
+//go:wasmimport env log
+func log(respptr unsafe.Pointer, respptrlen int32)
 
 func bufferToPointerLen(buf []byte) (unsafe.Pointer, int32) {
 	return unsafe.Pointer(&buf[0]), int32(len(buf))
@@ -46,6 +50,18 @@ func NewRunner() *Runner {
 
 			os.Exit(code)
 		},
+		SDK: Runtime{
+			Logger: logger.NewWithSync(&wasmWriteSyncer{}),
+		},
 		args: os.Args,
 	}
+}
+
+type wasmWriteSyncer struct{}
+
+// Write is used to proxy log requests from the WASM binary back to the host
+func (wws *wasmWriteSyncer) Write(p []byte) (n int, err error) {
+	ptr, ptrlen := bufferToPointerLen(p)
+	log(ptr, ptrlen)
+	return int(ptrlen), nil
 }

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -1,7 +1,12 @@
 package wasm
 
-import "github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
+)
 
-type Runtime struct{}
+type Runtime struct {
+	Logger logger.Logger
+}
 
 var _ sdk.Runtime = (*Runtime)(nil)


### PR DESCRIPTION
### Description

This pr introduces a logger to the SDK that can be used from the wasm guest.
It basically json encodes, sends to the host, json decodes in the host, and logs using the our custom logger.Logger.

In order to do this I've introduced a new constructor `NewWithZapLogger` that returns a new Logger based on a zap.Logger. With this we can build our own core and pass it down to the `logger.Logger`