### PR TITLE
Extract expirable cache abstraction for reuse

### DIFF
--- a/pkg/utils/cache/expirable_cache.go
+++ b/pkg/utils/cache/expirable_cache.go
@@ -1,0 +1,139 @@
+package cache
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+)
+
+type StatsCollector interface {
+	OnCacheHit()
+	OnCacheMiss()
+	OnCacheEviction(int)
+	OnCacheAddition()
+}
+
+// ExpirableCache is a cache that evicts entries after a configurable time of inactivity once a minimum size is reached.
+// It is safe for concurrent use.
+type ExpirableCache[K comparable, V any] struct {
+	m  map[K]*cachedValue[V]
+	mu sync.RWMutex
+
+	wg       sync.WaitGroup
+	stopChan services.StopChan
+
+	tickInterval   time.Duration
+	timeout        time.Duration
+	evictAfterSize int
+
+	statsCollector StatsCollector
+
+	clock clockwork.Clock
+}
+
+type cachedValue[V any] struct {
+	value         V
+	lastFetchedAt time.Time
+}
+
+type noopStatsCollector struct{}
+
+func (n *noopStatsCollector) OnCacheHit()         {}
+func (n *noopStatsCollector) OnCacheMiss()        {}
+func (n *noopStatsCollector) OnCacheEviction(int) {}
+func (n *noopStatsCollector) OnCacheAddition()    {}
+
+// NewExpirableCache creates a new ExpirableCache with the given tick interval, expiry time, and minimum size.  An optional
+// statsCollector can be provided to collect cache stats.
+func NewExpirableCache[K comparable, V any](clock clockwork.Clock, tick, expiryAfter time.Duration, evictAfterSize int,
+	statsCollector StatsCollector) *ExpirableCache[K, V] {
+
+	if statsCollector == nil {
+		statsCollector = &noopStatsCollector{}
+	}
+
+	return &ExpirableCache[K, V]{
+		m:              map[K]*cachedValue[V]{},
+		tickInterval:   tick,
+		timeout:        expiryAfter,
+		evictAfterSize: evictAfterSize,
+		clock:          clock,
+		stopChan:       make(chan struct{}),
+		statsCollector: statsCollector,
+	}
+}
+
+func (ec *ExpirableCache[K, V]) Start() {
+	ec.wg.Add(1)
+	go func() {
+		defer ec.wg.Done()
+		ec.reapLoop()
+	}()
+}
+
+func (ec *ExpirableCache[K, V]) Close() {
+	close(ec.stopChan)
+	ec.wg.Wait()
+}
+
+func (ec *ExpirableCache[K, V]) reapLoop() {
+	ticker := ec.clock.NewTicker(ec.tickInterval)
+	for {
+		select {
+		case <-ticker.Chan():
+			ec.evictOlderThan(ec.timeout)
+		case <-ec.stopChan:
+			return
+		}
+	}
+}
+
+func (ec *ExpirableCache[K, V]) Add(id K, v V) {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	ec.m[id] = &cachedValue[V]{
+		value:         v,
+		lastFetchedAt: time.Now(),
+	}
+	ec.statsCollector.OnCacheAddition()
+}
+
+func (ec *ExpirableCache[K, V]) Get(id K) (V, bool) {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	fetchdValue, ok := ec.m[id]
+	if !ok {
+		ec.statsCollector.OnCacheMiss()
+		var zero V
+		return zero, false
+	}
+
+	ec.statsCollector.OnCacheHit()
+	fetchdValue.lastFetchedAt = ec.clock.Now()
+	return fetchdValue.value, true
+}
+
+func (ec *ExpirableCache[K, V]) evictOlderThan(duration time.Duration) {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+
+	evicted := 0
+
+	if len(ec.m) > ec.evictAfterSize {
+		for id, m := range ec.m {
+			if ec.clock.Now().Sub(m.lastFetchedAt) > duration {
+				delete(ec.m, id)
+				evicted++
+			}
+
+			if len(ec.m) <= ec.evictAfterSize {
+				break
+			}
+		}
+	}
+
+	ec.statsCollector.OnCacheEviction(evicted)
+}

--- a/pkg/utils/cache/expirable_cache.go
+++ b/pkg/utils/cache/expirable_cache.go
@@ -50,7 +50,6 @@ func (n *noopStatsCollector) OnCacheAddition()    {}
 // statsCollector can be provided to collect cache stats.
 func NewExpirableCache[K comparable, V any](clock clockwork.Clock, tick, expiryAfter time.Duration, evictAfterSize int,
 	statsCollector StatsCollector) *ExpirableCache[K, V] {
-
 	if statsCollector == nil {
 		statsCollector = &noopStatsCollector{}
 	}

--- a/pkg/utils/cache/expirable_cache_test.go
+++ b/pkg/utils/cache/expirable_cache_test.go
@@ -1,0 +1,173 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	A int
+}
+
+func TestExpirableCache(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	tick := 1 * time.Second
+	timeout := 1 * time.Second
+
+	cache := NewExpirableCache[string, testStruct](clock, tick, timeout, 0, nil)
+	cache.Start()
+	defer cache.Close()
+
+	id := uuid.New().String()
+	value := testStruct{A: 42}
+	cache.Add(id, value)
+
+	got, ok := cache.Get(id)
+	assert.True(t, ok)
+	assert.Equal(t, value, got)
+
+	assert.Eventually(t, func() bool {
+		clock.Advance(15 * time.Second)
+		_, ok := cache.Get(id)
+		return !ok
+	}, 100*time.Second, 100*time.Millisecond)
+}
+
+func TestExpirableCache_DoesNotEvictIfBelowMinimumSize(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	tick := 1 * time.Second
+	timeout := 60 * time.Second
+
+	cache := NewExpirableCache[string, testStruct](clock, tick, timeout, 1, nil)
+	cache.Start()
+	defer cache.Close()
+
+	id := uuid.New().String()
+	value := testStruct{A: 42}
+	cache.Add(id, value)
+
+	got, ok := cache.Get(id)
+	assert.True(t, ok)
+	assert.Equal(t, value, got)
+
+	clock.Advance(120 * time.Second)
+	_, ok = cache.Get(id)
+	assert.True(t, ok)
+}
+
+func TestExpirableCache_DoesNotEvictBelowMinimumSize(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	tick := 1 * time.Second
+	timeout := 60 * time.Second
+
+	cache := NewExpirableCache[string, testStruct](clock, tick, timeout, 1, nil)
+	cache.Start()
+	defer cache.Close()
+
+	id1 := uuid.New().String()
+	value1 := testStruct{A: 43}
+	cache.Add(id1, value1)
+
+	id2 := uuid.New().String()
+	value2 := testStruct{A: 44}
+	cache.Add(id2, value2)
+
+	// Advance time to check eviction behavior
+	assert.Eventually(t, func() bool {
+		clock.Advance(120 * time.Second)
+		_, ok1 := cache.Get(id1)
+		_, ok2 := cache.Get(id2)
+		return ok1 != ok2
+	}, 100*time.Second, 100*time.Millisecond)
+}
+
+func TestExpirableCache_ExpiryTimeResetAfterFetch(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	tick := 1 * time.Second
+	timeout := 100 * time.Second
+
+	cache := NewExpirableCache[string, testStruct](clock, tick, timeout, 0, nil)
+	cache.Start()
+	defer cache.Close()
+
+	id := uuid.New().String()
+	value := testStruct{A: 42}
+	cache.Add(id, value)
+
+	clock.Advance(timeout / 2)
+
+	// Fetch the item to reset its expiry time
+	_, ok := cache.Get(id)
+	assert.True(t, ok)
+
+	clock.Advance(timeout)
+
+	_, ok = cache.Get(id)
+	assert.True(t, ok)
+}
+
+func TestExpirableCache_StatsCollector(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	tick := 1 * time.Second
+	timeout := 10 * time.Second
+
+	stats := &mockStatsCollector{}
+	cache := NewExpirableCache[string, testStruct](clock, tick, timeout, 0, stats)
+	cache.Start()
+	defer cache.Close()
+
+	id := uuid.New().String()
+	value := testStruct{A: 42}
+	cache.Add(id, value)
+
+	// Check addition count
+	assert.Equal(t, 1, stats.additions)
+
+	// Fetch the item to increment hit counter
+	_, ok := cache.Get(id)
+	assert.True(t, ok)
+	assert.Equal(t, 1, stats.hits)
+
+	// Fetch a non-existent item to increment miss counter
+	_, ok = cache.Get("non-existent")
+	assert.False(t, ok)
+	assert.Equal(t, 1, stats.misses)
+
+	// Advance time to trigger eviction
+
+	assert.Eventually(t, func() bool {
+		clock.Advance(15 * time.Second)
+		_, ok := cache.Get(id)
+		return !ok
+	}, 100*time.Second, 100*time.Millisecond)
+
+	// Check eviction count
+	assert.Equal(t, 1, stats.evictions)
+}
+
+type mockStatsCollector struct {
+	hits      int
+	misses    int
+	evictions int
+	additions int
+}
+
+func (m *mockStatsCollector) OnCacheHit() {
+	m.hits++
+}
+
+func (m *mockStatsCollector) OnCacheMiss() {
+	m.misses++
+}
+
+func (m *mockStatsCollector) OnCacheEviction(count int) {
+	m.evictions += count
+}
+
+func (m *mockStatsCollector) OnCacheAddition() {
+	m.additions++
+}


### PR DESCRIPTION
There's a requirement in the ReadContract capability (sits in the capability repo, has no dependencies on core) to cache with the same behaviour as the cache in this PR -> https://github.com/smartcontractkit/chainlink/pull/14496.    

This PR extracts the cache into a generic cache for use across both use cases.

fyi @cedric-cordenier 