### PR TITLE
Add aggregation_config to identical consensus

### DIFF
--- a/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus.go
@@ -22,6 +22,7 @@ func (c IdenticalConsensusConfig[T]) New(w *sdk.WorkflowSpecFactory, ref string,
 		Config: map[string]any{
 			"encoder":            c.Encoder,
 			"encoder_config":     c.EncoderConfig,
+			"aggregation_config": make(map[string]interface{}),
 			"aggregation_method": "identical",
 			"report_id":          c.ReportID,
 			"key_id":             c.KeyID,

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus_test.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus_test.go
@@ -70,6 +70,7 @@ func TestIdenticalConsensus(t *testing.T) {
 				Config: map[string]any{
 					"encoder":            "EVM",
 					"encoder_config":     map[string]any{},
+					"aggregation_config": map[string]any{},
 					"aggregation_method": "identical",
 					"report_id":          "0001",
 					"key_id":             "evm",


### PR DESCRIPTION
## Summary

Adds an `aggregation_config` map to the identical-consensus capability's config (defaulting to an empty map) alongside the existing `aggregation_method`.

## Changes

- `pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus.go`: include `"aggregation_config": make(map[string]interface{})` in the config map.
- `identical_consensus_test.go`: mirror the field in the test config.

## Why

The consensus framework expects an `aggregation_config` key; identical consensus was omitting it, which would cause downstream lookups to fail.
