### PR TITLE
Add MustEmbed Constraint to Contract Reader

### DIFF
--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -61,6 +61,8 @@ type ContractReader interface {
 
 	// QueryKey provides fetching chain agnostic events (Sequence) with general querying capability.
 	QueryKey(ctx context.Context, contract BoundContract, filter query.KeyFilter, limitAndSort query.LimitAndSort, sequenceDataType any) ([]Sequence, error)
+
+	mustEmbedUnimplementedContractReader()
 }
 
 // BatchGetLatestValuesRequest string is contract name.
@@ -163,3 +165,5 @@ func (UnimplementedContractReader) Name() string {
 func (UnimplementedContractReader) Ready() error {
 	return UnimplementedError("ContractReader.Ready unimplemented")
 }
+
+func (UnimplementedContractReader) mustEmbedUnimplementedContractReader() {}


### PR DESCRIPTION
Reintroducing the must embed constraint to `ContractReader` implementations to ensure that all implementations of `ContractReader` embed the `UnimplementedContractReader`.

If an implementation contains the unemplemented struct, changes to the interface will flow down to all implementations without introducing breaking changes.