### PR TITLE
ccip - Add Limit method to seq num range

### DIFF
--- a/pkg/types/ccipocr3/generic_types.go
+++ b/pkg/types/ccipocr3/generic_types.go
@@ -62,6 +62,27 @@ func (s *SeqNumRange) SetEnd(v SeqNum) {
 	s[1] = v
 }
 
+// Limit returns a range limited up to n elements by truncating the end if necessary.
+// Example: [1 -> 10].Limit(5) => [1 -> 5]
+func (s *SeqNumRange) Limit(n uint64) SeqNumRange {
+	limitedRange := NewSeqNumRange(s.Start(), s.End())
+
+	numElems := s.End() - s.Start() + 1
+	if numElems <= 0 {
+		return limitedRange
+	}
+
+	if uint64(numElems) > n {
+		newEnd := limitedRange.Start() + SeqNum(n) - 1
+		if newEnd > limitedRange.End() { // overflow - do nothing
+			return limitedRange
+		}
+		limitedRange.SetEnd(newEnd)
+	}
+
+	return limitedRange
+}
+
 // Overlaps returns true if the two ranges overlap.
 func (s SeqNumRange) Overlaps(other SeqNumRange) bool {
 	return s.Start() <= other.End() && other.Start() <= s.End()

--- a/pkg/types/ccipocr3/generic_types_test.go
+++ b/pkg/types/ccipocr3/generic_types_test.go
@@ -80,6 +80,61 @@ func TestSeqNumRange_Contains(t *testing.T) {
 	}
 }
 
+func TestSeqNumRangeLimit(t *testing.T) {
+	testCases := []struct {
+		name string
+		rng  SeqNumRange
+		n    uint64
+		want SeqNumRange
+	}{
+		{
+			name: "no truncation",
+			rng:  NewSeqNumRange(0, 10),
+			n:    11,
+			want: NewSeqNumRange(0, 10),
+		},
+		{
+			name: "no truncation 2",
+			rng:  NewSeqNumRange(100, 110),
+			n:    11,
+			want: NewSeqNumRange(100, 110),
+		},
+		{
+			name: "truncation",
+			rng:  NewSeqNumRange(0, 10),
+			n:    10,
+			want: NewSeqNumRange(0, 9),
+		},
+		{
+			name: "truncation 2",
+			rng:  NewSeqNumRange(100, 110),
+			n:    10,
+			want: NewSeqNumRange(100, 109),
+		},
+		{
+			name: "empty",
+			rng:  NewSeqNumRange(0, 0),
+			n:    0,
+			want: NewSeqNumRange(0, 0),
+		},
+		{
+			name: "wrong range",
+			rng:  NewSeqNumRange(20, 15),
+			n:    3,
+			want: NewSeqNumRange(20, 15),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.rng.Limit(tc.n)
+			if got != tc.want {
+				t.Errorf("SeqNumRangeLimit(%v, %v) = %v; want %v", tc.rng, tc.n, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCCIPMsg_String(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Add `Limit` method that returns a copy of the provided `SeqNumRange` limited up to `n` elements by truncating the end.