### PR TITLE
pkg/config/validate.go: check CanInterface on subitems correctly

### DIFF
--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -78,7 +78,7 @@ func validate(v reflect.Value, checkInterface bool) (err error) {
 		for iter.Next() {
 			mk := iter.Key()
 			mv := iter.Value()
-			if !v.CanInterface() {
+			if !mv.CanInterface() {
 				continue
 			}
 			if mv.Kind() == reflect.Ptr && mv.IsNil() {
@@ -92,7 +92,7 @@ func validate(v reflect.Value, checkInterface bool) (err error) {
 	case reflect.Slice, reflect.Array:
 		for i := 0; i < v.Len(); i++ {
 			iv := v.Index(i)
-			if !v.CanInterface() {
+			if !iv.CanInterface() {
 				continue
 			}
 			if iv.Kind() == reflect.Ptr && iv.IsNil() {


### PR DESCRIPTION
in the switch statement, `validate()` is called on each value in the map, and each element in the slice - which then calls `Interface` in the `checkInterface` clause at the top of `validate`. we should be checking `CanInterface` on those items.