### PR TITLE
Bump settings

### DIFF
--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -81,8 +81,8 @@ func (r *respStore) get(id string) (*wasmpb.Response, error) {
 
 var (
 	defaultTickInterval = 100 * time.Millisecond
-	defaultTimeout      = 300 * time.Millisecond
-	defaultMaxMemoryMBs = 64
+	defaultTimeout      = 2 * time.Second
+	defaultMaxMemoryMBs = 256
 	DefaultInitialFuel  = uint64(100_000_000)
 )
 

--- a/pkg/workflows/wasm/host/test/oom/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/oom/cmd/main.go
@@ -6,5 +6,5 @@ import "math"
 
 func main() {
 	// allocate more bytes than the binary should be able to access, 64 megs
-	_ = make([]byte, int64(128*math.Pow(10, 6)))
+	_ = make([]byte, int64(512*math.Pow(10, 6)))
 }


### PR DESCRIPTION
* Bump default timeout + max memoryMBs for the WASM capability