### PR TITLE
fix generate diff check

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -63,10 +63,12 @@ jobs:
       - name: Ensure "make gomodtidy" has been run
         run: |
           make gomodtidy
-          git diff --minimal --exit-code
+          git add --all
+          git diff --minimal --cached --exit-code
       - name: Ensure "make generate" has been run
         run: |
           make rm-mocked
           make rm-builders
           make generate
-          git diff --stat --exit-code
+          git add --all
+          git diff --stat --cached --exit-code


### PR DESCRIPTION
Our `git diff` checks (used to verify tidiness and that generated files are up to date) fail in cases where there are completely new files. This is both due to the files being unstaged as well as the default behavior of `git diff` to be to ignore them. We can call `git add -all` first, and include the `--cached` flag to get the behavior we want.