### PR TITLE
pkg/loop: swap eventually from assert to require

### DIFF
--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader_test.go
@@ -1025,12 +1025,12 @@ func runContractReaderByIDQueryKey(t *testing.T) {
 			_ = SubmitTransactionToCW(t, tester, MethodTriggeringEvent, ts2AnySecondContract, anySecondContract, types.Unconfirmed)
 
 			tsAnyContractType := &TestStruct{}
-			assert.Eventually(t, func() bool {
+			require.Eventually(t, func() bool {
 				sequences, err := cr.QueryKey(ctx, anyContractID, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, tsAnyContractType)
 				return err == nil && len(sequences) == 2 && reflect.DeepEqual(ts1AnyContract, sequences[1].Data) && reflect.DeepEqual(ts2AnyContract, sequences[0].Data)
 			}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)
 
-			assert.Eventually(t, func() bool {
+			require.Eventually(t, func() bool {
 				sequences, err := cr.QueryKey(ctx, anyContractID, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, tsAnyContractType)
 				return err == nil && len(sequences) == 2 && reflect.DeepEqual(ts1AnySecondContract, sequences[1].Data) && reflect.DeepEqual(ts2AnySecondContract, sequences[0].Data)
 			}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)
@@ -1079,20 +1079,20 @@ func runContractReaderByIDQueryKey(t *testing.T) {
 			_ = SubmitTransactionToCW(t, tester, MethodTriggeringEvent, ts2AnySecondContract2, anySecondContract2, types.Unconfirmed)
 
 			tsAnyContractType := &TestStruct{}
-			assert.Eventually(t, func() bool {
+			require.Eventually(t, func() bool {
 				sequences, err := cr.QueryKey(ctx, anyContractID1, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, tsAnyContractType)
 				return err == nil && len(sequences) == 2 && reflect.DeepEqual(ts1AnyContract1, sequences[1].Data) && reflect.DeepEqual(ts2AnyContract1, sequences[0].Data)
 			}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)
-			assert.Eventually(t, func() bool {
+			require.Eventually(t, func() bool {
 				sequences, err := cr.QueryKey(ctx, anyContractID2, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, tsAnyContractType)
 				return err == nil && len(sequences) == 2 && reflect.DeepEqual(ts1AnyContract2, sequences[1].Data) && reflect.DeepEqual(ts2AnyContract2, sequences[0].Data)
 			}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)
 
-			assert.Eventually(t, func() bool {
+			require.Eventually(t, func() bool {
 				sequences, err := cr.QueryKey(ctx, anySecondContractID1, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, tsAnyContractType)
 				return err == nil && len(sequences) == 2 && reflect.DeepEqual(ts1AnySecondContract1, sequences[1].Data) && reflect.DeepEqual(ts2AnySecondContract1, sequences[0].Data)
 			}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)
-			assert.Eventually(t, func() bool {
+			require.Eventually(t, func() bool {
 				sequences, err := cr.QueryKey(ctx, anySecondContractID2, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, tsAnyContractType)
 				return err == nil && len(sequences) == 2 && reflect.DeepEqual(ts1AnySecondContract2, sequences[1].Data) && reflect.DeepEqual(ts2AnySecondContract2, sequences[0].Data)
 			}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)

--- a/pkg/types/interfacetests/chain_components_interface_tests.go
+++ b/pkg/types/interfacetests/chain_components_interface_tests.go
@@ -307,7 +307,7 @@ func runContractReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester Ch
 				_ = SubmitTransactionToCW(t, tester, MethodTriggeringEvent, ts, contracts[0], types.Unconfirmed)
 
 				result := &TestStruct{}
-				assert.Eventually(t, func() bool {
+				require.Eventually(t, func() bool {
 					err := cr.GetLatestValue(ctx, bound.ReadIdentifier(EventName), primitives.Unconfirmed, nil, &result)
 					return err == nil && reflect.DeepEqual(result, &ts)
 				}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)
@@ -327,7 +327,7 @@ func runContractReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester Ch
 				txID := SubmitTransactionToCW(t, tester, MethodTriggeringEvent, ts1, bindings[0], types.Unconfirmed)
 
 				result := &TestStruct{}
-				assert.Eventually(t, func() bool {
+				require.Eventually(t, func() bool {
 					err := cr.GetLatestValue(ctx, bound.ReadIdentifier(EventName), primitives.Finalized, nil, &result)
 					return err != nil && assert.ErrorContains(t, err, types.ErrNotFound.Error())
 				}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)
@@ -338,12 +338,12 @@ func runContractReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester Ch
 				ts2 := CreateTestStruct[T](3, tester)
 				_ = SubmitTransactionToCW(t, tester, MethodTriggeringEvent, ts2, bindings[0], types.Unconfirmed)
 
-				assert.Eventually(t, func() bool {
+				require.Eventually(t, func() bool {
 					err := cr.GetLatestValue(ctx, bound.ReadIdentifier(EventName), primitives.Finalized, nil, &result)
 					return err == nil && reflect.DeepEqual(result, &ts1)
 				}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)
 
-				assert.Eventually(t, func() bool {
+				require.Eventually(t, func() bool {
 					err := cr.GetLatestValue(ctx, bound.ReadIdentifier(EventName), primitives.Unconfirmed, nil, &result)
 					return err == nil && reflect.DeepEqual(result, &ts2)
 				}, tester.MaxWaitTimeForEvents(), time.Millisecond*10)
@@ -711,7 +711,7 @@ func runQueryKeyInterfaceTests[T TestingT[T]](t T, tester ChainComponentsInterfa
 				_ = SubmitTransactionToCW(t, tester, MethodTriggeringEvent, ts2, boundContract, types.Unconfirmed)
 
 				ts := &TestStruct{}
-				assert.Eventually(t, func() bool {
+				require.Eventually(t, func() bool {
 					// sequences from queryKey without limit and sort should be in descending order
 					sequences, err := cr.QueryKey(ctx, boundContract, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, ts)
 					return err == nil && len(sequences) == 2 && reflect.DeepEqual(&ts1, sequences[1].Data) && reflect.DeepEqual(&ts2, sequences[0].Data)
@@ -735,7 +735,7 @@ func runQueryKeyInterfaceTests[T TestingT[T]](t T, tester ChainComponentsInterfa
 
 				var value values.Value
 
-				assert.Eventually(t, func() bool {
+				require.Eventually(t, func() bool {
 					// sequences from queryKey without limit and sort should be in descending order
 					sequences, err := cr.QueryKey(ctx, bound, query.KeyFilter{Key: EventName}, query.LimitAndSort{}, &value)
 					if err != nil || len(sequences) != 2 {
@@ -776,7 +776,7 @@ func runQueryKeyInterfaceTests[T TestingT[T]](t T, tester ChainComponentsInterfa
 				_ = SubmitTransactionToCW(t, tester, MethodTriggeringEvent, ts3, boundContract, types.Unconfirmed)
 
 				ts := &TestStruct{}
-				assert.Eventually(t, func() bool {
+				require.Eventually(t, func() bool {
 					// sequences from queryKey without limit and sort should be in descending order
 					sequences, err := cr.QueryKey(ctx, boundContract, query.KeyFilter{Key: EventName, Expressions: []query.Expression{
 						query.Comparator("Field",
@@ -814,7 +814,7 @@ func runQueryKeyInterfaceTests[T TestingT[T]](t T, tester ChainComponentsInterfa
 					_ = SubmitTransactionToCW(t, tester, MethodTriggeringEvent, testStructs[idx], boundContract, types.Unconfirmed)
 				}
 
-				assert.Eventually(t, func() bool {
+				require.Eventually(t, func() bool {
 					var allSequences []types.Sequence
 
 					filter := query.KeyFilter{Key: EventName, Expressions: []query.Expression{


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/11318796531/job/31473865744
<details>
<summary>RACE</summary>

```
==================
WARNING: DATA RACE
Write at 0x00c0050a2fec by goroutine 329379:
  reflect.Value.SetInt()
      /opt/hostedtoolcache/go/1.22.8/x64/src/reflect/value.go:2409 +0x144
  github.com/fxamacker/cbor/v2.fillPositiveInt()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:3007 +0x606
  github.com/fxamacker/cbor/v2.(*decoder).parseToValue()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1488 +0x1811
  github.com/fxamacker/cbor/v2.(*decoder).parseMapToStruct()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:2811 +0x14bb
  github.com/fxamacker/cbor/v2.(*decoder).parseToValue()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1638 +0x1e84
  github.com/fxamacker/cbor/v2.(*decoder).value()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1356 +0x366
  github.com/fxamacker/cbor/v2.(*decMode).Unmarshal()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1259 +0xef
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/contractreader.DecodeVersionedBytes()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go:136 +0x9f8
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/contractreader.(*Client).GetLatestValue()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go:196 +0x3a4
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runContractReaderGetLatestValueInterfaceTests[go.shape.*uint8].func11.3()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/types/interfacetests/chain_components_interface_tests.go:347 +0x12e
  github.com/stretchr/testify/assert.Eventually.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x33

Previous write at 0x00c0050a2fec by goroutine 329368:
  reflect.Value.SetInt()
      /opt/hostedtoolcache/go/1.22.8/x64/src/reflect/value.go:2409 +0x144
  github.com/fxamacker/cbor/v2.fillPositiveInt()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:3007 +0x606
  github.com/fxamacker/cbor/v2.(*decoder).parseToValue()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44

Goroutine 329368 (finished) created at:
  github.com/stretchr/testify/assert.Eventually()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x3d5
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runContractReaderGetLatestValueInterfaceTests[go.shape.*uint8].func11()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/types/interfacetests/chain_components_interface_tests.go:341 +0xc89
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runTests[go.shape.*uint8].func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/types/interfacetests/utils.go:40 +0x5b
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44
==================
==================
WARNING: DATA RACE
Write at 0x00c0015e2710 by goroutine 329379:
  reflect.Value.SetLen()
      /opt/hostedtoolcache/go/1.22.8/x64/src/reflect/value.go:2425 +0xaa
  github.com/fxamacker/cbor/v2.(*decoder).parseArrayToSlice()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:2259 +0x2ac
  github.com/fxamacker/cbor/v2.(*decoder).parseToValue()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1627 +0x2207
  github.com/fxamacker/cbor/v2.(*decoder).parseMapToStruct()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:2811 +0x14bb
  github.com/fxamacker/cbor/v2.(*decoder).parseToValue()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1638 +0x1e84
  github.com/fxamacker/cbor/v2.(*decoder).value()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1356 +0x366
  github.com/fxamacker/cbor/v2.(*decMode).Unmarshal()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1259 +0xef
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/contractreader.DecodeVersionedBytes()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go:136 +0x9f8
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/contractreader.(*Client).GetLatestValue()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go:196 +0x3a4
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runContractReaderGetLatestValueInterfaceTests[go.shape.*uint8].func11.3()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/types/interfacetests/chain_components_interface_tests.go:347 +0x12e
  github.com/stretchr/testify/assert.Eventually.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x33

Previous write at 0x00c0015e2710 by goroutine 329368:
  reflect.Value.SetLen()
      /opt/hostedtoolcache/go/1.22.8/x64/src/reflect/value.go:2425 +0xaa
  github.com/fxamacker/cbor/v2.(*decoder).parseArrayToSlice()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:2259 +0x2ac
  github.com/fxamacker/cbor/v2.(*decoder).parseToValue()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1627 +0x2207
  github.com/fxamacker/cbor/v2.(*decoder).parseMapToStruct()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:2811 +0x14bb
  github.com/fxamacker/cbor/v2.(*decoder).parseToValue()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1638 +0x1e84
  github.com/fxamacker/cbor/v2.(*decoder).value()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1356 +0x366
  github.com/fxamacker/cbor/v2.(*decMode).Unmarshal()
      /home/runner/go/pkg/mod/github.com/fxamacker/cbor/v2@v2.7.0/decode.go:1259 +0xef
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/contractreader.DecodeVersionedBytes()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go:136 +0x9f8
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer/pluginprovider/contractreader.(*Client).GetLatestValue()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go:196 +0x3a4
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runContractReaderGetLatestValueInterfaceTests[go.shape.*uint8].func11.2()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/types/interfacetests/chain_components_interface_tests.go:342 +0x12e
  github.com/stretchr/testify/assert.Eventually.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x33

Goroutine 329379 (running) created at:
  github.com/stretchr/testify/assert.Eventually()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x3d5
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runContractReaderGetLatestValueInterfaceTests[go.shape.*uint8].func11()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/types/interfacetests/chain_components_interface_tests.go:346 +0xf24
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runTests[go.shape.*uint8].func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/types/interfacetests/utils.go:40 +0x5b
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44

Goroutine 329368 (finished) created at:
  github.com/stretchr/testify/assert.Eventually()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x3d5
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runContractReaderGetLatestValueInterfaceTests[go.shape.*uint8].func11()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/types/interfacetests/chain_components_interface_tests.go:341 +0xc89
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runTests[go.shape.*uint8].func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/types/interfacetests/utils.go:40 +0x5b
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44
==================
github.event_name: schedule
github.ref: refs/heads/develop
```
</details>
Assert doesn't short circuit the test, and the passed func can still be executing when it returns.