### PR TITLE
Fix Foundry Shared Tests CI

### DIFF
--- a/pkg/codec/encodings/type_codec_test.go
+++ b/pkg/codec/encodings/type_codec_test.go
@@ -172,7 +172,9 @@ func (b *bigEndianInterfaceTester) encode(t *testing.T, bytes []byte, ts TestStr
 	for _, oid := range ts.OracleIDs {
 		bytes = append(bytes, byte(oid))
 	}
-	bytes = append(bytes, ts.AccountStruct.Account[:]...)
+	bytes = append(bytes, byte(len(ts.AccountStruct.Account)))
+	bytes = append(bytes, ts.AccountStruct.Account...)
+	bytes = rawbin.BigEndian.AppendUint32(bytes, uint32(len(ts.AccountStruct.AccountStr)))
 	bytes = append(bytes, []byte(ts.AccountStruct.AccountStr)...)
 	bytes = append(bytes, byte(len(ts.Accounts)))
 	for _, account := range ts.Accounts {
@@ -298,8 +300,8 @@ func (b *bigEndianInterfaceTester) GetCodec(t *testing.T) types.Codec {
 	}
 
 	mod, err := codec.NewHardCoder(map[string]any{
-		"BigField": ts.BigField.String(),
-		"Account":  ts.AccountStruct.Account,
+		"BigField":              ts.BigField.String(),
+		"AccountStruct.Account": ts.AccountStruct.Account,
 	}, map[string]any{"ExtraField": AnyExtraValue}, codec.BigIntHook)
 	require.NoError(t, err)
 

--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/codec_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/codec_test.go
@@ -144,7 +144,10 @@ func (f *fakeCodec) Encode(_ context.Context, item any, itemType string) ([]byte
 		return []byte{}, nil
 	case interfacetests.TestItemWithConfigExtra:
 		ts := item.(*interfacetests.TestStruct)
-		ts.Account = anyAccountBytes
+		ts.AccountStruct = interfacetests.AccountStruct{
+			Account:    anyAccountBytes,
+			AccountStr: anyAccountString,
+		}
 		ts.BigField = big.NewInt(2)
 		return encoder.Marshal(ts)
 	case interfacetests.TestItemType, interfacetests.TestItemSliceType, interfacetests.TestItemArray2Type, interfacetests.TestItemArray1Type:

--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader_test.go
@@ -484,7 +484,10 @@ func (f *fakeContractReader) GetLatestValue(_ context.Context, readIdentifier st
 		rv := returnVal.(*TestStructWithExtraField)
 		rv.TestStruct = *pv
 		rv.ExtraField = AnyExtraValue
-		rv.Account = anyAccountBytes
+		rv.AccountStruct = AccountStruct{
+			Account:    anyAccountBytes,
+			AccountStr: anyAccountString,
+		}
 		rv.BigField = big.NewInt(2)
 		return nil
 	} else if strings.HasSuffix(readIdentifier, EventName) {
@@ -569,7 +572,10 @@ func (f *fakeContractReader) BatchGetLatestValues(_ context.Context, request typ
 				*returnVal.(*[]uint64) = AnySliceToReadWithoutAnArgument
 			} else if req.ReadName == MethodReturningSeenStruct {
 				ts := *req.Params.(*TestStruct)
-				ts.Account = anyAccountBytes
+				ts.AccountStruct = AccountStruct{
+					Account:    anyAccountBytes,
+					AccountStr: anyAccountString,
+				}
 				ts.BigField = big.NewInt(2)
 				returnVal = &TestStructWithExtraField{
 					TestStruct: ts,

--- a/pkg/types/interfacetests/chain_components_interface_tests.go
+++ b/pkg/types/interfacetests/chain_components_interface_tests.go
@@ -270,7 +270,7 @@ func runContractReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester Ch
 				ctx := tests.Context(t)
 				testStruct := CreateTestStruct(0, tester)
 				testStruct.BigField = nil
-				testStruct.Account = nil
+				testStruct.AccountStruct = AccountStruct{}
 
 				bindings := tester.GetBindings(t)
 				bound := BindingsByName(bindings, AnyContractName)[0]
@@ -529,7 +529,7 @@ func runContractReaderBatchGetLatestValuesInterfaceTests[T TestingT[T]](t T, tes
 				// setup call data
 				testStruct := CreateTestStruct(0, tester)
 				testStruct.BigField = nil
-				testStruct.Account = nil
+				testStruct.AccountStruct = AccountStruct{}
 				actual := &TestStructWithExtraField{}
 				batchGetLatestValueRequest := make(types.BatchGetLatestValuesRequest)
 				bindings := tester.GetBindings(t)

--- a/pkg/types/interfacetests/chain_components_interface_tests.go
+++ b/pkg/types/interfacetests/chain_components_interface_tests.go
@@ -270,7 +270,7 @@ func runContractReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester Ch
 				ctx := tests.Context(t)
 				testStruct := CreateTestStruct(0, tester)
 				testStruct.BigField = nil
-				testStruct.AccountStruct = AccountStruct{}
+				testStruct.AccountStruct.Account = nil
 
 				bindings := tester.GetBindings(t)
 				bound := BindingsByName(bindings, AnyContractName)[0]
@@ -529,7 +529,7 @@ func runContractReaderBatchGetLatestValuesInterfaceTests[T TestingT[T]](t T, tes
 				// setup call data
 				testStruct := CreateTestStruct(0, tester)
 				testStruct.BigField = nil
-				testStruct.AccountStruct = AccountStruct{}
+				testStruct.AccountStruct.Account = nil
 				actual := &TestStructWithExtraField{}
 				batchGetLatestValueRequest := make(types.BatchGetLatestValuesRequest)
 				bindings := tester.GetBindings(t)

--- a/pkg/types/interfacetests/codec_interface_fuzz_tests.go
+++ b/pkg/types/interfacetests/codec_interface_fuzz_tests.go
@@ -37,10 +37,12 @@ func RunCodecInterfaceFuzzTests(f *testing.F, tester CodecInterfaceTester) {
 				DifferentField: differentField,
 				OracleID:       commontypes.OracleID(oracleId),
 				OracleIDs:      oids,
-				Account:        tester.GetAccountBytes(accountSeed),
-				AccountStr:     tester.GetAccountString(accountSeed),
-				Accounts:       [][]byte{tester.GetAccountBytes(accountsSeed + 1), tester.GetAccountBytes(accountsSeed + 2)},
-				BigField:       big.NewInt(bigField),
+				AccountStruct: AccountStruct{
+					Account:    tester.GetAccountBytes(accountSeed),
+					AccountStr: tester.GetAccountString(accountSeed),
+				},
+				Accounts: [][]byte{tester.GetAccountBytes(accountsSeed + 1), tester.GetAccountBytes(accountsSeed + 2)},
+				BigField: big.NewInt(bigField),
 				NestedDynamicStruct: MidLevelDynamicTestStruct{
 					FixedBytes: fb,
 					Inner: InnerDynamicTestStruct{

--- a/pkg/types/interfacetests/codec_interface_tests.go
+++ b/pkg/types/interfacetests/codec_interface_tests.go
@@ -65,8 +65,7 @@ func RunCodecInterfaceTests(t *testing.T, tester CodecInterfaceTester) {
 				req := &EncodeRequest{TestStructs: []TestStruct{item}, TestOn: TestItemType}
 				resp := tester.EncodeFields(t, req)
 				compatibleItem := compatibleTestStruct{
-					Account:             item.Account,
-					AccountStr:          item.AccountStr,
+					AccountStruct:       item.AccountStruct,
 					Accounts:            item.Accounts,
 					BigField:            item.BigField,
 					DifferentField:      item.DifferentField,
@@ -95,8 +94,10 @@ func RunCodecInterfaceTests(t *testing.T, tester CodecInterfaceTester) {
 				req := &EncodeRequest{TestStructs: []TestStruct{item}, TestOn: TestItemType}
 				resp := tester.EncodeFields(t, req)
 				compatibleMap := map[string]any{
-					"Account":        item.Account,
-					"AccountStr":     item.AccountStr,
+					"AccountStruct": map[string]any{
+						"Account":    item.AccountStruct.Account,
+						"AccountStr": item.AccountStruct.AccountStr,
+					},
 					"Accounts":       item.Accounts,
 					"BigField":       item.BigField,
 					"DifferentField": item.DifferentField,
@@ -140,8 +141,7 @@ func RunCodecInterfaceTests(t *testing.T, tester CodecInterfaceTester) {
 					DifferentField:      ts.DifferentField,
 					OracleID:            ts.OracleID,
 					OracleIDs:           ts.OracleIDs,
-					Account:             ts.Account,
-					AccountStr:          ts.AccountStr,
+					AccountStruct:       ts.AccountStruct,
 					Accounts:            ts.Accounts,
 					BigField:            ts.BigField,
 					NestedDynamicStruct: ts.NestedDynamicStruct,
@@ -325,7 +325,7 @@ func RunCodecInterfaceTests(t *testing.T, tester CodecInterfaceTester) {
 				cr := tester.GetCodec(t)
 				modified := CreateTestStruct[*testing.T](0, tester)
 				modified.BigField = nil
-				modified.Account = nil
+				modified.AccountStruct = AccountStruct{}
 				actual, err := cr.Encode(ctx, modified, TestItemWithConfigExtra)
 				require.NoError(t, err)
 
@@ -355,8 +355,7 @@ func RunCodecInterfaceTests(t *testing.T, tester CodecInterfaceTester) {
 					DifferentField:      "",
 					OracleID:            0,
 					OracleIDs:           [32]commontypes.OracleID{},
-					Account:             nil,
-					AccountStr:          "",
+					AccountStruct:       AccountStruct{},
 					Accounts:            nil,
 					BigField:            nil,
 					NestedDynamicStruct: MidLevelDynamicTestStruct{},

--- a/pkg/types/interfacetests/codec_interface_tests.go
+++ b/pkg/types/interfacetests/codec_interface_tests.go
@@ -325,7 +325,7 @@ func RunCodecInterfaceTests(t *testing.T, tester CodecInterfaceTester) {
 				cr := tester.GetCodec(t)
 				modified := CreateTestStruct[*testing.T](0, tester)
 				modified.BigField = nil
-				modified.AccountStruct = AccountStruct{}
+				modified.AccountStruct.Account = nil
 				actual, err := cr.Encode(ctx, modified, TestItemWithConfigExtra)
 				require.NoError(t, err)
 

--- a/pkg/types/interfacetests/utils.go
+++ b/pkg/types/interfacetests/utils.go
@@ -153,12 +153,16 @@ type MidLevelStaticTestStruct struct {
 	Inner      InnerStaticTestStruct
 }
 
+type AccountStruct struct {
+	Account    []byte
+	AccountStr string
+}
+
 type TestStruct struct {
 	Field               *int32
 	OracleID            commontypes.OracleID
 	OracleIDs           [32]commontypes.OracleID
-	Account             []byte
-	AccountStr          string
+	AccountStruct       AccountStruct
 	Accounts            [][]byte
 	DifferentField      string
 	BigField            *big.Int
@@ -175,8 +179,7 @@ type TestStructMissingField struct {
 	DifferentField      string
 	OracleID            commontypes.OracleID
 	OracleIDs           [32]commontypes.OracleID
-	Account             []byte
-	AccountStr          string
+	AccountStruct       AccountStruct
 	Accounts            [][]byte
 	BigField            *big.Int
 	NestedDynamicStruct MidLevelDynamicTestStruct
@@ -185,8 +188,7 @@ type TestStructMissingField struct {
 
 // compatibleTestStruct has fields in a different order
 type compatibleTestStruct struct {
-	Account             []byte
-	AccountStr          string
+	AccountStruct       AccountStruct
 	Accounts            [][]byte
 	BigField            *big.Int
 	DifferentField      string
@@ -217,11 +219,13 @@ func CreateTestStruct[T any](i int, tester BasicTester[T]) TestStruct {
 	s := fmt.Sprintf("field%v", i)
 	fv := int32(i)
 	return TestStruct{
-		Field:          &fv,
-		OracleID:       commontypes.OracleID(i + 1),
-		OracleIDs:      [32]commontypes.OracleID{commontypes.OracleID(i + 2), commontypes.OracleID(i + 3)},
-		Account:        tester.GetAccountBytes(i + 3),
-		AccountStr:     tester.GetAccountString(i + 3),
+		Field:     &fv,
+		OracleID:  commontypes.OracleID(i + 1),
+		OracleIDs: [32]commontypes.OracleID{commontypes.OracleID(i + 2), commontypes.OracleID(i + 3)},
+		AccountStruct: AccountStruct{
+			Account:    tester.GetAccountBytes(i),
+			AccountStr: tester.GetAccountString(i),
+		},
 		Accounts:       [][]byte{tester.GetAccountBytes(i + 4), tester.GetAccountBytes(i + 5)},
 		DifferentField: s,
 		BigField:       big.NewInt(int64((i + 1) * (i + 2))),


### PR DESCRIPTION
### Description
Refactor in order to fix `CompilerError: Stack too deep` within [Foundry Tests Shared](https://github.com/smartcontractkit/chainlink/actions/runs/11447128795/job/31847794134)

**NOTE:** No changes in the logic previously merged. Just tests refactor after introducing `AccountStruct` within the `TestStruct`
```
struct AccountStruct {
  address Account;
  address AccountStr;
}
```

### Related:
- https://github.com/smartcontractkit/chainlink/pull/14909
- https://github.com/smartcontractkit/chainlink-solana/pull/903

--- 

core ref: test-pack-address
solana ref: test-pack-address