### PR TITLE
Add key id field to consensus wrappers

### DIFF
--- a/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus.go
@@ -11,6 +11,7 @@ type IdenticalConsensusConfig[T any] struct {
 	Encoder       Encoder
 	EncoderConfig EncoderConfig
 	ReportID      ReportId
+	KeyID         KeyId
 }
 
 func (c IdenticalConsensusConfig[T]) New(w *sdk.WorkflowSpecFactory, ref string, input IdenticalConsensusInput[T]) SignedReportCap {
@@ -23,6 +24,7 @@ func (c IdenticalConsensusConfig[T]) New(w *sdk.WorkflowSpecFactory, ref string,
 			"encoder_config":     c.EncoderConfig,
 			"aggregation_method": "identical",
 			"report_id":          c.ReportID,
+			"key_id":             c.KeyID,
 		},
 		CapabilityType: capabilities.CapabilityTypeConsensus,
 	}

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus_test.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus_test.go
@@ -26,6 +26,7 @@ func TestIdenticalConsensus(t *testing.T) {
 		Encoder:       ocr3.EncoderEVM,
 		EncoderConfig: ocr3.EncoderConfig{},
 		ReportID:      "0001",
+		KeyID:         "evm",
 	}.New(workflow, "consensus", ocr3.IdenticalConsensusInput[basictrigger.TriggerOutputs]{
 		Observation:   trigger,
 		Encoder:       "evm",
@@ -71,6 +72,7 @@ func TestIdenticalConsensus(t *testing.T) {
 					"encoder_config":     map[string]any{},
 					"aggregation_method": "identical",
 					"report_id":          "0001",
+					"key_id":             "evm",
 				},
 				CapabilityType: capabilities.CapabilityTypeConsensus,
 			},

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/reduce_consensus.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/reduce_consensus.go
@@ -12,6 +12,7 @@ type ReduceConsensusConfig[T any] struct {
 	Encoder           Encoder
 	EncoderConfig     EncoderConfig
 	ReportID          ReportId
+	KeyID             KeyId
 	AggregationConfig aggregators.ReduceAggConfig
 }
 
@@ -26,6 +27,7 @@ func (c ReduceConsensusConfig[T]) New(w *sdk.WorkflowSpecFactory, ref string, in
 			"encoder":            c.Encoder,
 			"encoder_config":     c.EncoderConfig,
 			"report_id":          c.ReportID,
+			"key_id":             c.KeyID,
 		},
 		CapabilityType: capabilities.CapabilityTypeConsensus,
 	}

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/reduce_consensus_test.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/reduce_consensus_test.go
@@ -27,6 +27,7 @@ func TestReduceConsensus(t *testing.T) {
 		Encoder:       ocr3.EncoderEVM,
 		EncoderConfig: ocr3.EncoderConfig{},
 		ReportID:      "0001",
+		KeyID:         "evm",
 		AggregationConfig: aggregators.ReduceAggConfig{
 			Fields: []aggregators.AggregationField{
 				{
@@ -103,6 +104,7 @@ func TestReduceConsensus(t *testing.T) {
 					"encoder_config":     map[string]any{},
 					"report_id":          "0001",
 					"aggregation_method": "reduce",
+					"key_id":             "evm",
 					"aggregation_config": map[string]any{
 						"outputFieldName": "Reports",
 						"reportFormat":    "array",


### PR DESCRIPTION
This is a required configuration field so should be included on all Consensus wrappers.