### PR TITLE
Enable consensus based on a value.Map

### DIFF
--- a/pkg/capabilities/consensus/ocr3/ocr3cap/ocr3cap_common-schema.json
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/ocr3cap_common-schema.json
@@ -46,7 +46,7 @@
     },
     "encoder": {
       "type": "string",
-      "enum": ["EVM"]
+      "enum": ["EVM", "ValueMap"]
     },
     "encoder_config": {
       "type": "object",

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/ocr3cap_common_generated.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/ocr3cap_common_generated.go
@@ -14,9 +14,11 @@ type Encoder string
 type EncoderConfig map[string]interface{}
 
 const EncoderEVM Encoder = "EVM"
+const EncoderValueMap Encoder = "ValueMap"
 
 var enumValues_Encoder = []interface{}{
 	"EVM",
+	"ValueMap",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/utils.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/utils.go
@@ -1,0 +1,15 @@
+package ocr3cap
+
+var encoderTypes []Encoder
+
+func init() {
+	for _, v := range enumValues_Encoder {
+		encoderTypes = append(encoderTypes, Encoder(v.(string)))
+	}
+}
+
+func Encoders() []Encoder {
+	cpy := make([]Encoder, len(encoderTypes))
+	copy(cpy, encoderTypes)
+	return cpy
+}

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/utils_test.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/utils_test.go
@@ -1,0 +1,19 @@
+package ocr3cap_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/ocr3cap"
+)
+
+func TestEncoders(t *testing.T) {
+	t.Parallel()
+	t.Run("Returns a copy of the underlying encoders", func(t *testing.T) {
+		orig := ocr3cap.Encoders()
+		orig[0] = "foo"
+		assert.NotEqual(t, orig, ocr3cap.Encoders())
+		assert.Equal(t, ocr3cap.Encoder("foo"), orig[0])
+	})
+}

--- a/pkg/capabilities/consensus/ocr3/value_map_encoder.go
+++ b/pkg/capabilities/consensus/ocr3/value_map_encoder.go
@@ -1,0 +1,19 @@
+package ocr3
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/values"
+)
+
+type ValueMapEncoder struct{}
+
+func (v ValueMapEncoder) Encode(_ context.Context, input values.Map) ([]byte, error) {
+	opts := proto.MarshalOptions{Deterministic: true}
+	return opts.Marshal(values.Proto(&input))
+}
+
+var _ types.Encoder = (*ValueMapEncoder)(nil)

--- a/pkg/capabilities/consensus/ocr3/value_map_encoder_test.go
+++ b/pkg/capabilities/consensus/ocr3/value_map_encoder_test.go
@@ -1,0 +1,66 @@
+package ocr3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/values"
+	"github.com/smartcontractkit/chainlink-common/pkg/values/pb"
+)
+
+func Test_ValuesEncoder_Encode(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"foo": "bar",
+		"baz": int64(42),
+		"x":   map[string]any{"y": "z"},
+	}
+	inputWrapped, err := values.NewMap(input)
+	require.NoError(t, err)
+
+	expectedProto := &pb.Value{
+		Value: &pb.Value_MapValue{
+			MapValue: &pb.Map{
+				Fields: map[string]*pb.Value{
+					"foo": {Value: &pb.Value_StringValue{StringValue: "bar"}},
+					"baz": {Value: &pb.Value_Int64Value{Int64Value: 42}},
+					"x": {
+						Value: &pb.Value_MapValue{
+							MapValue: &pb.Map{
+								Fields: map[string]*pb.Value{
+									"y": {Value: &pb.Value_StringValue{StringValue: "z"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	encoder := ocr3.ValueMapEncoder{}
+	actual, err := encoder.Encode(tests.Context(t), *inputWrapped)
+	require.NoError(t, err)
+
+	opts := proto.MarshalOptions{Deterministic: true}
+	expected, err := opts.Marshal(expectedProto)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, actual)
+
+	decoded := &pb.Value{}
+	require.NoError(t, proto.Unmarshal(actual, decoded))
+
+	val, err := values.FromProto(decoded)
+	require.NoError(t, err)
+
+	output := map[string]any{}
+	require.NoError(t, val.UnwrapTo(&output))
+
+	assert.Equal(t, input, output)
+}


### PR DESCRIPTION
Use cases:

- We currently don't have custom compute encoders
- Users can decode to a map and read fields they care about without caring about others.