### PR TITLE
[INFOPLAT-1071] Add CSA auth mechanism to Beholder

### DIFF
--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -2,6 +2,7 @@ package beholder
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -216,6 +217,21 @@ func newOtelResource(cfg Config) (resource *sdkresource.Resource, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Add csa public key resource attribute
+	csaPublicKeyHex := "not-configured"
+	if len(cfg.CSAPublicKey) > 0 {
+		csaPublicKeyHex = hex.EncodeToString(cfg.CSAPublicKey)
+	}
+	csaPublicKeyAttr := attribute.String("csa_public_key", csaPublicKeyHex)
+	resource, err = sdkresource.Merge(
+		sdkresource.NewSchemaless(csaPublicKeyAttr),
+		resource,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	// Add custom resource attributes
 	resource, err = sdkresource.Merge(
 		sdkresource.NewSchemaless(cfg.ResourceAttributes...),

--- a/pkg/beholder/config.go
+++ b/pkg/beholder/config.go
@@ -1,6 +1,7 @@
 package beholder
 
 import (
+	"crypto/ed25519"
 	"time"
 
 	otelattr "go.opentelemetry.io/otel/attribute"
@@ -30,7 +31,13 @@ type Config struct {
 	// Batch processing is enabled by default
 	// Disable it only for testing
 	LogBatchProcessor bool
+
+	CSAAuthEnabled bool
+	CSAPublicKey   ed25519.PublicKey
+	CSASigner      CSASigner
 }
+
+type CSASigner func([]byte) []byte
 
 const (
 	defaultPackageName = "beholder"
@@ -58,6 +65,7 @@ func DefaultConfig() Config {
 		// Log
 		LogExportTimeout:  1 * time.Second,
 		LogBatchProcessor: true,
+		CSAAuthEnabled:    false,
 	}
 }
 

--- a/pkg/beholder/config_test.go
+++ b/pkg/beholder/config_test.go
@@ -37,5 +37,5 @@ func ExampleConfig() {
 	}
 	fmt.Printf("%+v", config)
 	// Output:
-	// {InsecureConnection:true CACertFile: OtelExporterGRPCEndpoint:localhost:4317 ResourceAttributes:[{Key:package_name Value:{vtype:4 numeric:0 stringly:beholder slice:<nil>}} {Key:sender Value:{vtype:4 numeric:0 stringly:beholderclient slice:<nil>}}] EmitterExportTimeout:1s EmitterBatchProcessor:true TraceSampleRatio:1 TraceBatchTimeout:1s TraceSpanExporter:<nil> MetricReaderInterval:1s LogExportTimeout:1s LogBatchProcessor:true}
+	// {InsecureConnection:true CACertFile: OtelExporterGRPCEndpoint:localhost:4317 ResourceAttributes:[{Key:package_name Value:{vtype:4 numeric:0 stringly:beholder slice:<nil>}} {Key:sender Value:{vtype:4 numeric:0 stringly:beholderclient slice:<nil>}}] EmitterExportTimeout:1s EmitterBatchProcessor:true TraceSampleRatio:1 TraceBatchTimeout:1s TraceSpanExporter:<nil> MetricReaderInterval:1s LogExportTimeout:1s LogBatchProcessor:true CSAAuthEnabled:false CSAPublicKey:[] CSASigner:<nil>}
 }

--- a/pkg/beholder/node_auth.go
+++ b/pkg/beholder/node_auth.go
@@ -1,0 +1,83 @@
+package beholder
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+)
+
+// NodeAuthenticator implements PerRPCCredentials interface from google.golang.org/grpc/credentials
+type NodeAuthenticator struct {
+	staticAuthHeaders        map[string]string
+	requireTransportSecurity bool
+}
+
+func NewNodeAuthenticator(config Config) (*NodeAuthenticator, error) {
+	if err := validateNodeAuthConfig(config); err != nil {
+		return nil, err
+	}
+
+	return &NodeAuthenticator{
+		staticAuthHeaders:        deriveAuthHeaders(config),
+		requireTransportSecurity: !config.InsecureConnection,
+	}, nil
+}
+
+func (na *NodeAuthenticator) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	authHeaders := make(map[string]string)
+	for k, v := range na.staticAuthHeaders {
+		authHeaders[k] = v
+	}
+	return authHeaders, nil
+}
+
+func (na *NodeAuthenticator) RequireTransportSecurity() bool {
+	return na.requireTransportSecurity
+}
+
+func validateNodeAuthConfig(config Config) error {
+	if config.CSAAuthEnabled {
+		if config.CSAPublicKey == nil {
+			return fmt.Errorf("CSA auth is enabled but no CSA public key was provided")
+		}
+		if config.CSASigner == nil {
+			return fmt.Errorf("CSA auth is enabled but no CSA signer was provided")
+		}
+	}
+	return nil
+}
+
+// authHeaderKey is the name of the header that the node authenticator will use to send the auth token
+var authHeaderKey = "X-Beholder-Node-Auth-Token"
+
+// authHeaderVersion is the version of the auth header format
+var authHeaderVersion = "1"
+
+// deriveAuthHeaders creates the auth header map to be included on requests
+func deriveAuthHeaders(config Config) map[string]string {
+	authHeaders := make(map[string]string)
+
+	if !config.CSAAuthEnabled {
+		return authHeaders
+	}
+
+	authHeaders[authHeaderKey] = deriveAuthHeaderValue(config)
+
+	return authHeaders
+}
+
+// deriveAuthHeaderValue creates the auth header value to be included on requests.
+// The current format for the header is:
+//
+// <version>:<csa_public_key_hex>:<signature_hex>
+//
+// where the byte value of <csa_public_key_hex> is what's being signed
+func deriveAuthHeaderValue(config Config) string {
+	messageBytes := config.CSAPublicKey
+	messageHex := hex.EncodeToString(messageBytes)
+
+	signature := config.CSASigner(messageBytes)
+	signatureHex := hex.EncodeToString(signature)
+
+	return fmt.Sprintf("%s:%s:%s", authHeaderVersion, messageHex, signatureHex)
+}

--- a/pkg/beholder/node_auth.go
+++ b/pkg/beholder/node_auth.go
@@ -37,7 +37,7 @@ func (na *NodeAuthenticator) RequireTransportSecurity() bool {
 
 func validateNodeAuthConfig(config Config) error {
 	if config.CSAAuthEnabled {
-		if config.CSAPublicKey == nil {
+		if len(config.CSAPublicKey) == 0 {
 			return fmt.Errorf("CSA auth is enabled but no CSA public key was provided")
 		}
 		if config.CSASigner == nil {

--- a/pkg/beholder/node_auth.go
+++ b/pkg/beholder/node_auth.go
@@ -74,10 +74,8 @@ func deriveAuthHeaders(config Config) map[string]string {
 // where the byte value of <csa_public_key_hex> is what's being signed
 func deriveAuthHeaderValue(config Config) string {
 	messageBytes := config.CSAPublicKey
-	messageHex := hex.EncodeToString(messageBytes)
 
 	signature := config.CSASigner(messageBytes)
-	signatureHex := hex.EncodeToString(signature)
 
-	return fmt.Sprintf("%s:%s:%s", authHeaderVersion, messageHex, signatureHex)
+	return fmt.Sprintf("%s:%x:%x", authHeaderVersion, messageBytes, signature)
 }

--- a/pkg/beholder/node_auth_test.go
+++ b/pkg/beholder/node_auth_test.go
@@ -1,0 +1,70 @@
+package beholder_test
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/stretchr/testify/assert"
+)
+
+func defaultTestingConfig() beholder.Config {
+	return beholder.Config{
+		CSAAuthEnabled:     true,
+		CSAPublicKey:       []byte("test-public-key"),
+		CSASigner:          func([]byte) []byte { return []byte("test-signature") },
+		InsecureConnection: false,
+	}
+
+}
+
+func TestNodeAuthenticator_HappyPath(t *testing.T) {
+	config := defaultTestingConfig()
+	na, err := beholder.NewNodeAuthenticator(config)
+	assert.NoError(t, err)
+
+	// Test GetRequestMetadata
+	expectedMessage := hex.EncodeToString([]byte("test-public-key"))
+	expectedSignature := hex.EncodeToString([]byte("test-signature"))
+	expectedRequestMetadata := map[string]string{
+		"X-Beholder-Node-Auth-Token": fmt.Sprintf("1:%s:%s", expectedMessage, expectedSignature),
+	}
+	requestMetadata, err := na.GetRequestMetadata(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedRequestMetadata, requestMetadata)
+
+	// Test RequireTransportSecurity
+	assert.True(t, na.RequireTransportSecurity())
+}
+
+func TestNodeAuthenticator_NodeAuthConfig(t *testing.T) {
+	// Should error on nil public CSA key
+	c1 := defaultTestingConfig()
+	c1.CSAPublicKey = nil
+	_, err := beholder.NewNodeAuthenticator(c1)
+	assert.Error(t, err, "CSA auth is enabled but no CSA public key was provided")
+
+	// Should error on nil CSA signer
+	c2 := defaultTestingConfig()
+	c2.CSASigner = nil
+	_, err = beholder.NewNodeAuthenticator(c2)
+	assert.Error(t, err, "CSA auth is enabled but no CSA signer was provided")
+}
+
+func TestNodeAuthenticator_CSAAuthDisabled(t *testing.T) {
+	// CSA Auth disabled should accept nil values and return empty map for request metadata
+	c := defaultTestingConfig()
+	c.CSAAuthEnabled = false
+	c.CSAPublicKey = nil
+	c.CSASigner = nil
+
+	na, err := beholder.NewNodeAuthenticator(c)
+	assert.NoError(t, err)
+
+	expectedRequestMetadata := map[string]string{}
+	requestMetadata, err := na.GetRequestMetadata(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedRequestMetadata, requestMetadata)
+}

--- a/pkg/beholder/node_auth_test.go
+++ b/pkg/beholder/node_auth_test.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 )
 
 func defaultTestingConfig() beholder.Config {
@@ -17,7 +18,6 @@ func defaultTestingConfig() beholder.Config {
 		CSASigner:          func([]byte) []byte { return []byte("test-signature") },
 		InsecureConnection: false,
 	}
-
 }
 
 func TestNodeAuthenticator_HappyPath(t *testing.T) {


### PR DESCRIPTION
## What 
- [Ticket here](https://smartcontract-it.atlassian.net/jira/software/c/projects/INFOPLAT/boards/260?selectedIssue=INFOPLAT-1071) 
- Adds mechanism to authenticate via CSA key signature in Beholder 
- Uses `grpc.WithPerRPCCredentials` despite the static header value in case this is dynamic in the future 
- Header format is `<version>:<csa_public_key_hex>:<signature_hex>` where the byte value of `<csa_public_key_hex>` is what's being signed
- Adds `csa_pub_key` attribute to all OTel message types