### PR TITLE
More alias handling in Unwrap functionality of Value 

### DIFF
--- a/pkg/values/bytes_test.go
+++ b/pkg/values/bytes_test.go
@@ -17,9 +17,14 @@ func Test_BytesUnwrapTo(t *testing.T) {
 
 	assert.Equal(t, hs, got)
 
-	var s string
-	err = tr.UnwrapTo(&s)
+	var b bool
+	err = tr.UnwrapTo(&b)
 	require.Error(t, err)
+
+	str := ""
+	err = tr.UnwrapTo(&str)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(str), tr.Underlying)
 
 	gotB := (*[]byte)(nil)
 	err = tr.UnwrapTo(gotB)
@@ -55,6 +60,17 @@ func Test_BytesUnwrapToAlias(t *testing.T) {
 
 	got := []byte{}
 	for _, b := range bp {
+		got = append(got, byte(b))
+	}
+	assert.Equal(t, underlying, got)
+
+	var oracleIDs [5]alias
+	underlying = []byte("hello")
+	bn = &Bytes{Underlying: underlying}
+	err = bn.UnwrapTo(&oracleIDs)
+	require.NoError(t, err)
+	got = []byte{}
+	for _, b := range oracleIDs {
 		got = append(got, byte(b))
 	}
 	assert.Equal(t, underlying, got)

--- a/pkg/values/int.go
+++ b/pkg/values/int.go
@@ -52,6 +52,9 @@ func (i *Int64) UnwrapTo(to any) error {
 			return fmt.Errorf("cannot unwrap int64 to %T: overflow", to)
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if i.Underlying < 0 {
+			return fmt.Errorf("cannot unwrap int64 to %T: underflow", to)
+		}
 		if rToVal.OverflowUint(uint64(i.Underlying)) {
 			return fmt.Errorf("cannot unwrap int64 to %T: overflow", to)
 		}

--- a/pkg/values/int.go
+++ b/pkg/values/int.go
@@ -55,6 +55,9 @@ func (i *Int64) UnwrapTo(to any) error {
 		if rToVal.OverflowUint(uint64(i.Underlying)) {
 			return fmt.Errorf("cannot unwrap int64 to %T: overflow", to)
 		}
+	case reflect.Interface:
+	default:
+		return fmt.Errorf("cannot unwrap to type %T", to)
 	}
 
 	return unwrapTo(i.Underlying, to)

--- a/pkg/values/int.go
+++ b/pkg/values/int.go
@@ -3,7 +3,6 @@ package values
 import (
 	"errors"
 	"fmt"
-	"math"
 	"reflect"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/values/pb"
@@ -42,74 +41,21 @@ func (i *Int64) UnwrapTo(to any) error {
 		return fmt.Errorf("cannot unwrap to nil pointer: %+v", to)
 	}
 
-	switch tv := to.(type) {
-	case *int64:
-		*tv = i.Underlying
-		return nil
-	case *int:
-		if i.Underlying > math.MaxInt {
-			return fmt.Errorf("cannot unwrap int64 to int: number would overflow %d", i)
-		}
-
-		if i.Underlying < math.MinInt {
-			return fmt.Errorf("cannot unwrap int64 to int: number would underflow %d", i)
-		}
-
-		*tv = int(i.Underlying)
-		return nil
-	case *uint:
-		if i.Underlying > math.MaxInt {
-			return fmt.Errorf("cannot unwrap int64 to int: number would overflow %d", i)
-		}
-
-		if i.Underlying < 0 {
-			return fmt.Errorf("cannot unwrap int64 to uint: number would underflow %d", i)
-		}
-
-		*tv = uint(i.Underlying)
-		return nil
-	case *uint32:
-		if i.Underlying > math.MaxInt {
-			return fmt.Errorf("cannot unwrap int64 to uint32: number would overflow %d", i)
-		}
-
-		if i.Underlying < 0 {
-			return fmt.Errorf("cannot unwrap int64 to uint32: number would underflow %d", i)
-		}
-
-		*tv = uint32(i.Underlying)
-		return nil
-	case *uint64:
-		if i.Underlying < 0 {
-			return fmt.Errorf("cannot unwrap int64 to uint: number would underflow %d", i)
-		}
-
-		*tv = uint64(i.Underlying)
-		return nil
-	case *any:
-		*tv = i.Underlying
-		return nil
+	if reflect.ValueOf(to).Kind() != reflect.Pointer {
+		return fmt.Errorf("cannot unwrap to non-pointer value: %+v", to)
 	}
 
-	rv := reflect.ValueOf(to)
-	if rv.Kind() == reflect.Ptr {
-		switch rv.Elem().Kind() {
-		case reflect.Int64:
-			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(int64(0)))).Interface())
-		case reflect.Int32:
-			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(int32(0)))).Interface())
-		case reflect.Int:
-			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(int(0)))).Interface())
-		case reflect.Uint64:
-			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(uint64(0)))).Interface())
-		case reflect.Uint32:
-			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(uint32(0)))).Interface())
-		case reflect.Uint:
-			return i.UnwrapTo(rv.Convert(reflect.PointerTo(reflect.TypeOf(uint(0)))).Interface())
-		default:
-			// fall through to the error, default is required by lint
+	rToVal := reflect.Indirect(reflect.ValueOf(to))
+	switch rToVal.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if rToVal.OverflowInt(i.Underlying) {
+			return fmt.Errorf("cannot unwrap int64 to %T: overflow", to)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if rToVal.OverflowUint(uint64(i.Underlying)) {
+			return fmt.Errorf("cannot unwrap int64 to %T: overflow", to)
 		}
 	}
 
-	return fmt.Errorf("cannot unwrap to type %T", to)
+	return unwrapTo(i.Underlying, to)
 }

--- a/pkg/values/int_test.go
+++ b/pkg/values/int_test.go
@@ -81,10 +81,18 @@ func Test_IntUnwrapping(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 
-	t.Run("int64 -> int32; underflow", func(st *testing.T) {
+	t.Run("int64 -> uint32; underflow", func(st *testing.T) {
 		expected := int64(math.MinInt64)
 		v := NewInt64(expected)
 		got := uint32(0)
+		err := v.UnwrapTo(&got)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("int64 -> uint64; underflow", func(st *testing.T) {
+		expected := int64(math.MinInt64)
+		v := NewInt64(expected)
+		got := uint64(0)
 		err := v.UnwrapTo(&got)
 		assert.NotNil(t, err)
 	})

--- a/pkg/values/int_test.go
+++ b/pkg/values/int_test.go
@@ -1,6 +1,7 @@
 package values
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,4 +36,56 @@ func Test_IntUnwrapTo(t *testing.T) {
 	var i int64
 	err = in.UnwrapTo(&i)
 	assert.ErrorContains(t, err, "cannot unwrap nil")
+}
+
+func Test_IntUnwrapping(t *testing.T) {
+	t.Run("int64 -> int32", func(st *testing.T) {
+		expected := int64(100)
+		v := NewInt64(expected)
+		got := int32(0)
+		err := v.UnwrapTo(&got)
+		require.NoError(t, err)
+		assert.Equal(t, int32(expected), got)
+	})
+
+	t.Run("int64 -> int32; overflow", func(st *testing.T) {
+		expected := int64(math.MaxInt64)
+		v := NewInt64(expected)
+		got := int32(0)
+		err := v.UnwrapTo(&got)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("int64 -> int32; underflow", func(st *testing.T) {
+		expected := int64(math.MinInt64)
+		v := NewInt64(expected)
+		got := int32(0)
+		err := v.UnwrapTo(&got)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("int64 -> uint32", func(st *testing.T) {
+		expected := int64(100)
+		v := NewInt64(expected)
+		got := uint32(0)
+		err := v.UnwrapTo(&got)
+		require.NoError(t, err)
+		assert.Equal(t, uint32(expected), got)
+	})
+
+	t.Run("int64 -> uint32; overflow", func(st *testing.T) {
+		expected := int64(math.MaxInt64)
+		v := NewInt64(expected)
+		got := uint32(0)
+		err := v.UnwrapTo(&got)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("int64 -> int32; underflow", func(st *testing.T) {
+		expected := int64(math.MinInt64)
+		v := NewInt64(expected)
+		got := uint32(0)
+		err := v.UnwrapTo(&got)
+		assert.NotNil(t, err)
+	})
 }


### PR DESCRIPTION
## Updates

- Generic case to handle both pointer type and raw type of type aliases in generic unwrap[T] function
- Simplify int unwrap to have common logic for different int types like int8, int16 etc.,. and alias handling using the above logic
- Update values_test, bytes_test and add new test cases for int_test

## Testing

```
$ go test -count=1 -v ./pkg/values
...
== RUN   Test_Aliases/int
=== RUN   Test_Aliases/[][]byte_->_[]aliasByte
=== RUN   Test_Aliases/aliasMap_->_map[string]any
--- PASS: Test_Aliases (0.00s)
    --- PASS: Test_Aliases/alias_to_[]byte (0.00s)
    --- PASS: Test_Aliases/simple_aliases (0.00s)
    --- PASS: Test_Aliases/aliasByte_->_[]byte (0.00s)
    --- PASS: Test_Aliases/[]aliasSingleByte_->_[]byte (0.00s)
    --- PASS: Test_Aliases/int (0.00s)
    --- PASS: Test_Aliases/[][]byte_->_[]aliasByte (0.00s)
    --- PASS: Test_Aliases/aliasMap_->_map[string]any (0.00s)
PASS
ok      github.com/smartcontractkit/chainlink-common/pkg/values 0.246s
```