### PR TITLE
ccip - Add RMNCrypto interface + Remove unused constructor

### DIFF
--- a/pkg/types/ccipocr3/interfaces.go
+++ b/pkg/types/ccipocr3/interfaces.go
@@ -17,3 +17,14 @@ type ExecutePluginCodec interface {
 type MessageHasher interface {
 	Hash(context.Context, Message) (Bytes32, error)
 }
+
+type RMNCrypto interface {
+	// VerifyReportSignatures verifies each provided signature against the provided report and the signer addresses.
+	// If any signature is invalid (no matching signer address is found), an error is returned immediately.
+	VerifyReportSignatures(
+		ctx context.Context,
+		sigs []ECDSASignature,
+		report RMNReport,
+		signerAddresses [][]byte,
+	) error
+}

--- a/pkg/types/ccipocr3/interfaces.go
+++ b/pkg/types/ccipocr3/interfaces.go
@@ -18,6 +18,9 @@ type MessageHasher interface {
 	Hash(context.Context, Message) (Bytes32, error)
 }
 
+// RMNCrypto provides a chain-agnostic interface for verifying RMN signatures.
+// For example, on EVM, RMN reports are abi-encoded prior to being signed.
+// On Solana, they would be borsh encoded instead, etc.
 type RMNCrypto interface {
 	// VerifyReportSignatures verifies each provided signature against the provided report and the signer addresses.
 	// If any signature is invalid (no matching signer address is found), an error is returned immediately.

--- a/pkg/types/ccipocr3/interfaces.go
+++ b/pkg/types/ccipocr3/interfaces.go
@@ -25,6 +25,6 @@ type RMNCrypto interface {
 		ctx context.Context,
 		sigs []RMNECDSASignature,
 		report RMNReport,
-		signerAddresses [][]byte,
+		signerAddresses []Bytes,
 	) error
 }

--- a/pkg/types/ccipocr3/interfaces.go
+++ b/pkg/types/ccipocr3/interfaces.go
@@ -23,7 +23,7 @@ type RMNCrypto interface {
 	// If any signature is invalid (no matching signer address is found), an error is returned immediately.
 	VerifyReportSignatures(
 		ctx context.Context,
-		sigs []ECDSASignature,
+		sigs []RMNECDSASignature,
 		report RMNReport,
 		signerAddresses [][]byte,
 	) error

--- a/pkg/types/ccipocr3/plugin_commit_types.go
+++ b/pkg/types/ccipocr3/plugin_commit_types.go
@@ -22,15 +22,6 @@ type CommitPluginReport struct {
 	RMNSignatures []RMNECDSASignature `json:"rmnSignatures"`
 }
 
-// Deprecated: don't use this constructor, just create a CommitPluginReport struct directly.
-// Will be removed in a future version once all uses have been replaced.
-func NewCommitPluginReport(merkleRoots []MerkleRootChain, tokenPriceUpdates []TokenPrice, gasPriceUpdate []GasPriceChain) CommitPluginReport {
-	return CommitPluginReport{
-		MerkleRoots:  merkleRoots,
-		PriceUpdates: PriceUpdates{TokenPriceUpdates: tokenPriceUpdates, GasPriceUpdates: gasPriceUpdate},
-	}
-}
-
 // IsEmpty returns true if the CommitPluginReport is empty
 func (r CommitPluginReport) IsEmpty() bool {
 	return len(r.MerkleRoots) == 0 &&

--- a/pkg/types/ccipocr3/plugin_commit_types.go
+++ b/pkg/types/ccipocr3/plugin_commit_types.go
@@ -15,8 +15,10 @@ package ccipocr3
 // RMNSignatures, if RMN is configured for some lanes involved in the commitment.
 // A report with RMN signatures but without merkle roots is invalid.
 type CommitPluginReport struct {
-	MerkleRoots   []MerkleRootChain   `json:"merkleRoots"`
-	PriceUpdates  PriceUpdates        `json:"priceUpdates"`
+	MerkleRoots  []MerkleRootChain `json:"merkleRoots"`
+	PriceUpdates PriceUpdates      `json:"priceUpdates"`
+	// RMNSignatures are the ECDSA signatures from the RMN signing nodes on the RMNReport structure.
+	// For more details see the contract here: https://github.com/smartcontractkit/chainlink/blob/7ba0f37134a618375542079ff1805fe2224d7916/contracts/src/v0.8/ccip/interfaces/IRMNV2.sol#L8-L12
 	RMNSignatures []RMNECDSASignature `json:"rmnSignatures"`
 }
 
@@ -53,26 +55,6 @@ func NewMerkleRootChain(
 		SeqNumsRange: seqNumsRange,
 		MerkleRoot:   merkleRoot,
 	}
-}
-
-// RMNECDSASignature is the ECDSA signature from a single RMN node
-// on the RMN "Report" structure that consists of:
-//  1. the destination chain ID
-//  2. the destination chain selector
-//  3. the rmn remote contract address
-//  4. the offramp address
-//  5. the rmn home config digest
-//  6. the dest lane updates array, which is a struct that consists of:
-//     * source chain selector
-//     * min sequence number
-//     * max sequence number
-//     * the merkle root of the messages in the above range
-//     * the onramp address (in bytes, for EVM, abi-encoded)
-//
-// For more details see the contract here: https://github.com/smartcontractkit/chainlink/blob/7ba0f37134a618375542079ff1805fe2224d7916/contracts/src/v0.8/ccip/interfaces/IRMNV2.sol#L8-L12
-type RMNECDSASignature struct {
-	R Bytes32 `json:"r"`
-	S Bytes32 `json:"s"`
 }
 
 type PriceUpdates struct {

--- a/pkg/types/ccipocr3/rmn_types.go
+++ b/pkg/types/ccipocr3/rmn_types.go
@@ -4,21 +4,21 @@ type RMNReport struct {
 	ReportVersion               string // e.g. "RMN_V1_6_ANY2EVM_REPORT".
 	DestChainID                 BigInt // If applies, a chain specific id, e.g. evm chain id otherwise empty.
 	DestChainSelector           ChainSelector
-	RmnRemoteContractAddress    []byte
-	OfframpAddress              []byte
+	RmnRemoteContractAddress    Bytes
+	OfframpAddress              Bytes
 	RmnHomeContractConfigDigest Bytes32
 	LaneUpdates                 []RMNLaneUpdate
 }
 
 type RMNLaneUpdate struct {
 	SourceChainSelector ChainSelector
-	OnRampAddress       []byte
+	OnRampAddress       Bytes // (for EVM should be abi-encoded)
 	MinSeqNr            SeqNum
 	MaxSeqNr            SeqNum
 	MerkleRoot          Bytes32
 }
 
-type ECDSASignature struct {
-	R Bytes
-	S Bytes
+type RMNECDSASignature struct {
+	R Bytes32 `json:"r"`
+	S Bytes32 `json:"s"`
 }

--- a/pkg/types/ccipocr3/rmn_types.go
+++ b/pkg/types/ccipocr3/rmn_types.go
@@ -1,5 +1,6 @@
 package ccipocr3
 
+// RMNReport is the payload that is signed by the RMN nodes, transmitted and verified onchain.
 type RMNReport struct {
 	ReportVersion               string // e.g. "RMN_V1_6_ANY2EVM_REPORT".
 	DestChainID                 BigInt // If applies, a chain specific id, e.g. evm chain id otherwise empty.
@@ -10,6 +11,8 @@ type RMNReport struct {
 	LaneUpdates                 []RMNLaneUpdate
 }
 
+// RMNLaneUpdate represents an interval that has been observed by an RMN node.
+// It is part of the payload that is signed and transmitted onchain.
 type RMNLaneUpdate struct {
 	SourceChainSelector ChainSelector
 	OnRampAddress       Bytes // (for EVM should be abi-encoded)
@@ -18,6 +21,7 @@ type RMNLaneUpdate struct {
 	MerkleRoot          Bytes32
 }
 
+// // RMNECDSASignature represents the signature provided by RMN on the RMNReport structure.
 type RMNECDSASignature struct {
 	R Bytes32 `json:"r"`
 	S Bytes32 `json:"s"`

--- a/pkg/types/ccipocr3/rmn_types.go
+++ b/pkg/types/ccipocr3/rmn_types.go
@@ -1,0 +1,24 @@
+package ccipocr3
+
+type RMNReport struct {
+	ReportVersion               string // e.g. "RMN_V1_6_ANY2EVM_REPORT".
+	DestChainID                 BigInt // If applies, a chain specific id, e.g. evm chain id otherwise empty.
+	DestChainSelector           ChainSelector
+	RmnRemoteContractAddress    []byte
+	OfframpAddress              []byte
+	RmnHomeContractConfigDigest Bytes32
+	LaneUpdates                 []RMNLaneUpdate
+}
+
+type RMNLaneUpdate struct {
+	SourceChainSelector ChainSelector
+	OnRampAddress       []byte
+	MinSeqNr            SeqNum
+	MaxSeqNr            SeqNum
+	MerkleRoot          Bytes32
+}
+
+type ECDSASignature struct {
+	R Bytes
+	S Bytes
+}


### PR DESCRIPTION
1. Add `RMNCrypto` interface that will be responsible for chain-specific RMN crypto functionality, e.g. report verification.
2. Remove an unused constructor (not related to RMN).