### PR TITLE
fix lint issues

### DIFF
--- a/pkg/loop/internal/core/services/capability/capabilities_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_test.go
@@ -468,7 +468,6 @@ func Test_Capabilities(t *testing.T) {
 			expectedRequest)
 		require.NotNil(t, err)
 		assert.Equal(t, "bang", err.Error())
-
 	})
 
 	t.Run("fetching an action capability, and closing it", func(t *testing.T) {
@@ -494,7 +493,6 @@ func Test_Capabilities(t *testing.T) {
 			ctx,
 			expectedRequest)
 		require.NoError(t, err)
-
 	})
 
 	t.Run("calling execute should be synchronous", func(t *testing.T) {


### PR DESCRIPTION
```
pkg/monitoring/manager.go:76:4: nested context in loop (fatcontext)
                        localCtx, localCtxCancel = context.WithCancel(backgroundCtx)
                        ^
pkg/loop/internal/core/services/capability/capabilities_test.go:472:2: unnecessary trailing newline (whitespace)

^
pkg/loop/internal/core/services/capability/capabilities_test.go:498:2: unnecessary trailing newline (whitespace)

^
```