### PR TITLE
Do not merge: Contract reader interface suggestion.

### DIFF
--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go
@@ -43,7 +43,7 @@ const DefaultEncodingVersion = CBOREncodingVersion
 type ClientOpt func(*Client)
 
 type Client struct {
-	types.UnimplementedContractReader
+	types.ContractReader
 	serviceClient *goplugin.ServiceClient
 	grpc          pb.ContractReaderClient
 	encodeWith    EncodingVersion

--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader_test.go
@@ -339,7 +339,7 @@ type eventConfidencePair struct {
 }
 
 type fakeContractReader struct {
-	types.UnimplementedContractReader
+	types.ContractReader
 	fakeTypeProvider
 	vals        []valConfidencePair
 	triggers    []eventConfidencePair
@@ -606,7 +606,7 @@ func (f *fakeContractReader) GenerateBlocksTillConfidenceLevel(_ *testing.T, _, 
 }
 
 type errContractReader struct {
-	types.UnimplementedContractReader
+	types.ContractReader
 	err error
 }
 
@@ -641,7 +641,7 @@ func (e *errContractReader) QueryKey(_ context.Context, _ types.BoundContract, _
 }
 
 type protoConversionTestContractReader struct {
-	types.UnimplementedContractReader
+	types.ContractReader
 	expectedBindings     types.BoundContract
 	expectedQueryFilter  query.KeyFilter
 	expectedLimitAndSort query.LimitAndSort

--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/test/contract_reader.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/test/contract_reader.go
@@ -26,7 +26,7 @@ var (
 
 // staticContractReader is a static implementation of ContractReaderTester
 type staticContractReader struct {
-	types.UnimplementedContractReader
+	types.ContractReader
 	address        string
 	contractName   string
 	contractMethod string

--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -17,49 +17,96 @@ const (
 	ErrNotFound                    = NotFoundError("not found")
 )
 
-// ContractReader defines essential read operations a chain should implement for reading contract values and events.
+/*
 type ContractReader interface {
 	services.Service
-	// GetLatestValue gets the latest value with a certain confidence level that maps to blockchain finality....
-	// The params argument can be any object which maps a set of generic parameters into chain specific parameters defined in RelayConfig.
-	// It must encode as an object via [json.Marshal] and [github.com/fxamacker/cbor/v2.Marshal].
-	// Typically, would be either a struct with field names mapping to arguments, or anonymous map such as `map[string]any{"baz": 42, "test": true}}`
-	//
-	// returnVal must [json.Unmarshal] and and [github.com/fxamacker/cbor/v2.Marshal] as an object.
-	//
-	// Example use:
-	//  type ProductParams struct {
-	// 		ID int `json:"id"`
-	//  }
-	//  type ProductReturn struct {
-	// 		Foo string `json:"foo"`
-	// 		Bar *big.Int `json:"bar"`
-	//  }
-	//  func do(ctx context.Context, cr ContractReader) (resp ProductReturn, err error) {
-	// 		err = cr.GetLatestValue(ctx, "FooContract", "GetProduct", primitives.Finalized, ProductParams{ID:1}, &resp)
-	// 		return
-	//  }
-	//
-	// Note that implementations should ignore extra fields in params that are not expected in the call to allow easier
-	// use across chains and contract versions.
-	// Similarly, when using a struct for returnVal, fields in the return value that are not on-chain will not be set.
 	GetLatestValue(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) error
 
-	// BatchGetLatestValues batches get latest value calls based on request, which is grouped by contract names that each have a slice of BatchRead.
-	// BatchGetLatestValuesRequest params and returnVal follow same rules as GetLatestValue params and returnVal arguments, with difference in how response is returned.
-	// BatchGetLatestValuesResult response is grouped by contract names, which contain read results that maintain the order from the request.
-	// Contract call errors are returned in the Err field of BatchGetLatestValuesResult.
 	BatchGetLatestValues(ctx context.Context, request BatchGetLatestValuesRequest) (BatchGetLatestValuesResult, error)
 
-	// Bind will add provided bindings and will return an error if the contract is not known by the ContractReader, or if
-	// the Address is invalid. Any provided binding that already exists should result in a noop.
-	Bind(ctx context.Context, bindings []BoundContract) error
+}
+*/
 
-	// Unbind will remove all provided bindings.
-	Unbind(ctx context.Context, bindings []BoundContract) error
+// ContractReader defines essential read operations a chain should implement for reading contract values and events.
+type ContractReader struct {
+	services.Service
+}
 
-	// QueryKey provides fetching chain agnostic events (Sequence) with general querying capability.
-	QueryKey(ctx context.Context, contract BoundContract, filter query.KeyFilter, limitAndSort query.LimitAndSort, sequenceDataType any) ([]Sequence, error)
+// GetLatestValue gets the latest value with a certain confidence level that maps to blockchain finality....
+// The params argument can be any object which maps a set of generic parameters into chain specific parameters defined in RelayConfig.
+// It must encode as an object via [json.Marshal] and [github.com/fxamacker/cbor/v2.Marshal].
+// Typically, would be either a struct with field names mapping to arguments, or anonymous map such as `map[string]any{"baz": 42, "test": true}}`
+//
+// returnVal must [json.Unmarshal] and and [github.com/fxamacker/cbor/v2.Marshal] as an object.
+//
+// Example use:
+//
+//	 type ProductParams struct {
+//			ID int `json:"id"`
+//	 }
+//	 type ProductReturn struct {
+//			Foo string `json:"foo"`
+//			Bar *big.Int `json:"bar"`
+//	 }
+//	 func do(ctx context.Context, cr ContractReader) (resp ProductReturn, err error) {
+//			err = cr.GetLatestValue(ctx, "FooContract", "GetProduct", primitives.Finalized, ProductParams{ID:1}, &resp)
+//			return
+//	 }
+//
+// Note that implementations should ignore extra fields in params that are not expected in the call to allow easier
+// use across chains and contract versions.
+// Similarly, when using a struct for returnVal, fields in the return value that are not on-chain will not be set.
+func (ContractReader) GetLatestValue(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) error {
+	return UnimplementedError("ContractReader.GetLatestValue unimplemented")
+}
+
+// BatchGetLatestValues batches get latest value calls based on request, which is grouped by contract names that each have a slice of BatchRead.
+// BatchGetLatestValuesRequest params and returnVal follow same rules as GetLatestValue params and returnVal arguments, with difference in how response is returned.
+// BatchGetLatestValuesResult response is grouped by contract names, which contain read results that maintain the order from the request.
+// Contract call errors are returned in the Err field of BatchGetLatestValuesResult.
+func (ContractReader) BatchGetLatestValues(ctx context.Context, request BatchGetLatestValuesRequest) (BatchGetLatestValuesResult, error) {
+	return nil, UnimplementedError("ContractReader.BatchGetLatestValues unimplemented")
+}
+
+// Bind will add provided bindings and will return an error if the contract is not known by the ContractReader, or if
+// the Address is invalid. Any provided binding that already exists should result in a noop.
+func (ContractReader) Bind(ctx context.Context, bindings []BoundContract) error {
+	return UnimplementedError("ContractReader.Bind unimplemented")
+}
+
+// Unbind will remove all provided bindings.
+func (ContractReader) Unbind(ctx context.Context, bindings []BoundContract) error {
+	return UnimplementedError("ContractReader.Unbind unimplemented")
+}
+
+// QueryKey provides fetching chain agnostic events (Sequence) with general querying capability.
+func (ContractReader) QueryKey(ctx context.Context, boundContract BoundContract, filter query.KeyFilter, limitAndSort query.LimitAndSort, sequenceDataType any) ([]Sequence, error) {
+	return nil, UnimplementedError("ContractReader.QueryKey unimplemented")
+}
+
+// mustEmbedUnimplementedContractReaderServer surely serves some purpose, but I don't totally understand it.
+func (ContractReader) mustEmbedUnimplementedContractReaderServer() {}
+
+// Sneaky functions below are not part of the original ContractReader interface.
+
+func (ContractReader) Start(context.Context) error {
+	return UnimplementedError("ContractReader.Start unimplemented")
+}
+
+func (ContractReader) Close() error {
+	return UnimplementedError("ContractReader.Close unimplemented")
+}
+
+func (ContractReader) HealthReport() map[string]error {
+	panic(UnimplementedError("ContractReader.HealthReport unimplemented"))
+}
+
+func (ContractReader) Name() string {
+	panic(UnimplementedError("ContractReader.Name unimplemented"))
+}
+
+func (ContractReader) Ready() error {
+	return UnimplementedError("ContractReader.Ready unimplemented")
 }
 
 // BatchGetLatestValuesRequest string is contract name.
@@ -117,48 +164,4 @@ func (bc BoundContract) ReadIdentifier(readName string) string {
 
 func (bc BoundContract) String() string {
 	return bc.Address + "-" + bc.Name
-}
-
-type UnimplementedContractReader struct{}
-
-var _ ContractReader = UnimplementedContractReader{}
-
-func (UnimplementedContractReader) GetLatestValue(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) error {
-	return UnimplementedError("ContractReader.GetLatestValue unimplemented")
-}
-
-func (UnimplementedContractReader) BatchGetLatestValues(ctx context.Context, request BatchGetLatestValuesRequest) (BatchGetLatestValuesResult, error) {
-	return nil, UnimplementedError("ContractReader.BatchGetLatestValues unimplemented")
-}
-
-func (UnimplementedContractReader) Bind(ctx context.Context, bindings []BoundContract) error {
-	return UnimplementedError("ContractReader.Bind unimplemented")
-}
-
-func (UnimplementedContractReader) Unbind(ctx context.Context, bindings []BoundContract) error {
-	return UnimplementedError("ContractReader.Unbind unimplemented")
-}
-
-func (UnimplementedContractReader) QueryKey(ctx context.Context, boundContract BoundContract, filter query.KeyFilter, limitAndSort query.LimitAndSort, sequenceDataType any) ([]Sequence, error) {
-	return nil, UnimplementedError("ContractReader.QueryKey unimplemented")
-}
-
-func (UnimplementedContractReader) Start(context.Context) error {
-	return UnimplementedError("ContractReader.Start unimplemented")
-}
-
-func (UnimplementedContractReader) Close() error {
-	return UnimplementedError("ContractReader.Close unimplemented")
-}
-
-func (UnimplementedContractReader) HealthReport() map[string]error {
-	panic(UnimplementedError("ContractReader.HealthReport unimplemented"))
-}
-
-func (UnimplementedContractReader) Name() string {
-	panic(UnimplementedError("ContractReader.Name unimplemented"))
-}
-
-func (UnimplementedContractReader) Ready() error {
-	return UnimplementedError("ContractReader.Ready unimplemented")
 }


### PR DESCRIPTION
This might be an option for defining the ChainReader "interface" and also prevent people from using it incorrectly.