### PR TITLE
Add binary + config to custom compute

### DIFF
--- a/pkg/workflows/exec/interpolation.go
+++ b/pkg/workflows/exec/interpolation.go
@@ -87,8 +87,12 @@ func InterpolateKey(key string, state Results) (any, error) {
 func FindAndInterpolateAllKeys(input any, state Results) (any, error) {
 	return workflows.DeepMap(
 		input,
-		func(el string) (any, error) {
-			matches := workflows.InterpolationTokenRe.FindStringSubmatch(el)
+		func(el any) (any, error) {
+			if _, ok := el.(string); !ok {
+				return el, nil
+			}
+
+			matches := workflows.InterpolationTokenRe.FindStringSubmatch(el.(string))
 			if len(matches) < 2 {
 				return el, nil
 			}
@@ -111,19 +115,23 @@ type Env struct {
 func FindAndInterpolateEnvVars(input any, env Env) (any, error) {
 	return workflows.DeepMap(
 		input,
-		func(el string) (any, error) {
-			matches := workflows.InterpolationTokenRe.FindStringSubmatch(el)
+		func(el any) (any, error) {
+			if _, ok := el.(string); !ok {
+				return el, nil
+			}
+
+			matches := workflows.InterpolationTokenRe.FindStringSubmatch(el.(string))
 			if len(matches) < 2 {
 				return el, nil
 			}
 
 			splitToken := strings.Split(matches[1], ".")
 			if len(splitToken) != 2 {
-				return "", fmt.Errorf("invalid env token: must be of the form $(ENV.<config|binary>): got %s", el)
+				return el, nil
 			}
 
 			if splitToken[0] != "ENV" {
-				return "", fmt.Errorf("invalid env token: must be of the form $(ENV.<config|binary>): got %s", el)
+				return el, nil
 			}
 
 			switch splitToken[1] {

--- a/pkg/workflows/exec/interpolation.go
+++ b/pkg/workflows/exec/interpolation.go
@@ -98,3 +98,42 @@ func FindAndInterpolateAllKeys(input any, state Results) (any, error) {
 		},
 	)
 }
+
+type Env struct {
+	Binary []byte
+	Config []byte
+}
+
+// FindAndInterpolateEnv takes a `config` any value, and recursively
+// identifies any values that should be replaced from `env`.
+//
+// A value `v` should be replaced if it is wrapped as follows: `$(v)`.
+func FindAndInterpolateEnvVars(input any, env Env) (any, error) {
+	return workflows.DeepMap(
+		input,
+		func(el string) (any, error) {
+			matches := workflows.InterpolationTokenRe.FindStringSubmatch(el)
+			if len(matches) < 2 {
+				return el, nil
+			}
+
+			splitToken := strings.Split(matches[1], ".")
+			if len(splitToken) != 2 {
+				return "", fmt.Errorf("invalid env token: must be of the form $(ENV.<config|binary>): got %s", el)
+			}
+
+			if splitToken[0] != "ENV" {
+				return "", fmt.Errorf("invalid env token: must be of the form $(ENV.<config|binary>): got %s", el)
+			}
+
+			switch splitToken[1] {
+			case "config":
+				return env.Config, nil
+			case "binary":
+				return env.Binary, nil
+			default:
+				return "", fmt.Errorf("invalid env token: must be of the form $(ENV.<config|binary>): got %s", el)
+			}
+		},
+	)
+}

--- a/pkg/workflows/exec/interpolation_test.go
+++ b/pkg/workflows/exec/interpolation_test.go
@@ -237,7 +237,7 @@ func TestInterpolateEnv(t *testing.T) {
 		"binary": "$(something-else)",
 	}
 	_, err = exec.FindAndInterpolateEnvVars(c, exec.Env{})
-	assert.Error(t, err, "invalid env token")
+	assert.NoError(t, err)
 
 	c = map[string]any{
 		"binary": "something-else",

--- a/pkg/workflows/sdk/compute_generated.go
+++ b/pkg/workflows/sdk/compute_generated.go
@@ -27,10 +27,13 @@ func (input Compute1Inputs[I0]) ToSteps() StepInputs {
 
 func Compute1[I0 any, O any](w *WorkflowSpecFactory, ref string, input Compute1Inputs[I0], compute func(Runtime, I0) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 
@@ -91,10 +94,13 @@ func (input Compute2Inputs[I0, I1]) ToSteps() StepInputs {
 
 func Compute2[I0 any, I1 any, O any](w *WorkflowSpecFactory, ref string, input Compute2Inputs[I0, I1], compute func(Runtime, I0, I1) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 
@@ -158,10 +164,13 @@ func (input Compute3Inputs[I0, I1, I2]) ToSteps() StepInputs {
 
 func Compute3[I0 any, I1 any, I2 any, O any](w *WorkflowSpecFactory, ref string, input Compute3Inputs[I0, I1, I2], compute func(Runtime, I0, I1, I2) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 
@@ -228,10 +237,13 @@ func (input Compute4Inputs[I0, I1, I2, I3]) ToSteps() StepInputs {
 
 func Compute4[I0 any, I1 any, I2 any, I3 any, O any](w *WorkflowSpecFactory, ref string, input Compute4Inputs[I0, I1, I2, I3], compute func(Runtime, I0, I1, I2, I3) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 
@@ -301,10 +313,13 @@ func (input Compute5Inputs[I0, I1, I2, I3, I4]) ToSteps() StepInputs {
 
 func Compute5[I0 any, I1 any, I2 any, I3 any, I4 any, O any](w *WorkflowSpecFactory, ref string, input Compute5Inputs[I0, I1, I2, I3, I4], compute func(Runtime, I0, I1, I2, I3, I4) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 
@@ -377,10 +392,13 @@ func (input Compute6Inputs[I0, I1, I2, I3, I4, I5]) ToSteps() StepInputs {
 
 func Compute6[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, O any](w *WorkflowSpecFactory, ref string, input Compute6Inputs[I0, I1, I2, I3, I4, I5], compute func(Runtime, I0, I1, I2, I3, I4, I5) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 
@@ -456,10 +474,13 @@ func (input Compute7Inputs[I0, I1, I2, I3, I4, I5, I6]) ToSteps() StepInputs {
 
 func Compute7[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, O any](w *WorkflowSpecFactory, ref string, input Compute7Inputs[I0, I1, I2, I3, I4, I5, I6], compute func(Runtime, I0, I1, I2, I3, I4, I5, I6) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 
@@ -538,10 +559,13 @@ func (input Compute8Inputs[I0, I1, I2, I3, I4, I5, I6, I7]) ToSteps() StepInputs
 
 func Compute8[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, I7 any, O any](w *WorkflowSpecFactory, ref string, input Compute8Inputs[I0, I1, I2, I3, I4, I5, I6, I7], compute func(Runtime, I0, I1, I2, I3, I4, I5, I6, I7) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 
@@ -623,10 +647,13 @@ func (input Compute9Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8]) ToSteps() StepIn
 
 func Compute9[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, I7 any, I8 any, O any](w *WorkflowSpecFactory, ref string, input Compute9Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8], compute func(Runtime, I0, I1, I2, I3, I4, I5, I6, I7, I8) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 
@@ -711,10 +738,13 @@ func (input Compute10Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8, I9]) ToSteps() S
 
 func Compute10[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, I7 any, I8 any, I9 any, O any](w *WorkflowSpecFactory, ref string, input Compute10Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8, I9], compute func(Runtime, I0, I1, I2, I3, I4, I5, I6, I7, I8, I9) (O, error)) ComputeOutputCap[O] {
 	def := StepDefinition{
-		ID:             "__internal__custom_compute@1.0.0",
-		Ref:            ref,
-		Inputs:         input.ToSteps(),
-		Config:         map[string]any{},
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
 		CapabilityType: capabilities.CapabilityTypeAction,
 	}
 

--- a/pkg/workflows/sdk/compute_test.go
+++ b/pkg/workflows/sdk/compute_test.go
@@ -53,12 +53,15 @@ func TestCompute(t *testing.T) {
 			},
 			Actions: []sdk.StepDefinition{
 				{
-					ID:  "__internal__custom_compute@1.0.0",
+					ID:  "custom_compute@1.0.0",
 					Ref: "Compute",
 					Inputs: sdk.StepInputs{
 						Mapping: map[string]any{"Arg0": "$(trigger.outputs)"},
 					},
-					Config:         map[string]any{},
+					Config: map[string]any{
+						"binary": "$(ENV.binary)",
+						"config": "$(ENV.config)",
+					},
 					CapabilityType: capabilities.CapabilityTypeAction,
 				},
 			},

--- a/pkg/workflows/sdk/gen/compute.go.tmpl
+++ b/pkg/workflows/sdk/gen/compute.go.tmpl
@@ -32,10 +32,13 @@ func (input Compute{{.}}Inputs[{{range RangeNum . }}I{{.}},{{ end }}]) ToSteps()
 
 func Compute{{.}}[{{range  RangeNum .}}I{{.}} any, {{ end }}O any](w *WorkflowSpecFactory, ref string, input Compute{{.}}Inputs[{{range RangeNum . }}I{{.}},{{ end }}], compute func(Runtime, {{range RangeNum . }}I{{.}},{{ end }})(O, error)) ComputeOutputCap[O] {
     def := StepDefinition{
-       ID: "__internal__custom_compute@1.0.0",
+       ID: "custom_compute@1.0.0",
        Ref: ref,
        Inputs: input.ToSteps(),
-       Config: map[string]any{},
+       Config: map[string]any{
+         "config": "$(ENV.config)",
+         "binary": "$(ENV.binary)",
+       },
        CapabilityType: capabilities.CapabilityTypeAction,
    }
 

--- a/pkg/workflows/sdk/testutils/compute_capability.go
+++ b/pkg/workflows/sdk/testutils/compute_capability.go
@@ -14,7 +14,7 @@ type computeCapability struct {
 
 func (c *computeCapability) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {
 	info := capabilities.MustNewCapabilityInfo(
-		"__internal__custom_compute@1.0.0", capabilities.CapabilityTypeAction, "Custom compute capability",
+		"custom_compute@1.0.0", capabilities.CapabilityTypeAction, "Custom compute capability",
 	)
 	info.IsLocal = true
 	return info, nil


### PR DESCRIPTION
* Add InterpolateEnvVars to allow the binary + config to be passed to capabilities as part of the execute request.
* Modify the custom compute generated capability to pass in the binary + config.