### PR TITLE
feat(wasm): override random_get

### DIFF
--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -21,6 +21,7 @@ import (
 	wasmpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/pb"
 )
 
+// safeMem returns a copy of the wasm module memory at the given pointer and size.
 func safeMem(caller *wasmtime.Caller, ptr int32, size int32) ([]byte, error) {
 	mem := caller.GetExport("memory").Memory()
 	data := mem.UnsafeData(caller)
@@ -32,6 +33,8 @@ func safeMem(caller *wasmtime.Caller, ptr int32, size int32) ([]byte, error) {
 	copy(cd, data[ptr:ptr+size])
 	return cd, nil
 }
+
+// copyBuffer copies the given src byte slice into the wasm module memory at the given pointer and size.
 func copyBuffer(caller *wasmtime.Caller, src []byte, ptr int32, size int32) int64 {
 	mem := caller.GetExport("memory").Memory()
 	rawData := mem.UnsafeData(caller)

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -306,7 +306,7 @@ func createRandomGet(cfg *ModuleConfig) func(caller *wasmtime.Caller, buf, bufLe
 		var (
 			// Fix the random source with a hardcoded seed
 			seed       = cfg.Determinism.Seed
-			randSource = rand.New(rand.NewSource(seed))
+			randSource = rand.New(rand.NewSource(seed)) //nolint:gosec
 			randOutput = make([]byte, bufLen)
 		)
 

--- a/pkg/workflows/wasm/host/test/rand/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/rand/cmd/main.go
@@ -45,9 +45,7 @@ func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
 }
 
 func main() {
-
 	runner := wasm.NewRunner()
 	workflow := BuildWorkflow(runner.Config())
 	runner.Run(workflow)
-
 }

--- a/pkg/workflows/wasm/host/test/rand/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/rand/cmd/main.go
@@ -1,0 +1,53 @@
+//go:build wasip1
+
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/cli/cmd/testdata/fixtures/capabilities/basictrigger"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm"
+)
+
+func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
+	workflow := sdk.NewWorkflowSpecFactory(
+		sdk.NewWorkflowParams{},
+	)
+
+	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
+	trigger := triggerCfg.New(workflow)
+
+	sdk.Compute1[basictrigger.TriggerOutputs, bool](
+		workflow,
+		"transform",
+		sdk.Compute1Inputs[basictrigger.TriggerOutputs]{Arg0: trigger},
+		func(sdk sdk.Runtime, outputs basictrigger.TriggerOutputs) (bool, error) {
+			b := make([]byte, 5)
+			_, err := rand.Read(b)
+			if err != nil {
+				return false, err
+			}
+
+			// Compare to first 5 bytes of rand source seeded with 42.
+			deterministic := bytes.Compare(b, []byte{0x53, 0x8c, 0x7f, 0x96, 0xb1}) == 0
+
+			if !deterministic {
+				return false, errors.New("expected deterministic output")
+			}
+
+			return deterministic, nil
+		})
+
+	return workflow
+}
+
+func main() {
+
+	runner := wasm.NewRunner()
+	workflow := BuildWorkflow(runner.Config())
+	runner.Run(workflow)
+
+}

--- a/pkg/workflows/wasm/host/wasip1.go
+++ b/pkg/workflows/wasm/host/wasip1.go
@@ -2,6 +2,8 @@ package host
 
 import (
 	"encoding/binary"
+	"io"
+	"math/rand"
 	"time"
 
 	"github.com/bytecodealliance/wasmtime-go/v23"
@@ -41,7 +43,39 @@ func newWasiLinker(engine *wasmtime.Engine) (*wasmtime.Linker, error) {
 		return nil, err
 	}
 
+	err = linker.FuncWrap(
+		"wasi_snapshot_preview1",
+		"random_get",
+		randomGet,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return linker, nil
+}
+
+// randomGet overrides the random_get function in the WASI API and fixes the random source with
+// a hardcoded seed via insecure randomness.  This is to ensure that workflows are deterministic.
+// Randomness should not be used in workflows.
+func randomGet(caller *wasmtime.Caller, buf, bufLen int32) int32 {
+	var (
+		// Fix the random source with a hardcoded seed
+		randSource = rand.New(rand.NewSource(42)) //nolint:gosec
+		randOutput = make([]byte, bufLen)
+	)
+
+	// Generate random bytes from the source
+	if _, err := io.ReadAtLeast(randSource, randOutput, int(bufLen)); err != nil {
+		return ErrnoFault
+	}
+
+	// Copy the random bytes into the wasm module memory
+	if n := copyBuffer(caller, randOutput, buf, bufLen); n != int64(len(randOutput)) {
+		return ErrnoFault
+	}
+
+	return ErrnoSuccess
 }
 
 const (

--- a/pkg/workflows/wasm/host/wasm.go
+++ b/pkg/workflows/wasm/host/wasm.go
@@ -13,7 +13,7 @@ import (
 )
 
 func GetWorkflowSpec(modCfg *ModuleConfig, binary []byte, config []byte) (*sdk.WorkflowSpec, error) {
-	m, err := NewModule(modCfg, binary)
+	m, err := NewModule(modCfg, binary, WithDeterminism())
 	if err != nil {
 		return nil, fmt.Errorf("could not instantiate module: %w", err)
 	}

--- a/pkg/workflows/wasm/host/wasm_test.go
+++ b/pkg/workflows/wasm/host/wasm_test.go
@@ -42,6 +42,8 @@ const (
 	envBinaryCmd          = "test/env/cmd"
 	logBinaryLocation     = "test/log/cmd/testmodule.wasm"
 	logBinaryCmd          = "test/log/cmd"
+	randBinaryLocation    = "test/rand/cmd/testmodule.wasm"
+	randBinaryCmd         = "test/rand/cmd"
 )
 
 func createTestBinary(outputPath, path string, compress bool, t *testing.T) []byte {
@@ -371,6 +373,33 @@ func TestModule_Sandbox_ReadEnv(t *testing.T) {
 		},
 	}
 	// This will return an error if FOO == BAR in the WASM binary
+	_, err = m.Run(req)
+	assert.Nil(t, err)
+}
+
+func TestModule_Sandbox_RandRead(t *testing.T) {
+	binary := createTestBinary(randBinaryCmd, randBinaryLocation, true, t)
+
+	m, err := NewModule(&ModuleConfig{Logger: logger.Test(t)}, binary)
+	require.NoError(t, err)
+
+	m.Start()
+
+	req := &wasmpb.Request{
+		Id: uuid.New().String(),
+		Message: &wasmpb.Request_ComputeRequest{
+			ComputeRequest: &wasmpb.ComputeRequest{
+				Request: &capabilitiespb.CapabilityRequest{
+					Inputs: &valuespb.Map{},
+					Config: &valuespb.Map{},
+					Metadata: &capabilitiespb.RequestMetadata{
+						ReferenceId: "transform",
+					},
+				},
+			},
+		},
+	}
+
 	_, err = m.Run(req)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
this PR allows overrides of `random_get` of `wasi` such that a cryptographically insecure, pre-seeded source is used for all generated randomness.  forcing determinism in a wasm module can ensure that binaries execute deterministically.  `WithDeterminism` is only used when building a workflow spec.