### PR TITLE
ccip: Add unknown address types

### DIFF
--- a/pkg/types/ccipocr3/common_types.go
+++ b/pkg/types/ccipocr3/common_types.go
@@ -24,6 +24,14 @@ func (a UnknownAddress) String() string {
 	return Bytes(a).String()
 }
 
+func (a UnknownAddress) MarshalJSON() ([]byte, error) {
+	return Bytes(a).MarshalJSON()
+}
+
+func (a *UnknownAddress) UnmarshalJSON(data []byte) error {
+	return (*Bytes)(a).UnmarshalJSON(data)
+}
+
 // UnknownEncodedAddress represents an encoded address with an unknown encoding.
 type UnknownEncodedAddress string
 

--- a/pkg/types/ccipocr3/common_types.go
+++ b/pkg/types/ccipocr3/common_types.go
@@ -7,6 +7,26 @@ import (
 	"strings"
 )
 
+// UnknownAddress represents a raw address with an unknown encoding.
+type UnknownAddress []byte
+
+// NewUnknownAddressFromHex creates a new UnknownAddress from a hex string.
+func NewUnknownAddressFromHex(s string) (UnknownAddress, error) {
+	b, err := NewBytesFromString(s)
+	if err != nil {
+		return nil, err
+	}
+	return UnknownAddress(b), nil
+}
+
+// String returns the hex representation of the unknown address.
+func (a UnknownAddress) String() string {
+	return Bytes(a).String()
+}
+
+// UnknownEncodedAddress represents an encoded address with an unknown encoding.
+type UnknownEncodedAddress string
+
 type Bytes []byte
 
 func NewBytesFromString(s string) (Bytes, error) {

--- a/pkg/types/ccipocr3/common_types_test.go
+++ b/pkg/types/ccipocr3/common_types_test.go
@@ -132,5 +132,15 @@ func TestNewBytesFromString(t *testing.T) {
 				require.Equal(t, tt.want, got)
 			}
 		})
+
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewUnknownAddressFromHex(tt.arg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, UnknownAddress(tt.want), got)
+			}
+		})
 	}
 }

--- a/pkg/types/ccipocr3/generic_types.go
+++ b/pkg/types/ccipocr3/generic_types.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
-
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
 
 type TokenPrice struct {
-	TokenID types.Account `json:"tokenID"`
-	Price   BigInt        `json:"price"`
+	TokenID UnknownEncodedAddress `json:"tokenID"`
+	Price   BigInt                `json:"price"`
 }
 
-func NewTokenPrice(tokenID types.Account, price *big.Int) TokenPrice {
+func NewTokenPrice(tokenID UnknownEncodedAddress, price *big.Int) TokenPrice {
 	return TokenPrice{
 		TokenID: tokenID,
 		Price:   BigInt{price},
@@ -113,18 +111,18 @@ type Message struct {
 	Header RampMessageHeader `json:"header"`
 	// Sender address on the source chain.
 	// i.e if the source chain is EVM, this is an abi-encoded EVM address.
-	Sender Bytes `json:"sender"`
+	Sender UnknownAddress `json:"sender"`
 	// Data is the arbitrary data payload supplied by the message sender.
 	Data Bytes `json:"data"`
 	// Receiver is the receiver address on the destination chain.
 	// This is encoded in the destination chain family specific encoding.
 	// i.e if the destination is EVM, this is abi.encode(receiver).
-	Receiver Bytes `json:"receiver"`
+	Receiver UnknownAddress `json:"receiver"`
 	// ExtraArgs is destination-chain specific extra args, such as the gasLimit for EVM chains.
 	ExtraArgs Bytes `json:"extraArgs"`
 	// FeeToken is the fee token address.
 	// i.e if the source chain is EVM, len(FeeToken) == 20 (i.e, is not abi-encoded).
-	FeeToken Bytes `json:"feeToken"`
+	FeeToken UnknownAddress `json:"feeToken"`
 	// FeeTokenAmount is the amount of fee tokens paid.
 	FeeTokenAmount BigInt `json:"feeTokenAmount"`
 	// FeeValueJuels is the fee amount in Juels
@@ -161,7 +159,7 @@ type RampMessageHeader struct {
 
 	// OnRamp is the address of the onramp that sent the message.
 	// NOTE: This is populated by the ccip reader. Not emitted explicitly onchain.
-	OnRamp Bytes `json:"onRamp"`
+	OnRamp UnknownAddress `json:"onRamp"`
 }
 
 // RampTokenAmount represents the family-agnostic token amounts used for both OnRamp & OffRamp messages.
@@ -169,11 +167,11 @@ type RampTokenAmount struct {
 	// SourcePoolAddress is the source pool address, encoded according to source family native encoding scheme.
 	// This value is trusted as it was obtained through the onRamp. It can be relied upon by the destination
 	// pool to validate the source pool.
-	SourcePoolAddress Bytes `json:"sourcePoolAddress"`
+	SourcePoolAddress UnknownAddress `json:"sourcePoolAddress"`
 
 	// DestTokenAddress is the address of the destination token, abi encoded in the case of EVM chains.
 	// This value is UNTRUSTED as any pool owner can return whatever value they want.
-	DestTokenAddress Bytes `json:"destTokenAddress"`
+	DestTokenAddress UnknownAddress `json:"destTokenAddress"`
 
 	// ExtraData is optional pool data to be transferred to the destination chain. Be default this is capped at
 	// CCIP_LOCK_OR_BURN_V1_RET_BYTES bytes. If more data is required, the TokenTransferFeeConfig.destBytesOverhead

--- a/pkg/types/ccipocr3/generic_types_test.go
+++ b/pkg/types/ccipocr3/generic_types_test.go
@@ -152,7 +152,7 @@ func TestCCIPMsg_String(t *testing.T) {
 					Nonce:               1,
 
 					MsgHash: mustNewBytes32(t, "0x23"),
-					OnRamp:  mustNewBytes(t, "0x04D4cC5972ad487F71b85654d48b27D32b13a22F"),
+					OnRamp:  mustNewUnknownAddress(t, "0x04D4cC5972ad487F71b85654d48b27D32b13a22F"),
 				},
 			},
 			`{"header":{"messageId":"0x0100000000000000000000000000000000000000000000000000000000000000","sourceChainSelector":"1","destChainSelector":"2","seqNum":"2","nonce":1,"msgHash":"0x2300000000000000000000000000000000000000000000000000000000000000","onRamp":"0x04d4cc5972ad487f71b85654d48b27d32b13a22f"},"sender":"0x","data":"0x","receiver":"0x","extraArgs":"0x","feeToken":"0x","feeTokenAmount":null,"feeValueJuels":null,"tokenAmounts":null}`,
@@ -168,18 +168,18 @@ func TestCCIPMsg_String(t *testing.T) {
 					Nonce:               1,
 
 					MsgHash: mustNewBytes32(t, "0x23"),
-					OnRamp:  mustNewBytes(t, "0x04D4cC5972ad487F71b85654d48b27D32b13a22F"),
+					OnRamp:  mustNewUnknownAddress(t, "0x04D4cC5972ad487F71b85654d48b27D32b13a22F"),
 				},
-				Sender:         mustNewBytes(t, "0x04D4cC5972ad487F71b85654d48b27D32b13a22F"),
-				Receiver:       mustNewBytes(t, "0x101112131415"), // simulate a non-evm receiver
+				Sender:         mustNewUnknownAddress(t, "0x04D4cC5972ad487F71b85654d48b27D32b13a22F"),
+				Receiver:       mustNewUnknownAddress(t, "0x101112131415"), // simulate a non-evm receiver
 				Data:           []byte("some data"),
 				ExtraArgs:      []byte("extra args"),
-				FeeToken:       mustNewBytes(t, "0xB5fCC870d2aC8745054b4ba99B1f176B93382162"),
+				FeeToken:       mustNewUnknownAddress(t, "0xB5fCC870d2aC8745054b4ba99B1f176B93382162"),
 				FeeTokenAmount: BigInt{Int: big.NewInt(1000)},
 				FeeValueJuels:  BigInt{Int: big.NewInt(287)},
 				TokenAmounts: []RampTokenAmount{
 					{
-						SourcePoolAddress: mustNewBytes(t, "0x3E8456720B88A1DAdce8E2808C9Bf73dfFFd807c"),
+						SourcePoolAddress: mustNewUnknownAddress(t, "0x3E8456720B88A1DAdce8E2808C9Bf73dfFFd807c"),
 						DestTokenAddress:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, // simulate a non-evm token
 						ExtraData:         []byte("extra token data"),
 						Amount:            BigInt{Int: big.NewInt(2000)},
@@ -250,4 +250,10 @@ func mustNewBytes(t *testing.T, s string) Bytes {
 	b, err := NewBytesFromString(s)
 	require.NoError(t, err)
 	return b
+}
+
+func mustNewUnknownAddress(t *testing.T, s string) UnknownAddress {
+	a, err := NewUnknownAddressFromHex(s)
+	require.NoError(t, err)
+	return a
 }

--- a/pkg/types/ccipocr3/interfaces.go
+++ b/pkg/types/ccipocr3/interfaces.go
@@ -28,7 +28,7 @@ type RMNCrypto interface {
 		ctx context.Context,
 		sigs []RMNECDSASignature,
 		report RMNReport,
-		signerAddresses []Bytes,
+		signerAddresses []UnknownAddress,
 	) error
 }
 

--- a/pkg/types/ccipocr3/rmn_types.go
+++ b/pkg/types/ccipocr3/rmn_types.go
@@ -5,8 +5,8 @@ type RMNReport struct {
 	ReportVersion               string // e.g. "RMN_V1_6_ANY2EVM_REPORT".
 	DestChainID                 BigInt // If applies, a chain specific id, e.g. evm chain id otherwise empty.
 	DestChainSelector           ChainSelector
-	RmnRemoteContractAddress    Bytes
-	OfframpAddress              Bytes
+	RmnRemoteContractAddress    UnknownAddress
+	OfframpAddress              UnknownAddress
 	RmnHomeContractConfigDigest Bytes32
 	LaneUpdates                 []RMNLaneUpdate
 }
@@ -15,7 +15,7 @@ type RMNReport struct {
 // It is part of the payload that is signed and transmitted onchain.
 type RMNLaneUpdate struct {
 	SourceChainSelector ChainSelector
-	OnRampAddress       Bytes // (for EVM should be abi-encoded)
+	OnRampAddress       UnknownAddress // (for EVM should be abi-encoded)
 	MinSeqNr            SeqNum
 	MaxSeqNr            SeqNum
 	MerkleRoot          Bytes32


### PR DESCRIPTION
Use new address types in chainlink, chainlink-common and chainlink-ccip.

Related:
* https://github.com/smartcontractkit/chainlink-ccip/pull/212
* https://github.com/smartcontractkit/chainlink/pull/14673