### PR TITLE
pkg/types/ccipocr3: add DestExecData to RampTokenAmount

### DIFF
--- a/pkg/types/ccipocr3/generic_types.go
+++ b/pkg/types/ccipocr3/generic_types.go
@@ -168,13 +168,23 @@ type RampTokenAmount struct {
 	// This value is trusted as it was obtained through the onRamp. It can be relied upon by the destination
 	// pool to validate the source pool.
 	SourcePoolAddress Bytes `json:"sourcePoolAddress"`
+
 	// DestTokenAddress is the address of the destination token, abi encoded in the case of EVM chains.
 	// This value is UNTRUSTED as any pool owner can return whatever value they want.
 	DestTokenAddress Bytes `json:"destTokenAddress"`
+
 	// ExtraData is optional pool data to be transferred to the destination chain. Be default this is capped at
 	// CCIP_LOCK_OR_BURN_V1_RET_BYTES bytes. If more data is required, the TokenTransferFeeConfig.destBytesOverhead
 	// has to be set for the specific token.
 	ExtraData Bytes `json:"extraData"`
+
 	// Amount is the amount of tokens to be transferred.
 	Amount BigInt `json:"amount"`
+
+	// DestExecData is destination chain specific execution data encoded in bytes.
+	// For an EVM destination, it consists of the amount of gas available for the releaseOrMint
+	// and transfer calls made by the offRamp.
+	// NOTE: this must be decoded before providing it as an execution input to the destination chain
+	// or hashing it. See Internal._hash(Any2EVMRampMessage) for more details as an example.
+	DestExecData Bytes `json:"destExecData"`
 }

--- a/pkg/types/ccipocr3/generic_types_test.go
+++ b/pkg/types/ccipocr3/generic_types_test.go
@@ -182,10 +182,11 @@ func TestCCIPMsg_String(t *testing.T) {
 						DestTokenAddress:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, // simulate a non-evm token
 						ExtraData:         []byte("extra token data"),
 						Amount:            BigInt{Int: big.NewInt(2000)},
+						DestExecData:      []byte("extra token data"),
 					},
 				},
 			},
-			`{"header":{"messageId":"0x0100000000000000000000000000000000000000000000000000000000000000","sourceChainSelector":"1","destChainSelector":"2","seqNum":"2","nonce":1,"msgHash":"0x2300000000000000000000000000000000000000000000000000000000000000","onRamp":"0x04d4cc5972ad487f71b85654d48b27d32b13a22f"},"sender":"0x04d4cc5972ad487f71b85654d48b27d32b13a22f","data":"0x736f6d652064617461","receiver":"0x101112131415","extraArgs":"0x65787472612061726773","feeToken":"0xb5fcc870d2ac8745054b4ba99b1f176b93382162","feeTokenAmount":"1000","tokenAmounts":[{"sourcePoolAddress":"0x3e8456720b88a1dadce8e2808c9bf73dfffd807c","destTokenAddress":"0x0102030405060708090a","extraData":"0x657874726120746f6b656e2064617461","amount":"2000"}]}`,
+			`{"header":{"messageId":"0x0100000000000000000000000000000000000000000000000000000000000000","sourceChainSelector":"1","destChainSelector":"2","seqNum":"2","nonce":1,"msgHash":"0x2300000000000000000000000000000000000000000000000000000000000000","onRamp":"0x04d4cc5972ad487f71b85654d48b27d32b13a22f"},"sender":"0x04d4cc5972ad487f71b85654d48b27d32b13a22f","data":"0x736f6d652064617461","receiver":"0x101112131415","extraArgs":"0x65787472612061726773","feeToken":"0xb5fcc870d2ac8745054b4ba99b1f176b93382162","feeTokenAmount":"1000","tokenAmounts":[{"sourcePoolAddress":"0x3e8456720b88a1dadce8e2808c9bf73dfffd807c","destTokenAddress":"0x0102030405060708090a","extraData":"0x657874726120746f6b656e2064617461","amount":"2000","destExecData":"0x657874726120746f6b656e2064617461"}]}`,
 		},
 	}
 


### PR DESCRIPTION
To resolve breaking changes in the contracts.

A new field was added [here](https://github.com/smartcontractkit/chainlink/blob/d1baa36ee26f2ea9797929c9b8cfd34ad9680cbc/contracts/src/v0.8/ccip/libraries/Internal.sol#L303-L306).

I'm not going to do the rename since that will be a breaking change, and we all know how painful those are 😉 