### PR TITLE
Register ContractReader gRPC service fixes and tests

### DIFF
--- a/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractreader/contract_reader.go
@@ -618,11 +618,11 @@ func convertLimitAndSortToProto(limitAndSort query.LimitAndSort) (*pb.LimitAndSo
 		var tp pb.SortType
 
 		switch sort := sortBy.(type) {
-		case query.SortByBlock:
+		case query.SortByBlock, *query.SortByBlock:
 			tp = pb.SortType_SortBlock
-		case query.SortByTimestamp:
+		case query.SortByTimestamp, *query.SortByTimestamp:
 			tp = pb.SortType_SortTimestamp
-		case query.SortBySequence:
+		case query.SortBySequence, *query.SortBySequence:
 			tp = pb.SortType_SortSequence
 		default:
 			return &pb.LimitAndSort{}, status.Errorf(codes.InvalidArgument, "Unknown sort by type: %T", sort)
@@ -902,5 +902,7 @@ func convertSequencesFromProto(pbSequences []*pb.Sequence, sequenceDataType any)
 }
 
 func RegisterContractReaderService(s *grpc.Server, contractReader types.ContractReader) {
-	pb.RegisterServiceServer(s, &goplugin.ServiceServer{Srv: contractReader})
+	service := goplugin.ServiceServer{Srv: contractReader}
+	pb.RegisterServiceServer(s, &service)
+	pb.RegisterContractReaderServer(s, NewServer(contractReader))
 }

--- a/pkg/workflows/sdk/compute_generated.go
+++ b/pkg/workflows/sdk/compute_generated.go
@@ -95,6 +95,58 @@ func Compute1WithConfig[I0 any, O any, C any](w *WorkflowSpecFactory, ref string
 	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
 }
 
+// Compute1WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute1WithMetadata[I0 any, O any](w *WorkflowSpecFactory, ref string, input Compute1Inputs[I0], compute func(Runtime, I0, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime1Inputs[I0]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime1Inputs[I0]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, request.Metadata)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
 type Compute2Inputs[T0 any, T1 any] struct {
 	Arg0 CapDefinition[T0]
 	Arg1 CapDefinition[T1]
@@ -163,6 +215,58 @@ func Compute2WithConfig[I0 any, I1 any, O any, C any](w *WorkflowSpecFactory, re
 		}
 
 		output, err := compute(runtime, conf, inputs.Arg0, inputs.Arg1)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
+// Compute2WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute2WithMetadata[I0 any, I1 any, O any](w *WorkflowSpecFactory, ref string, input Compute2Inputs[I0, I1], compute func(Runtime, I0, I1, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime2Inputs[I0, I1]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime2Inputs[I0, I1]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, inputs.Arg1, request.Metadata)
 		if err != nil {
 			return capabilities.CapabilityResponse{}, err
 		}
@@ -274,6 +378,58 @@ func Compute3WithConfig[I0 any, I1 any, I2 any, O any, C any](w *WorkflowSpecFac
 	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
 }
 
+// Compute3WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute3WithMetadata[I0 any, I1 any, I2 any, O any](w *WorkflowSpecFactory, ref string, input Compute3Inputs[I0, I1, I2], compute func(Runtime, I0, I1, I2, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime3Inputs[I0, I1, I2]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime3Inputs[I0, I1, I2]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, inputs.Arg1, inputs.Arg2, request.Metadata)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
 type Compute4Inputs[T0 any, T1 any, T2 any, T3 any] struct {
 	Arg0 CapDefinition[T0]
 	Arg1 CapDefinition[T1]
@@ -348,6 +504,58 @@ func Compute4WithConfig[I0 any, I1 any, I2 any, I3 any, O any, C any](w *Workflo
 		}
 
 		output, err := compute(runtime, conf, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
+// Compute4WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute4WithMetadata[I0 any, I1 any, I2 any, I3 any, O any](w *WorkflowSpecFactory, ref string, input Compute4Inputs[I0, I1, I2, I3], compute func(Runtime, I0, I1, I2, I3, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime4Inputs[I0, I1, I2, I3]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime4Inputs[I0, I1, I2, I3]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, request.Metadata)
 		if err != nil {
 			return capabilities.CapabilityResponse{}, err
 		}
@@ -465,6 +673,58 @@ func Compute5WithConfig[I0 any, I1 any, I2 any, I3 any, I4 any, O any, C any](w 
 	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
 }
 
+// Compute5WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute5WithMetadata[I0 any, I1 any, I2 any, I3 any, I4 any, O any](w *WorkflowSpecFactory, ref string, input Compute5Inputs[I0, I1, I2, I3, I4], compute func(Runtime, I0, I1, I2, I3, I4, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime5Inputs[I0, I1, I2, I3, I4]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime5Inputs[I0, I1, I2, I3, I4]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, inputs.Arg4, request.Metadata)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
 type Compute6Inputs[T0 any, T1 any, T2 any, T3 any, T4 any, T5 any] struct {
 	Arg0 CapDefinition[T0]
 	Arg1 CapDefinition[T1]
@@ -545,6 +805,58 @@ func Compute6WithConfig[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, O any, C
 		}
 
 		output, err := compute(runtime, conf, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, inputs.Arg4, inputs.Arg5)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
+// Compute6WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute6WithMetadata[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, O any](w *WorkflowSpecFactory, ref string, input Compute6Inputs[I0, I1, I2, I3, I4, I5], compute func(Runtime, I0, I1, I2, I3, I4, I5, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime6Inputs[I0, I1, I2, I3, I4, I5]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime6Inputs[I0, I1, I2, I3, I4, I5]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, inputs.Arg4, inputs.Arg5, request.Metadata)
 		if err != nil {
 			return capabilities.CapabilityResponse{}, err
 		}
@@ -668,6 +980,58 @@ func Compute7WithConfig[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, 
 	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
 }
 
+// Compute7WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute7WithMetadata[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, O any](w *WorkflowSpecFactory, ref string, input Compute7Inputs[I0, I1, I2, I3, I4, I5, I6], compute func(Runtime, I0, I1, I2, I3, I4, I5, I6, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime7Inputs[I0, I1, I2, I3, I4, I5, I6]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime7Inputs[I0, I1, I2, I3, I4, I5, I6]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, inputs.Arg4, inputs.Arg5, inputs.Arg6, request.Metadata)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
 type Compute8Inputs[T0 any, T1 any, T2 any, T3 any, T4 any, T5 any, T6 any, T7 any] struct {
 	Arg0 CapDefinition[T0]
 	Arg1 CapDefinition[T1]
@@ -754,6 +1118,58 @@ func Compute8WithConfig[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, 
 		}
 
 		output, err := compute(runtime, conf, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, inputs.Arg4, inputs.Arg5, inputs.Arg6, inputs.Arg7)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
+// Compute8WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute8WithMetadata[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, I7 any, O any](w *WorkflowSpecFactory, ref string, input Compute8Inputs[I0, I1, I2, I3, I4, I5, I6, I7], compute func(Runtime, I0, I1, I2, I3, I4, I5, I6, I7, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime8Inputs[I0, I1, I2, I3, I4, I5, I6, I7]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime8Inputs[I0, I1, I2, I3, I4, I5, I6, I7]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, inputs.Arg4, inputs.Arg5, inputs.Arg6, inputs.Arg7, request.Metadata)
 		if err != nil {
 			return capabilities.CapabilityResponse{}, err
 		}
@@ -883,6 +1299,58 @@ func Compute9WithConfig[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, 
 	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
 }
 
+// Compute9WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute9WithMetadata[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, I7 any, I8 any, O any](w *WorkflowSpecFactory, ref string, input Compute9Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8], compute func(Runtime, I0, I1, I2, I3, I4, I5, I6, I7, I8, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime9Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime9Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, inputs.Arg4, inputs.Arg5, inputs.Arg6, inputs.Arg7, inputs.Arg8, request.Metadata)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
 type Compute10Inputs[T0 any, T1 any, T2 any, T3 any, T4 any, T5 any, T6 any, T7 any, T8 any, T9 any] struct {
 	Arg0 CapDefinition[T0]
 	Arg1 CapDefinition[T1]
@@ -975,6 +1443,58 @@ func Compute10WithConfig[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any,
 		}
 
 		output, err := compute(runtime, conf, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, inputs.Arg4, inputs.Arg5, inputs.Arg6, inputs.Arg7, inputs.Arg8, inputs.Arg9)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
+// Compute10WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute10WithMetadata[I0 any, I1 any, I2 any, I3 any, I4 any, I5 any, I6 any, I7 any, I8 any, I9 any, O any](w *WorkflowSpecFactory, ref string, input Compute10Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8, I9], compute func(Runtime, I0, I1, I2, I3, I4, I5, I6, I7, I8, I9, capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+	def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime10Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8, I9]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime10Inputs[I0, I1, I2, I3, I4, I5, I6, I7, I8, I9]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, inputs.Arg0, inputs.Arg1, inputs.Arg2, inputs.Arg3, inputs.Arg4, inputs.Arg5, inputs.Arg6, inputs.Arg7, inputs.Arg8, inputs.Arg9, request.Metadata)
 		if err != nil {
 			return capabilities.CapabilityResponse{}, err
 		}

--- a/pkg/workflows/sdk/gen/compute.go.tmpl
+++ b/pkg/workflows/sdk/gen/compute.go.tmpl
@@ -70,13 +70,13 @@ func Compute{{.}}WithConfig[{{range  RangeNum .}}I{{.}} any, {{ end }}O any, C a
             return capabilities.CapabilityResponse{}, err
         }
 
-	var conf C
-	if request.Config != nil {
-		err = request.Config.UnwrapTo(&conf)
-		if err != nil {
-		    return capabilities.CapabilityResponse{}, err
-		}
-	}
+        var conf C
+        if request.Config != nil {
+            err = request.Config.UnwrapTo(&conf)
+            if err != nil {
+                return capabilities.CapabilityResponse{}, err
+            }
+        }
 
         output, err := compute(runtime, conf, {{range RangeNum . }}inputs.Arg{{.}},{{ end }})
         if err != nil {
@@ -97,5 +97,57 @@ func Compute{{.}}WithConfig[{{range  RangeNum .}}I{{.}} any, {{ end }}O any, C a
     }
     w.fns[ref] = capFn
     return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
+}
+
+// Compute{{.}}WithMetadata DO NOT USE, this functions is for internal local testing while other tools are being developed and is temporary
+func Compute{{.}}WithMetadata[{{range  RangeNum .}}I{{.}} any, {{ end }}O any](w *WorkflowSpecFactory, ref string, input Compute{{.}}Inputs[{{range RangeNum . }}I{{.}},{{ end }}], compute func(Runtime, {{range RangeNum . }}I{{.}},{{ end }} capabilities.RequestMetadata) (O, error)) ComputeOutputCap[O] {
+    def := StepDefinition{
+		ID:     "custom_compute@1.0.0",
+		Ref:    ref,
+		Inputs: input.ToSteps(),
+		Config: map[string]any{
+			"config": "$(ENV.config)",
+			"binary": "$(ENV.binary)",
+		},
+		CapabilityType: capabilities.CapabilityTypeAction,
+	}
+
+	capFn := func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+		var inputs runtime{{.}}Inputs[{{range RangeNum . }}I{{.}},{{ end }}]
+		if err := request.Inputs.UnwrapTo(&inputs); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// verify against any schema by marshalling and unmarshalling
+		ji, err := json.Marshal(inputs)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		// use a temp variable to unmarshal to avoid type loss if the inputs has an any in it
+		var tmp runtime{{.}}Inputs[{{range RangeNum . }}I{{.}},{{ end }}]
+		if err := json.Unmarshal(ji, &tmp); err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		output, err := compute(runtime, {{range RangeNum . }}inputs.Arg{{.}},{{ end }} request.Metadata)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		computeOutput := ComputeOutput[O]{Value: output}
+		wrapped, err := values.CreateMapFromStruct(computeOutput)
+		if err != nil {
+			return capabilities.CapabilityResponse{}, err
+		}
+
+		return capabilities.CapabilityResponse{Value: wrapped}, nil
+	}
+
+	if w.fns == nil {
+		w.fns = map[string]func(runtime Runtime, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error){}
+	}
+	w.fns[ref] = capFn
+	return &computeOutputCap[O]{(&Step[ComputeOutput[O]]{Definition: def}).AddTo(w)}
 }
 {{- end }}

--- a/pkg/workflows/wasm/pb/wasm.go
+++ b/pkg/workflows/wasm/pb/wasm.go
@@ -75,7 +75,7 @@ func WorkflowSpecToProto(spec *sdk.WorkflowSpec) (*WorkflowSpec, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error translating step definition to proto: %w", err)
 		}
-		ws.Targets = append(ws.Consensus, tt)
+		ws.Targets = append(ws.Targets, tt)
 	}
 
 	return ws, nil
@@ -163,7 +163,7 @@ func ProtoToWorkflowSpec(spec *WorkflowSpec) (*sdk.WorkflowSpec, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error translating step definition to proto: %w", err)
 		}
-		ws.Targets = append(ws.Consensus, tt)
+		ws.Targets = append(ws.Targets, tt)
 	}
 
 	return ws, nil

--- a/pkg/workflows/wasm/runner_test.go
+++ b/pkg/workflows/wasm/runner_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/cli/cmd/testdata/fixtures/capabilities/basictarget"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/cli/cmd/testdata/fixtures/capabilities/basictrigger"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -164,6 +165,10 @@ func TestRunner_Run_GetWorkflowSpec(t *testing.T) {
 	)
 
 	trigger := basictrigger.TriggerConfig{Name: "trigger", Number: 100}.New(workflow)
+	// Define and add a target to the workflow
+	targetInput := basictarget.TargetInput{CoolInput: trigger.CoolOutput()}
+	targetConfig := basictarget.TargetConfig{Name: "basictarget", Number: 150}
+	targetConfig.New(workflow, targetInput)
 	computeFn := func(sdk sdk.Runtime, outputs basictrigger.TriggerOutputs) (bool, error) {
 		return true, nil
 	}
@@ -205,7 +210,11 @@ func TestRunner_Run_GetWorkflowSpec(t *testing.T) {
 	// Do some massaging due to protos lossy conversion of types
 	gotSpec.Triggers[0].Inputs.Mapping = map[string]any{}
 	gotSpec.Triggers[0].Config["number"] = int64(gotSpec.Triggers[0].Config["number"].(uint64))
+	gotSpec.Targets[0].Config["number"] = int64(gotSpec.Targets[0].Config["number"].(uint64))
 	assert.Equal(t, &gotSpec, spc)
+
+	// Verify the target is included in the workflow spec
+	assert.Equal(t, targetConfig.Number, uint64(gotSpec.Targets[0].Config["number"].(int64)))
 }
 
 // Test_createEmitFn validates the runtime's emit function implementation.  Uses mocks of the


### PR DESCRIPTION
## Updates

- Register contract reader service as LOOPP gRPC server to access contract reader functions in contract reader LOOPP plugin namespace
- Bug fixes to WASM workflow targets
- Support pointer type for SortByTimestamp

## Testing

```
$ go test -count=1 -v -run="^TestRunner_Run_GetWorkflowSpec" ./pkg/workflows/wasm
=== RUN   TestRunner_Run_GetWorkflowSpec
--- PASS: TestRunner_Run_GetWorkflowSpec (0.00s)
PASS
ok      github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm 0.324s
```

## References

- PR reviews and comments are in the [Original PR](https://github.com/smartcontractkit/chainlink-common/pull/916).