### PR TITLE
refactor(custmsg+wasm): adjust message emitter iface

### DIFF
--- a/pkg/custmsg/custom_message.go
+++ b/pkg/custmsg/custom_message.go
@@ -11,6 +11,20 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 )
 
+type MessageEmitter interface {
+	// Emit sends a message to the labeler's destination.
+	Emit(string) error
+
+	// WithMapLabels sets the labels for the message to be emitted.  Labels are cumulative.
+	WithMapLabels(map[string]string) MessageEmitter
+
+	// With adds multiple key-value pairs to the emission.
+	With(keyValues ...string) MessageEmitter
+
+	// Labels returns a view of the current labels.
+	Labels() map[string]string
+}
+
 type Labeler struct {
 	labels map[string]string
 }
@@ -21,7 +35,7 @@ func NewLabeler() Labeler {
 
 // WithMapLabels adds multiple key-value pairs to the CustomMessageLabeler for transmission
 // With SendLogAsCustomMessage
-func (l Labeler) WithMapLabels(labels map[string]string) Labeler {
+func (l Labeler) WithMapLabels(labels map[string]string) MessageEmitter {
 	newCustomMessageLabeler := NewLabeler()
 
 	// Copy existing labels from the current agent
@@ -38,7 +52,7 @@ func (l Labeler) WithMapLabels(labels map[string]string) Labeler {
 }
 
 // With adds multiple key-value pairs to the CustomMessageLabeler for transmission With SendLogAsCustomMessage
-func (l Labeler) With(keyValues ...string) Labeler {
+func (l Labeler) With(keyValues ...string) MessageEmitter {
 	newCustomMessageLabeler := NewLabeler()
 
 	if len(keyValues)%2 != 0 {

--- a/pkg/custmsg/custom_message_test.go
+++ b/pkg/custmsg/custom_message_test.go
@@ -16,15 +16,11 @@ func Test_CustomMessageAgent(t *testing.T) {
 }
 
 func Test_CustomMessageAgent_With(t *testing.T) {
-	cma := NewLabeler()
-	cma = cma.With("key1", "value1")
-
+	cma := NewLabeler().With("key1", "value1")
 	assert.Equal(t, cma.Labels(), map[string]string{"key1": "value1"})
 }
 
 func Test_CustomMessageAgent_WithMapLabels(t *testing.T) {
-	cma := NewLabeler()
-	cma = cma.WithMapLabels(map[string]string{"key1": "value1"})
-
+	cma := NewLabeler().WithMapLabels(map[string]string{"key1": "value1"})
 	assert.Equal(t, cma.Labels(), map[string]string{"key1": "value1"})
 }

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bytecodealliance/wasmtime-go/v23"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm"
@@ -65,15 +66,6 @@ type DeterminismConfig struct {
 	// Seed is the seed used to generate cryptographically insecure random numbers in the module.
 	Seed int64
 }
-
-type MessageEmitter interface {
-	// Emit sends a message to the labeler's destination.
-	Emit(string) error
-
-	// WithMapLabels sets the labels for the message to be emitted.  Labels are cumulative.
-	WithMapLabels(map[string]string) MessageEmitter
-}
-
 type ModuleConfig struct {
 	TickInterval   time.Duration
 	Timeout        *time.Duration
@@ -84,7 +76,7 @@ type ModuleConfig struct {
 	Fetch          func(*wasmpb.FetchRequest) (*wasmpb.FetchResponse, error)
 
 	// Labeler is used to emit messages from the module.
-	Labeler MessageEmitter
+	Labeler custmsg.MessageEmitter
 
 	// If Determinism is set, the module will override the random_get function in the WASI API with
 	// the provided seed to ensure deterministic behavior.
@@ -445,7 +437,7 @@ func fetchFn(logger logger.Logger, modCfg *ModuleConfig) func(caller *wasmtime.C
 // Emit, if any, are returned in the Error Message of the response.
 func createEmitFn(
 	l logger.Logger,
-	e MessageEmitter,
+	e custmsg.MessageEmitter,
 	reader unsafeReaderFunc,
 	writer unsafeWriterFunc,
 	sizeWriter unsafeFixedLengthWriterFunc,
@@ -508,8 +500,16 @@ func (u *unimplementedMessageEmitter) Emit(string) error {
 	return errors.New("unimplemented")
 }
 
-func (u *unimplementedMessageEmitter) WithMapLabels(map[string]string) MessageEmitter {
+func (u *unimplementedMessageEmitter) WithMapLabels(map[string]string) custmsg.MessageEmitter {
 	return u
+}
+
+func (u *unimplementedMessageEmitter) With(kvs ...string) custmsg.MessageEmitter {
+	return u
+}
+
+func (u *unimplementedMessageEmitter) Labels() map[string]string {
+	return nil
 }
 
 func toEmissible(b []byte) (string, map[string]string, error) {

--- a/pkg/workflows/wasm/host/module_test.go
+++ b/pkg/workflows/wasm/host/module_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/values/pb"
 	wasmpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/pb"
@@ -22,12 +23,21 @@ func (m *mockMessageEmitter) Emit(msg string) error {
 	return m.e(msg, m.labels)
 }
 
-func (m *mockMessageEmitter) WithMapLabels(labels map[string]string) MessageEmitter {
+func (m *mockMessageEmitter) WithMapLabels(labels map[string]string) custmsg.MessageEmitter {
 	m.labels = labels
 	return m
 }
 
-func newMockMessageEmitter(e func(string, map[string]string) error) MessageEmitter {
+func (m *mockMessageEmitter) With(keyValues ...string) custmsg.MessageEmitter {
+	// do nothing
+	return m
+}
+
+func (m *mockMessageEmitter) Labels() map[string]string {
+	return m.labels
+}
+
+func newMockMessageEmitter(e func(string, map[string]string) error) custmsg.MessageEmitter {
 	return &mockMessageEmitter{e: e}
 }
 

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -69,7 +69,7 @@ func newWasmGuestEmitter(emitFn func(string, map[string]string) error) wasmGuest
 	return wasmGuestEmitter{
 		emitFn: emitFn,
 		labels: make(map[string]string),
-		base:   custmsg.NewLabeler(),
+		base:   custmsg.NewMessageEmitter(),
 	}
 }
 

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -60,7 +60,7 @@ func (r *Runtime) Emitter() sdk.MessageEmitter {
 }
 
 type wasmGuestEmitter struct {
-	base   custmsg.Labeler
+	base   custmsg.MessageEmitter
 	emitFn func(string, map[string]string) error
 	labels map[string]string
 }
@@ -69,7 +69,7 @@ func newWasmGuestEmitter(emitFn func(string, map[string]string) error) wasmGuest
 	return wasmGuestEmitter{
 		emitFn: emitFn,
 		labels: make(map[string]string),
-		base:   custmsg.NewMessageEmitter(),
+		base:   custmsg.NewLabeler(),
 	}
 }
 


### PR DESCRIPTION
passing the `custmsg.Labeler` to `host.ModuleConfig.Labeler` is blocked because the types do not match.  this PR fixes the type mismatch:

* removes the `MessageEmitter` interface from `wasm/host` as it is self-referential and therefore cannot be satisfied by an implementation that does not import `wasm/host`.

* `MessageEmitter` is instead defined in `custmsg` and imported into `wasm/host`.  Now `custmsg.Labeler` implements `custmsg.MessageEmitter` and can be passed directly to `host.ModuleConfig`.

