### PR TITLE
contract reader api change for block meta data

### DIFF
--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -17,10 +17,6 @@ const (
 	ErrNotFound                    = NotFoundError("not found")
 )
 
-type BlockMetaData struct {
-	Height uint64
-}
-
 // ContractReader defines essential read operations a chain should implement for reading contract values and events.
 type ContractReader interface {
 	services.Service
@@ -50,8 +46,8 @@ type ContractReader interface {
 	// Passing in a *values.Value as the returnVal will encode the return value as an appropriate value.Value instance.
 	GetLatestValue(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) error
 
-	// GetLatestValueWithBlockMetaData should be used in the same was as GetLatestValue, but also returns the block metadata.
-	GetLatestValueWithBlockMetaData(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) (BlockMetaData, error)
+	// GetLatestValueWithHeadData should be used in the same was as GetLatestValue, but also returns the head data.
+	GetLatestValueWithHeadData(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) (Head, error)
 
 	// BatchGetLatestValues batches get latest value calls based on request, which is grouped by contract names that each have a slice of BatchRead.
 	// BatchGetLatestValuesRequest params and returnVal follow same rules as GetLatestValue params and returnVal arguments, with difference in how response is returned.
@@ -137,8 +133,8 @@ func (UnimplementedContractReader) GetLatestValue(ctx context.Context, readIdent
 	return UnimplementedError("ContractReader.GetLatestValue unimplemented")
 }
 
-func (UnimplementedContractReader) GetLatestValueWithBlockMetaData(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) (BlockMetaData, error) {
-	return BlockMetaData{}, UnimplementedError("ContractReader.GetLatestValueWithBlockMetaData unimplemented")
+func (UnimplementedContractReader) GetLatestValueWithHeadData(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) (Head, error) {
+	return Head{}, UnimplementedError("ContractReader.GetLatestValueWithBlockMetaData unimplemented")
 }
 
 func (UnimplementedContractReader) BatchGetLatestValues(ctx context.Context, request BatchGetLatestValuesRequest) (BatchGetLatestValuesResult, error) {

--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -134,7 +134,7 @@ func (UnimplementedContractReader) GetLatestValue(ctx context.Context, readIdent
 }
 
 func (UnimplementedContractReader) GetLatestValueWithHeadData(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) (Head, error) {
-	return Head{}, UnimplementedError("ContractReader.GetLatestValueWithBlockMetaData unimplemented")
+	return Head{}, UnimplementedError("ContractReader.GetLatestValueWithHeadData unimplemented")
 }
 
 func (UnimplementedContractReader) BatchGetLatestValues(ctx context.Context, request BatchGetLatestValuesRequest) (BatchGetLatestValuesResult, error) {

--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -137,6 +137,10 @@ func (UnimplementedContractReader) GetLatestValue(ctx context.Context, readIdent
 	return UnimplementedError("ContractReader.GetLatestValue unimplemented")
 }
 
+func (UnimplementedContractReader) GetLatestValueWithBlockMetaData(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) (BlockMetaData, error) {
+	return BlockMetaData{}, UnimplementedError("ContractReader.GetLatestValueWithBlockMetaData unimplemented")
+}
+
 func (UnimplementedContractReader) BatchGetLatestValues(ctx context.Context, request BatchGetLatestValuesRequest) (BatchGetLatestValuesResult, error) {
 	return nil, UnimplementedError("ContractReader.BatchGetLatestValues unimplemented")
 }

--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -46,7 +46,7 @@ type ContractReader interface {
 	// Passing in a *values.Value as the returnVal will encode the return value as an appropriate value.Value instance.
 	GetLatestValue(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) error
 
-	// GetLatestValueWithHeadData should be used in the same was as GetLatestValue, but also returns the head data.
+	// GetLatestValueWithHeadData should be used in the same way as GetLatestValue, but also returns the head data.
 	GetLatestValueWithHeadData(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) (Head, error)
 
 	// BatchGetLatestValues batches get latest value calls based on request, which is grouped by contract names that each have a slice of BatchRead.

--- a/pkg/types/contract_reader.go
+++ b/pkg/types/contract_reader.go
@@ -17,6 +17,10 @@ const (
 	ErrNotFound                    = NotFoundError("not found")
 )
 
+type BlockMetaData struct {
+	Height uint64
+}
+
 // ContractReader defines essential read operations a chain should implement for reading contract values and events.
 type ContractReader interface {
 	services.Service
@@ -45,6 +49,9 @@ type ContractReader interface {
 	// Similarly, when using a struct for returnVal, fields in the return value that are not on-chain will not be set.
 	// Passing in a *values.Value as the returnVal will encode the return value as an appropriate value.Value instance.
 	GetLatestValue(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) error
+
+	// GetLatestValueWithBlockMetaData should be used in the same was as GetLatestValue, but also returns the block metadata.
+	GetLatestValueWithBlockMetaData(ctx context.Context, readIdentifier string, confidenceLevel primitives.ConfidenceLevel, params, returnVal any) (BlockMetaData, error)
 
 	// BatchGetLatestValues batches get latest value calls based on request, which is grouped by contract names that each have a slice of BatchRead.
 	// BatchGetLatestValuesRequest params and returnVal follow same rules as GetLatestValue params and returnVal arguments, with difference in how response is returned.


### PR DESCRIPTION
Part of the work for -> https://smartcontract-it.atlassian.net/browse/CAPPL-108

ContractReader API change discussed  here-> https://docs.google.com/document/d/1jyJ2eXIR0EP8eO30Sj4eVj-jJFW34OsnwIzV5mYwKKY/edit?tab=t.0#heading=h.3hiih1q4rib