### PR TITLE
Beholder: Add domain and entity to metadata

### DIFF
--- a/pkg/beholder/client_test.go
+++ b/pkg/beholder/client_test.go
@@ -50,6 +50,8 @@ func TestClient(t *testing.T) {
 			"byte_key_1":           []byte("byte_val_1"),
 			"str_slice_key_1":      []string{"str_val_1", "str_val_2"},
 			"nil_key_1":            nil,
+			"beholder_domain":      "TestDomain",        // Required field
+			"beholder_entity":      "TestEntity",        // Required field
 			"beholder_data_schema": "/schemas/ids/1001", // Required field, URI
 		}
 	}
@@ -202,15 +204,39 @@ func TestEmitterMessageValidation(t *testing.T) {
 		{
 			name: "Invalid URI",
 			attrs: Attributes{
+				"beholder_domain":      "TestDomain",
+				"beholder_entity":      "TestEntity",
 				"beholder_data_schema": "example-schema",
 			},
 			exporterCalledTimes: 0,
 			expectedError:       "'Metadata.BeholderDataSchema' Error:Field validation for 'BeholderDataSchema' failed on the 'uri' tag",
 		},
 		{
-			name:                "Valid URI",
+			name: "Invalid BeholderDomain",
+			attrs: Attributes{
+				"beholder_data_schema": "/example-schema/versions/1",
+				"beholder_entity":      "TestEntity",
+				"beholder_domain":      "Test__Domain",
+			},
+			exporterCalledTimes: 0,
+			expectedError:       "'Metadata.BeholderDomain' Error:Field validation for 'BeholderDomain' failed on the 'no_double_underscore' tag",
+		},
+		{
+			name: "Invalid BeholderEntity",
+			attrs: Attributes{
+				"beholder_data_schema": "/example-schema/versions/1",
+				"beholder_entity":      "Test__Entity",
+				"beholder_domain":      "TestDomain",
+			},
+			exporterCalledTimes: 0,
+			expectedError:       "'Metadata.BeholderEntity' Error:Field validation for 'BeholderEntity' failed on the 'no_double_underscore' tag",
+		},
+		{
+			name:                "Valid Attributes",
 			exporterCalledTimes: 1,
 			attrs: Attributes{
+				"beholder_domain":      "TestDomain",
+				"beholder_entity":      "TestEntity",
 				"beholder_data_schema": "/example-schema/versions/1",
 			},
 			expectedError: "",

--- a/pkg/beholder/client_test.go
+++ b/pkg/beholder/client_test.go
@@ -212,24 +212,44 @@ func TestEmitterMessageValidation(t *testing.T) {
 			expectedError:       "'Metadata.BeholderDataSchema' Error:Field validation for 'BeholderDataSchema' failed on the 'uri' tag",
 		},
 		{
-			name: "Invalid BeholderDomain",
+			name: "Invalid Beholder domain (double underscore)",
 			attrs: Attributes{
 				"beholder_data_schema": "/example-schema/versions/1",
 				"beholder_entity":      "TestEntity",
 				"beholder_domain":      "Test__Domain",
 			},
 			exporterCalledTimes: 0,
-			expectedError:       "'Metadata.BeholderDomain' Error:Field validation for 'BeholderDomain' failed on the 'no_double_underscore' tag",
+			expectedError:       "'Metadata.BeholderDomain' Error:Field validation for 'BeholderDomain' failed on the 'domain_entity' tag",
 		},
 		{
-			name: "Invalid BeholderEntity",
+			name: "Invalid Beholder domain (special characters)",
+			attrs: Attributes{
+				"beholder_data_schema": "/example-schema/versions/1",
+				"beholder_entity":      "TestEntity",
+				"beholder_domain":      "TestDomain*$",
+			},
+			exporterCalledTimes: 0,
+			expectedError:       "'Metadata.BeholderDomain' Error:Field validation for 'BeholderDomain' failed on the 'domain_entity' tag",
+		},
+		{
+			name: "Invalid Beholder entity (double underscore)",
 			attrs: Attributes{
 				"beholder_data_schema": "/example-schema/versions/1",
 				"beholder_entity":      "Test__Entity",
 				"beholder_domain":      "TestDomain",
 			},
 			exporterCalledTimes: 0,
-			expectedError:       "'Metadata.BeholderEntity' Error:Field validation for 'BeholderEntity' failed on the 'no_double_underscore' tag",
+			expectedError:       "'Metadata.BeholderEntity' Error:Field validation for 'BeholderEntity' failed on the 'domain_entity' tag",
+		},
+		{
+			name: "Invalid Beholder entity (special characters)",
+			attrs: Attributes{
+				"beholder_data_schema": "/example-schema/versions/1",
+				"beholder_entity":      "TestEntity*$",
+				"beholder_domain":      "TestDomain",
+			},
+			exporterCalledTimes: 0,
+			expectedError:       "'Metadata.BeholderEntity' Error:Field validation for 'BeholderEntity' failed on the 'domain_entity' tag",
 		},
 		{
 			name:                "Valid Attributes",
@@ -237,6 +257,16 @@ func TestEmitterMessageValidation(t *testing.T) {
 			attrs: Attributes{
 				"beholder_domain":      "TestDomain",
 				"beholder_entity":      "TestEntity",
+				"beholder_data_schema": "/example-schema/versions/1",
+			},
+			expectedError: "",
+		},
+		{
+			name:                "Valid Attributes (special characters)",
+			exporterCalledTimes: 1,
+			attrs: Attributes{
+				"beholder_domain":      "Test.Domain_42-1",
+				"beholder_entity":      "Test.Entity_42-1",
 				"beholder_data_schema": "/example-schema/versions/1",
 			},
 			expectedError: "",

--- a/pkg/beholder/example_test.go
+++ b/pkg/beholder/example_test.go
@@ -45,6 +45,8 @@ func ExampleNewClient() {
 	for range 10 {
 		err := beholder.GetEmitter().Emit(context.Background(), payloadBytes,
 			"beholder_data_schema", "/custom-message/versions/1", // required
+			"beholder_domain", "ExampleDomain", // required
+			"beholder_entity", "ExampleEntity", // required
 			"beholder_data_type", "custom_message",
 			"foo", "bar",
 		)
@@ -105,6 +107,8 @@ func ExampleNewNoopClient() {
 
 	err := beholder.GetEmitter().Emit(context.Background(), []byte("test message"),
 		"beholder_data_schema", "/custom-message/versions/1", // required
+		"beholder_domain", "ExampleDomain", // required
+		"beholder_entity", "ExampleEntity", // required
 	)
 	if err != nil {
 		log.Printf("Error emitting message: %v", err)

--- a/pkg/beholder/message.go
+++ b/pkg/beholder/message.go
@@ -235,7 +235,7 @@ func NewMetadata(attrs Attributes) *Metadata {
 // validDomainAndEntityRegex allows for alphanumeric characters and ._-
 var validDomainAndEntityRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
-func NewMetadataValidator() *validator.Validate {
+func NewMetadataValidator() (*validator.Validate, error) {
 	validate := validator.New()
 	err := validate.RegisterValidation("domain_entity", func(fl validator.FieldLevel) bool {
 		str, isStr := fl.Field().Interface().(string)
@@ -251,13 +251,16 @@ func NewMetadataValidator() *validator.Validate {
 		return true
 	})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return validate
+	return validate, nil
 }
 
 func (m *Metadata) Validate() error {
-	validate := NewMetadataValidator()
+	validate, err := NewMetadataValidator()
+	if err != nil {
+		return err
+	}
 	return validate.Struct(m)
 }
 

--- a/pkg/beholder/message.go
+++ b/pkg/beholder/message.go
@@ -233,12 +233,15 @@ func NewMetadata(attrs Attributes) *Metadata {
 
 func NewMetadataValidator() *validator.Validate {
 	validate := validator.New()
-	validate.RegisterValidation("no_double_underscore", func(fl validator.FieldLevel) bool {
+	err := validate.RegisterValidation("no_double_underscore", func(fl validator.FieldLevel) bool {
 		if str, ok := fl.Field().Interface().(string); ok {
 			return !strings.Contains(str, "__")
 		}
 		return true
 	})
+	if err != nil {
+		panic(err)
+	}
 	return validate
 }
 

--- a/pkg/beholder/message_test.go
+++ b/pkg/beholder/message_test.go
@@ -129,7 +129,10 @@ func ExampleMetadata() {
 }
 
 func ExampleValidate() {
-	validate := beholder.NewMetadataValidator()
+	validate, err := beholder.NewMetadataValidator()
+	if err != nil {
+		fmt.Println(err)
+	}
 
 	metadata := beholder.Metadata{
 		BeholderDomain: "TestDomain",

--- a/pkg/beholder/message_test.go
+++ b/pkg/beholder/message_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 	otellog "go.opentelemetry.io/otel/log"
 
@@ -110,6 +109,8 @@ func testMetadata() beholder.Metadata {
 		WorkflowOwnerAddress:      "test_owner_address",
 		WorkflowSpecID:            "test_spec_id",
 		WorkflowExecutionID:       "test_execution_id",
+		BeholderDomain:            "TestDomain",               // required field
+		BeholderEntity:            "TestEntity",               // required field
 		BeholderDataSchema:        "/schemas/ids/test_schema", // required field, URI
 		CapabilityContractAddress: "test_contract_address",
 		CapabilityID:              "test_capability_id",
@@ -123,14 +124,17 @@ func ExampleMetadata() {
 	fmt.Printf("%#v\n", m)
 	fmt.Println(m.Attributes())
 	// Output:
-	// beholder.Metadata{BeholderDataSchema:"/schemas/ids/test_schema", NodeVersion:"v1.0.0", NodeCsaKey:"test_key", NodeCsaSignature:"test_signature", DonID:"test_don_id", NetworkName:[]string{"test_network"}, WorkflowID:"test_workflow_id", WorkflowName:"test_workflow_name", WorkflowOwnerAddress:"test_owner_address", WorkflowSpecID:"test_spec_id", WorkflowExecutionID:"test_execution_id", CapabilityContractAddress:"test_contract_address", CapabilityID:"test_capability_id", CapabilityVersion:"test_capability_version", CapabilityName:"test_capability_name", NetworkChainID:"test_chain_id"}
-	// map[beholder_data_schema:/schemas/ids/test_schema capability_contract_address:test_contract_address capability_id:test_capability_id capability_name:test_capability_name capability_version:test_capability_version don_id:test_don_id network_chain_id:test_chain_id network_name:[test_network] node_csa_key:test_key node_csa_signature:test_signature node_version:v1.0.0 workflow_execution_id:test_execution_id workflow_id:test_workflow_id workflow_name:test_workflow_name workflow_owner_address:test_owner_address workflow_spec_id:test_spec_id]
+	// beholder.Metadata{BeholderDomain:"TestDomain", BeholderEntity:"TestEntity", BeholderDataSchema:"/schemas/ids/test_schema", NodeVersion:"v1.0.0", NodeCsaKey:"test_key", NodeCsaSignature:"test_signature", DonID:"test_don_id", NetworkName:[]string{"test_network"}, WorkflowID:"test_workflow_id", WorkflowName:"test_workflow_name", WorkflowOwnerAddress:"test_owner_address", WorkflowSpecID:"test_spec_id", WorkflowExecutionID:"test_execution_id", CapabilityContractAddress:"test_contract_address", CapabilityID:"test_capability_id", CapabilityVersion:"test_capability_version", CapabilityName:"test_capability_name", NetworkChainID:"test_chain_id"}
+	// map[beholder_data_schema:/schemas/ids/test_schema beholder_domain:TestDomain beholder_entity:TestEntity capability_contract_address:test_contract_address capability_id:test_capability_id capability_name:test_capability_name capability_version:test_capability_version don_id:test_don_id network_chain_id:test_chain_id network_name:[test_network] node_csa_key:test_key node_csa_signature:test_signature node_version:v1.0.0 workflow_execution_id:test_execution_id workflow_id:test_workflow_id workflow_name:test_workflow_name workflow_owner_address:test_owner_address workflow_spec_id:test_spec_id]
 }
 
 func ExampleValidate() {
-	validate := validator.New()
+	validate := beholder.NewMetadataValidator()
 
-	metadata := beholder.Metadata{}
+	metadata := beholder.Metadata{
+		BeholderDomain: "TestDomain",
+		BeholderEntity: "TestEntity",
+	}
 	if err := validate.Struct(metadata); err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
- Adds required attributes `beholder_domain` and `beholder_entity` to custom messages
- [Companion Atlas PR](https://github.com/smartcontractkit/atlas/pull/7316)