### PR TITLE
[CAPPL-195] preserve errors across the WASM boundary

### DIFF
--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -447,29 +447,55 @@ func createFetchFn(
 	return func(caller *wasmtime.Caller, respptr int32, resplenptr int32, reqptr int32, reqptrlen int32) int32 {
 		const errFetchSfx = "error calling fetch"
 
+		// writeErr marshals and writes an error response to wasm
+		writeErr := func(err error) int32 {
+			resp := &wasmpb.FetchResponse{
+				ExecutionError: true,
+				ErrorMessage:   err.Error(),
+			}
+
+			respBytes, perr := proto.Marshal(resp)
+			if perr != nil {
+				logger.Errorf("%s: %s", errFetchSfx, perr)
+				return ErrnoFault
+			}
+
+			if size := writer(caller, respBytes, respptr, int32(len(respBytes))); size == -1 {
+				logger.Errorf("%s: %s", errFetchSfx, errors.New("failed to write error response"))
+				return ErrnoFault
+			}
+
+			if size := sizeWriter(caller, resplenptr, uint32(len(respBytes))); size == -1 {
+				logger.Errorf("%s: %s", errFetchSfx, errors.New("failed to write error response length"))
+				return ErrnoFault
+			}
+
+			return ErrnoSuccess
+		}
+
 		b, innerErr := reader(caller, reqptr, reqptrlen)
 		if innerErr != nil {
 			logger.Errorf("%s: %s", errFetchSfx, innerErr)
-			return ErrnoFault
+			return writeErr(innerErr)
 		}
 
 		req := &wasmpb.FetchRequest{}
 		innerErr = proto.Unmarshal(b, req)
 		if innerErr != nil {
 			logger.Errorf("%s: %s", errFetchSfx, innerErr)
-			return ErrnoFault
+			return writeErr(innerErr)
 		}
 
 		storedRequest, innerErr := requestStore.get(req.Id)
 		if innerErr != nil {
 			logger.Errorf("%s: %s", errFetchSfx, innerErr)
-			return ErrnoFault
+			return writeErr(innerErr)
 		}
 
 		// limit the number of fetch calls we can make per request
 		if storedRequest.fetchRequestsCounter >= modCfg.MaxFetchRequests {
 			logger.Errorf("%s: max number of fetch request %d exceeded", errFetchSfx, modCfg.MaxFetchRequests)
-			return ErrnoFault
+			return writeErr(errors.New("max number of fetch requests exceeded"))
 		}
 		storedRequest.fetchRequestsCounter++
 
@@ -482,21 +508,21 @@ func createFetchFn(
 		})
 		if innerErr != nil {
 			logger.Errorf("%s: %s", errFetchSfx, innerErr)
-			return ErrnoFault
+			return writeErr(innerErr)
 		}
 
 		respBytes, innerErr := proto.Marshal(fetchResp)
 		if innerErr != nil {
 			logger.Errorf("%s: %s", errFetchSfx, innerErr)
-			return ErrnoFault
+			return writeErr(innerErr)
 		}
 
 		if size := writer(caller, respBytes, respptr, int32(len(respBytes))); size == -1 {
-			return ErrnoFault
+			return writeErr(errors.New("failed to write response"))
 		}
 
 		if size := sizeWriter(caller, resplenptr, uint32(len(respBytes))); size == -1 {
-			return ErrnoFault
+			return writeErr(errors.New("failed to write response length"))
 		}
 
 		return ErrnoSuccess

--- a/pkg/workflows/wasm/host/wasm_test.go
+++ b/pkg/workflows/wasm/host/wasm_test.go
@@ -466,6 +466,7 @@ func Test_Compute_Fetch(t *testing.T) {
 		}
 		_, err = m.Run(ctx, req)
 		assert.NotNil(t, err)
+		assert.ErrorContains(t, err, assert.AnError.Error())
 		require.Len(t, logs.AllUntimed(), 1)
 
 		expectedEntries := []Entry{
@@ -574,7 +575,7 @@ func Test_Compute_Fetch(t *testing.T) {
 		cancel()
 		_, err = m.Run(ctx, req)
 		require.NotNil(t, err)
-		assert.ErrorContains(t, err, "error executing runner: error executing custom compute: failed to execute fetch")
+		assert.ErrorContains(t, err, fmt.Sprintf("error executing runner: error executing custom compute: %s", assert.AnError))
 	})
 
 	t.Run("NOK_exceed_amout_of_defined_max_fetch_calls", func(t *testing.T) {

--- a/pkg/workflows/wasm/runner_wasip1.go
+++ b/pkg/workflows/wasm/runner_wasip1.go
@@ -1,17 +1,12 @@
 package wasm
 
 import (
-	"encoding/binary"
-	"errors"
-	"fmt"
 	"os"
 	"unsafe"
 
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/values"
-	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
 	wasmpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/pb"
 )
 
@@ -39,7 +34,7 @@ func NewRunner() *Runner {
 
 			return &Runtime{
 				logger:  l,
-				fetchFn: createFetchFn(sdkConfig, l),
+				fetchFn: createFetchFn(sdkConfig, l, fetch),
 				emitFn:  createEmitFn(sdkConfig, l, emit),
 			}
 		},
@@ -75,69 +70,6 @@ func sendResponseFn(response *wasmpb.Response) {
 	}
 
 	os.Exit(code)
-}
-
-// createFetchFn injects dependencies and creates a fetch function that can be used by the WASM
-// binary.
-func createFetchFn(
-	sdkConfig *RuntimeConfig,
-	l logger.Logger,
-) func(sdk.FetchRequest) (sdk.FetchResponse, error) {
-	fetchFn := func(req sdk.FetchRequest) (sdk.FetchResponse, error) {
-		headerspb, err := values.NewMap(req.Headers)
-		if err != nil {
-			return sdk.FetchResponse{}, fmt.Errorf("failed to create headers map: %w", err)
-		}
-
-		b, err := proto.Marshal(&wasmpb.FetchRequest{
-			Id:        *sdkConfig.RequestID,
-			Url:       req.URL,
-			Method:    req.Method,
-			Headers:   values.ProtoMap(headerspb),
-			Body:      req.Body,
-			TimeoutMs: req.TimeoutMs,
-		})
-		if err != nil {
-			return sdk.FetchResponse{}, fmt.Errorf("failed to marshal fetch request: %w", err)
-		}
-		reqptr, reqptrlen := bufferToPointerLen(b)
-
-		respBuffer := make([]byte, sdkConfig.MaxFetchResponseSizeBytes)
-		respptr, _ := bufferToPointerLen(respBuffer)
-
-		resplenBuffer := make([]byte, uint32Size)
-		resplenptr, _ := bufferToPointerLen(resplenBuffer)
-
-		errno := fetch(respptr, resplenptr, reqptr, reqptrlen)
-		if errno != 0 {
-			return sdk.FetchResponse{}, fmt.Errorf("fetch failed with errno %d", errno)
-		}
-		responseSize := binary.LittleEndian.Uint32(resplenBuffer)
-		response := &wasmpb.FetchResponse{}
-		err = proto.Unmarshal(respBuffer[:responseSize], response)
-		if err != nil {
-			return sdk.FetchResponse{}, fmt.Errorf("failed to unmarshal fetch response: %w", err)
-		}
-		if response.ExecutionError == true && response.ErrorMessage != "" {
-			return sdk.FetchResponse{
-				ExecutionError: response.ExecutionError,
-				ErrorMessage:   response.ErrorMessage,
-			}, errors.New(response.ErrorMessage)
-		}
-
-		fields := response.Headers.GetFields()
-		headersResp := make(map[string]any, len(fields))
-		for k, v := range fields {
-			headersResp[k] = v
-		}
-
-		return sdk.FetchResponse{
-			StatusCode: uint8(response.StatusCode),
-			Headers:    headersResp,
-			Body:       response.Body,
-		}, nil
-	}
-	return fetchFn
 }
 
 type wasmWriteSyncer struct{}

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -152,6 +152,74 @@ func createEmitFn(
 	return emitFn
 }
 
+// createFetchFn injects dependencies and creates a fetch function that can be used by the WASM
+// binary.
+func createFetchFn(
+	sdkConfig *RuntimeConfig,
+	l logger.Logger,
+	fetch func(respptr unsafe.Pointer, resplenptr unsafe.Pointer, reqptr unsafe.Pointer, reqptrlen int32) int32,
+) func(sdk.FetchRequest) (sdk.FetchResponse, error) {
+	fetchFn := func(req sdk.FetchRequest) (sdk.FetchResponse, error) {
+		headerspb, err := values.NewMap(req.Headers)
+		if err != nil {
+			return sdk.FetchResponse{}, fmt.Errorf("failed to create headers map: %w", err)
+		}
+
+		if sdkConfig.RequestID == nil {
+			return sdk.FetchResponse{}, fmt.Errorf("request ID is required to fetch")
+		}
+
+		b, err := proto.Marshal(&wasmpb.FetchRequest{
+			Id:        *sdkConfig.RequestID,
+			Url:       req.URL,
+			Method:    req.Method,
+			Headers:   values.ProtoMap(headerspb),
+			Body:      req.Body,
+			TimeoutMs: req.TimeoutMs,
+		})
+		if err != nil {
+			return sdk.FetchResponse{}, fmt.Errorf("failed to marshal fetch request: %w", err)
+		}
+		reqptr, reqptrlen := bufferToPointerLen(b)
+
+		respBuffer := make([]byte, sdkConfig.MaxFetchResponseSizeBytes)
+		respptr, _ := bufferToPointerLen(respBuffer)
+
+		resplenBuffer := make([]byte, uint32Size)
+		resplenptr, _ := bufferToPointerLen(resplenBuffer)
+
+		errno := fetch(respptr, resplenptr, reqptr, reqptrlen)
+		if errno != 0 {
+			return sdk.FetchResponse{}, fmt.Errorf("fetch failed with errno %d", errno)
+		}
+		responseSize := binary.LittleEndian.Uint32(resplenBuffer)
+		response := &wasmpb.FetchResponse{}
+		err = proto.Unmarshal(respBuffer[:responseSize], response)
+		if err != nil {
+			return sdk.FetchResponse{}, fmt.Errorf("failed to unmarshal fetch response: %w", err)
+		}
+		if response.ExecutionError && response.ErrorMessage != "" {
+			return sdk.FetchResponse{
+				ExecutionError: response.ExecutionError,
+				ErrorMessage:   response.ErrorMessage,
+			}, errors.New(response.ErrorMessage)
+		}
+
+		fields := response.Headers.GetFields()
+		headersResp := make(map[string]any, len(fields))
+		for k, v := range fields {
+			headersResp[k] = v
+		}
+
+		return sdk.FetchResponse{
+			StatusCode: uint8(response.StatusCode),
+			Headers:    headersResp,
+			Body:       response.Body,
+		}, nil
+	}
+	return fetchFn
+}
+
 // bufferToPointerLen returns a pointer to the first element of the buffer and the length of the buffer.
 func bufferToPointerLen(buf []byte) (unsafe.Pointer, int32) {
 	return unsafe.Pointer(&buf[0]), int32(len(buf))


### PR DESCRIPTION
### Description
This pr adds the missing handling of errors on the guest side by writing them to the buffer as part of the response and recovering it on the host side.

[CAPPL-195](https://smartcontract-it.atlassian.net/browse/CAPPL-195)
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->


[CAPPL-195]: https://smartcontract-it.atlassian.net/browse/CAPPL-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ