### PR TITLE
Fix Latest timestamp metric to return timestamp in seconds

### DIFF
--- a/pkg/monitoring/exporter_prometheus.go
+++ b/pkg/monitoring/exporter_prometheus.go
@@ -199,7 +199,7 @@ func (p *prometheusExporter) exportEnvelope(envelope Envelope) {
 		p.chainConfig.GetNetworkName(),
 	)
 	p.metrics.SetOffchainAggregatorAnswersLatestTimestamp(
-		float64(envelope.LatestTimestamp.Second()),
+		float64(envelope.LatestTimestamp.Unix()),
 		p.feedConfig.GetID(),
 		p.feedConfig.GetID(),
 		p.chainConfig.GetChainID(),

--- a/pkg/monitoring/exporter_prometheus_test.go
+++ b/pkg/monitoring/exporter_prometheus_test.go
@@ -119,16 +119,16 @@ func TestPrometheusExporter(t *testing.T) {
 			chainConfig.GetNetworkName(),   // networkName
 		).Once()
 		metrics.On("SetOffchainAggregatorAnswersLatestTimestamp",
-			float64(envelope1.LatestTimestamp.Second()), // latestTimestamp
-			feedConfig.GetID(),                          // contractAddress
-			feedConfig.GetID(),                          // feedID
-			chainConfig.GetChainID(),                    // chainID
-			feedConfig.GetContractStatus(),              // contractStatus
-			feedConfig.GetContractType(),                // contractType
-			feedConfig.GetName(),                        // feedName
-			feedConfig.GetPath(),                        // feedPath
-			chainConfig.GetNetworkID(),                  // networkID
-			chainConfig.GetNetworkName(),                // networkName
+			float64(envelope1.LatestTimestamp.Unix()), // latestTimestamp
+			feedConfig.GetID(),                        // contractAddress
+			feedConfig.GetID(),                        // feedID
+			chainConfig.GetChainID(),                  // chainID
+			feedConfig.GetContractStatus(),            // contractStatus
+			feedConfig.GetContractType(),              // contractType
+			feedConfig.GetName(),                      // feedName
+			feedConfig.GetPath(),                      // feedPath
+			chainConfig.GetNetworkID(),                // networkID
+			chainConfig.GetNetworkName(),              // networkName
 		).Once()
 		metrics.On("SetOffchainAggregatorJuelsPerFeeCoinRaw",
 			toFloat64(envelope1.JuelsPerFeeCoin),
@@ -278,16 +278,16 @@ func TestPrometheusExporter(t *testing.T) {
 			chainConfig.GetNetworkName(),   // networkName
 		).Once()
 		metrics.On("SetOffchainAggregatorAnswersLatestTimestamp",
-			float64(envelope2.LatestTimestamp.Second()), // latestTimestamp
-			feedConfig.GetID(),                          // contractAddress
-			feedConfig.GetID(),                          // feedID
-			chainConfig.GetChainID(),                    // chainID
-			feedConfig.GetContractStatus(),              // contractStatus
-			feedConfig.GetContractType(),                // contractType
-			feedConfig.GetName(),                        // feedName
-			feedConfig.GetPath(),                        // feedPath
-			chainConfig.GetNetworkID(),                  // networkID
-			chainConfig.GetNetworkName(),                // networkName
+			float64(envelope2.LatestTimestamp.Unix()), // latestTimestamp
+			feedConfig.GetID(),                        // contractAddress
+			feedConfig.GetID(),                        // feedID
+			chainConfig.GetChainID(),                  // chainID
+			feedConfig.GetContractStatus(),            // contractStatus
+			feedConfig.GetContractType(),              // contractType
+			feedConfig.GetName(),                      // feedName
+			feedConfig.GetPath(),                      // feedPath
+			chainConfig.GetNetworkID(),                // networkID
+			chainConfig.GetNetworkName(),              // networkName
 		).Once()
 		metrics.On("SetOffchainAggregatorJuelsPerFeeCoinRaw",
 			toFloat64(envelope2.JuelsPerFeeCoin),
@@ -504,16 +504,16 @@ func TestPrometheusExporter(t *testing.T) {
 			chainConfig.GetNetworkName(),   // networkName
 		).Once()
 		metrics.On("SetOffchainAggregatorAnswersLatestTimestamp",
-			float64(envelope1.LatestTimestamp.Second()), // latestTimestamp
-			feedConfig.GetID(),                          // contractAddress
-			feedConfig.GetID(),                          // feedID
-			chainConfig.GetChainID(),                    // chainID
-			feedConfig.GetContractStatus(),              // contractStatus
-			feedConfig.GetContractType(),                // contractType
-			feedConfig.GetName(),                        // feedName
-			feedConfig.GetPath(),                        // feedPath
-			chainConfig.GetNetworkID(),                  // networkID
-			chainConfig.GetNetworkName(),                // networkName
+			float64(envelope1.LatestTimestamp.Unix()), // latestTimestamp
+			feedConfig.GetID(),                        // contractAddress
+			feedConfig.GetID(),                        // feedID
+			chainConfig.GetChainID(),                  // chainID
+			feedConfig.GetContractStatus(),            // contractStatus
+			feedConfig.GetContractType(),              // contractType
+			feedConfig.GetName(),                      // feedName
+			feedConfig.GetPath(),                      // feedPath
+			chainConfig.GetNetworkID(),                // networkID
+			chainConfig.GetNetworkName(),              // networkName
 		).Once()
 		metrics.On("SetOffchainAggregatorJuelsPerFeeCoinRaw",
 			toFloat64(envelope1.JuelsPerFeeCoin),


### PR DESCRIPTION
- Made a rookie mistake when first adding this metric and extracted the Seconds component of the time, rather than the time in seconds 🤦. 