### PR TITLE
[CAPPL-197/CAPPL-309] Small fixes to compute

### DIFF
--- a/pkg/capabilities/cli/cmd/generator_test.go
+++ b/pkg/capabilities/cli/cmd/generator_test.go
@@ -253,7 +253,7 @@ func TestTypeGeneration(t *testing.T) {
 	})
 
 	t.Run("casing is respected from the json schema", func(t *testing.T) {
-		workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{Owner: "owner", Name: "name"})
+		workflow := sdk.NewWorkflowSpecFactory()
 		ai := basicaction.ActionConfig{CamelCaseInSchemaForTesting: "foo", SnakeCaseInSchemaForTesting: 12}.
 			New(workflow, "ref", basicaction.ActionInput{InputThing: sdk.ConstantDefinition[bool](true)})
 		spec, _ := workflow.Spec()

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus_test.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus_test.go
@@ -40,8 +40,6 @@ func TestIdenticalConsensus(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := sdk.WorkflowSpec{
-		Name:  "Test",
-		Owner: "0x1234",
 		Triggers: []sdk.StepDefinition{
 			{
 				ID:     "basic-test-trigger@1.0.0",

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus_test.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/identical_consensus_test.go
@@ -15,10 +15,7 @@ import (
 
 func TestIdenticalConsensus(t *testing.T) {
 	t.Parallel()
-	workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{
-		Owner: "0x1234",
-		Name:  "Test",
-	})
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	trigger := basictrigger.TriggerConfig{Name: "1234", Number: 1}.New(workflow)
 

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/reduce_consensus_test.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/reduce_consensus_test.go
@@ -70,8 +70,6 @@ func TestReduceConsensus(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := sdk.WorkflowSpec{
-		Name:  "Test",
-		Owner: "0x1234",
 		Triggers: []sdk.StepDefinition{
 			{
 				ID:     "basic-test-trigger@1.0.0",

--- a/pkg/capabilities/consensus/ocr3/ocr3cap/reduce_consensus_test.go
+++ b/pkg/capabilities/consensus/ocr3/ocr3cap/reduce_consensus_test.go
@@ -16,10 +16,7 @@ import (
 
 func TestReduceConsensus(t *testing.T) {
 	t.Parallel()
-	workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{
-		Owner: "0x1234",
-		Name:  "Test",
-	})
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	trigger := basictrigger.TriggerConfig{Name: "1234", Number: 1}.New(workflow)
 

--- a/pkg/workflows/sdk/builder.go
+++ b/pkg/workflows/sdk/builder.go
@@ -125,18 +125,9 @@ func (c *capDefinitionImpl[O]) self() CapDefinition[O] {
 
 func (c *capDefinitionImpl[O]) private() {}
 
-type NewWorkflowParams struct {
-	Owner string
-	Name  string
-}
-
-func NewWorkflowSpecFactory(
-	params NewWorkflowParams,
-) *WorkflowSpecFactory {
+func NewWorkflowSpecFactory() *WorkflowSpecFactory {
 	return &WorkflowSpecFactory{
 		spec: &WorkflowSpec{
-			Owner:     params.Owner,
-			Name:      params.Name,
 			Triggers:  make([]StepDefinition, 0),
 			Actions:   make([]StepDefinition, 0),
 			Consensus: make([]StepDefinition, 0),

--- a/pkg/workflows/sdk/builder_test.go
+++ b/pkg/workflows/sdk/builder_test.go
@@ -211,8 +211,6 @@ func TestBuilder_ValidSpec(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := sdk.WorkflowSpec{
-			Name:  "notccipethsep",
-			Owner: "0x00000000000000000000000000000000000000aa",
 			Triggers: []sdk.StepDefinition{
 				{
 					ID:             "notstreams@1.0.0",
@@ -295,8 +293,6 @@ func TestBuilder_ValidSpec(t *testing.T) {
 		spec, err := workflow.Spec()
 		require.NoError(t, err)
 		testutils.AssertWorkflowSpec(t, sdk.WorkflowSpec{
-			Name:  "name",
-			Owner: "owner",
 			Triggers: []sdk.StepDefinition{
 				{
 					ID:     "basic-test-trigger@1.0.0",
@@ -332,8 +328,6 @@ func TestBuilder_ValidSpec(t *testing.T) {
 		spec, err := workflow.Spec()
 		require.NoError(t, err)
 		testutils.AssertWorkflowSpec(t, sdk.WorkflowSpec{
-			Name:  "name",
-			Owner: "owner",
 			Triggers: []sdk.StepDefinition{
 				{
 					ID:     "basic-test-trigger@1.0.0",
@@ -377,8 +371,6 @@ func TestBuilder_ValidSpec(t *testing.T) {
 		require.NoError(t, err)
 
 		testutils.AssertWorkflowSpec(t, sdk.WorkflowSpec{
-			Name:  "name",
-			Owner: "owner",
 			Triggers: []sdk.StepDefinition{
 				{
 					ID:             "list@1.0.0",
@@ -434,8 +426,6 @@ func TestBuilder_ValidSpec(t *testing.T) {
 		require.NoError(t, err)
 
 		testutils.AssertWorkflowSpec(t, sdk.WorkflowSpec{
-			Name:  "name",
-			Owner: "owner",
 			Triggers: []sdk.StepDefinition{
 				{
 					ID:             "basic-test-trigger@1.0.0",
@@ -491,8 +481,6 @@ func TestBuilder_ValidSpec(t *testing.T) {
 		require.NoError(t, err)
 
 		testutils.AssertWorkflowSpec(t, sdk.WorkflowSpec{
-			Name:  "name",
-			Owner: "owner",
 			Triggers: []sdk.StepDefinition{
 				{
 					ID:             "basic-test-trigger@1.0.0",

--- a/pkg/workflows/sdk/compute_test.go
+++ b/pkg/workflows/sdk/compute_test.go
@@ -179,10 +179,7 @@ type ComputeOutput struct {
 }
 
 func createComputeWithConfigWorkflow(config ComputeConfig, fn func(_ sdk.Runtime, config ComputeConfig, input basictrigger.TriggerOutputs) (ComputeOutput, error)) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{
-		Owner: "owner",
-		Name:  "name",
-	})
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)
@@ -202,10 +199,7 @@ func createComputeWithConfigWorkflow(config ComputeConfig, fn func(_ sdk.Runtime
 }
 
 func createWorkflow(fn func(_ sdk.Runtime, inputFeed notstreams.Feed) ([]streams.Feed, error)) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{
-		Owner: "owner",
-		Name:  "name",
-	})
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	trigger := notstreams.TriggerConfig{MaxFrequencyMs: 5000}.New(workflow)
 	computed := sdk.Compute1(workflow, "Compute", sdk.Compute1Inputs[notstreams.Feed]{Arg0: trigger}, fn)

--- a/pkg/workflows/sdk/compute_test.go
+++ b/pkg/workflows/sdk/compute_test.go
@@ -42,8 +42,6 @@ func TestCompute(t *testing.T) {
 		spec, err2 := workflow.Spec()
 		require.NoError(t, err2)
 		expectedSpec := sdk.WorkflowSpec{
-			Name:  "name",
-			Owner: "owner",
 			Triggers: []sdk.StepDefinition{
 				{
 					ID:             "notstreams@1.0.0",

--- a/pkg/workflows/sdk/testdata/fixtures/workflows/expected_sepolia.yaml
+++ b/pkg/workflows/sdk/testdata/fixtures/workflows/expected_sepolia.yaml
@@ -1,8 +1,6 @@
 # At the time of writing, this was taken form the staging deployment
 # trigger ref was added so it can match the way it's done by the builder.  It's implied as trigger today, and not harmful to add.
 # One of the heartbeat and deviation values were modified so that the defaults example can be shown to work.
-name: "ccipethsep"
-owner: "0x00000000000000000000000000000000000000aa"
 triggers:
   - id: "streams-trigger@1.0.0"
     ref: "trigger"

--- a/pkg/workflows/sdk/testdata/fixtures/workflows/notstreamssepolia.yaml
+++ b/pkg/workflows/sdk/testdata/fixtures/workflows/notstreamssepolia.yaml
@@ -1,6 +1,3 @@
-workflow:
-  name: notccipethsep
-  owner: '0x00000000000000000000000000000000000000aa'
 not_stream:
   maxFrequencyMs: 5000
 ocr:

--- a/pkg/workflows/sdk/testdata/fixtures/workflows/sepolia.yaml
+++ b/pkg/workflows/sdk/testdata/fixtures/workflows/sepolia.yaml
@@ -1,6 +1,3 @@
-workflow:
-  name: ccipethsep
-  owner: '0x00000000000000000000000000000000000000aa'
 streams:
   feedIds:
     - '0x0003fbba4fce42f65d6032b18aee53efdf526cc734ad296cb57565979d883bdd'

--- a/pkg/workflows/sdk/testdata/fixtures/workflows/sepolia_defaults.yaml
+++ b/pkg/workflows/sdk/testdata/fixtures/workflows/sepolia_defaults.yaml
@@ -1,6 +1,3 @@
-workflow:
-  name: ccipethsep
-  owner: '0x00000000000000000000000000000000000000aa'
 maxFrequencyMs: 5000
 default_heartbeat: 3600
 default_deviation: '0.05'

--- a/pkg/workflows/sdk/testutils/runner_test.go
+++ b/pkg/workflows/sdk/testutils/runner_test.go
@@ -64,7 +64,7 @@ func TestRunner(t *testing.T) {
 	})
 
 	t.Run("Run allows hard-coded values", func(t *testing.T) {
-		workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{Name: "tester", Owner: "ryan"})
+		workflow := sdk.NewWorkflowSpecFactory()
 		trigger := basictrigger.TriggerConfig{Name: "trigger", Number: 100}.New(workflow)
 		hardCodedInput := basicaction.NewActionOutputsFromFields(sdk.ConstantDefinition("hard-coded"))
 		tTransform := sdk.Compute2[basictrigger.TriggerOutputs, basicaction.ActionOutputs, bool](
@@ -261,7 +261,7 @@ type ComputeConfig struct {
 
 func TestCompute(t *testing.T) {
 	t.Run("Inputs don't loose integer types when any is deserialized to", func(t *testing.T) {
-		workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{Name: "name", Owner: "owner"})
+		workflow := sdk.NewWorkflowSpecFactory()
 		trigger := basictrigger.TriggerConfig{Name: "foo", Number: 100}.New(workflow)
 		toMap := sdk.Compute1(workflow, "tomap", sdk.Compute1Inputs[string]{Arg0: trigger.CoolOutput()}, func(runtime sdk.Runtime, i0 string) (map[string]any, error) {
 			v, err := strconv.Atoi(i0)
@@ -292,7 +292,7 @@ func TestCompute(t *testing.T) {
 	})
 
 	t.Run("Config interpolates secrets", func(t *testing.T) {
-		workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{Name: "name", Owner: "owner"})
+		workflow := sdk.NewWorkflowSpecFactory()
 		trigger := basictrigger.TriggerConfig{Name: "foo", Number: 100}.New(workflow)
 
 		conf := ComputeConfig{
@@ -321,7 +321,7 @@ func TestCompute(t *testing.T) {
 }
 
 func registrationWorkflow() (*sdk.WorkflowSpecFactory, map[string]any, map[string]any) {
-	workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{Name: "tester", Owner: "ryan"})
+	workflow := sdk.NewWorkflowSpecFactory()
 	testTriggerConfig := map[string]any{"something": "from nothing"}
 	trigger := sdk.Step[int]{
 		Definition: sdk.StepDefinition{
@@ -369,7 +369,7 @@ func setupAllRunnerMocks(t *testing.T, runner *testutils.Runner) (*testutils.Tri
 type actionTransform func(sdk sdk.Runtime, outputs basictrigger.TriggerOutputs) (bool, error)
 
 func createBasicTestWorkflow(actionTransform actionTransform) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(sdk.NewWorkflowParams{Name: "tester", Owner: "ryan"})
+	workflow := sdk.NewWorkflowSpecFactory()
 	trigger := basictrigger.TriggerConfig{Name: "trigger", Number: 100}.New(workflow)
 	tTransform := sdk.Compute1[basictrigger.TriggerOutputs, bool](
 		workflow,

--- a/pkg/workflows/wasm/host/test/builderr/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/builderr/cmd/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
+)
+
+func BuildWorkflow(config []byte) (*sdk.WorkflowSpecFactory, error) {
+	// Do something that errors
+	return nil, errors.New("oops: I couldn't build this workflow")
+}
+
+func main() {
+	runner := wasm.NewRunner()
+	workflow, err := BuildWorkflow(runner.Config())
+	if err != nil {
+		runner.ExitWithError(err)
+	}
+	runner.Run(workflow)
+}

--- a/pkg/workflows/wasm/host/test/computepanic/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/computepanic/cmd/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/cli/cmd/testdata/fixtures/capabilities/basictrigger"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
+)
+
+type foo struct {
+	thing string
+}
+
+func (f *foo) doAThing() {
+	_ = f.thing
+}
+
+func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
+	workflow := sdk.NewWorkflowSpecFactory()
+
+	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
+	trigger := triggerCfg.New(workflow)
+
+	sdk.Compute1[basictrigger.TriggerOutputs, bool](
+		workflow,
+		"transform",
+		sdk.Compute1Inputs[basictrigger.TriggerOutputs]{Arg0: trigger},
+		func(sdk sdk.Runtime, outputs basictrigger.TriggerOutputs) (bool, error) {
+			var f *foo
+			f.doAThing()
+			return false, nil
+		})
+
+	return workflow
+}
+
+func main() {
+	runner := wasm.NewRunner()
+	workflow := BuildWorkflow(runner.Config())
+	runner.Run(workflow)
+}

--- a/pkg/workflows/wasm/host/test/dirs/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/dirs/cmd/main.go
@@ -12,12 +12,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "ryan",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/emit/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/emit/cmd/main.go
@@ -10,9 +10,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/env/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/env/cmd/main.go
@@ -13,12 +13,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "ryan",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/fetch/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/fetch/cmd/main.go
@@ -12,12 +12,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "ryan",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/fetchlimit/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/fetchlimit/cmd/main.go
@@ -12,12 +12,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "ryan",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/files/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/files/cmd/main.go
@@ -12,12 +12,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "ryan",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/http/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/http/cmd/main.go
@@ -12,12 +12,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "ryan",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/log/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/log/cmd/main.go
@@ -10,12 +10,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "ryan",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/rand/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/rand/cmd/main.go
@@ -13,9 +13,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	trigger := triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/runnerapi/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/runnerapi/cmd/main.go
@@ -8,12 +8,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "ryan",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	_ = triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/test/success/cmd/main.go
+++ b/pkg/workflows/wasm/host/test/success/cmd/main.go
@@ -10,12 +10,7 @@ import (
 )
 
 func BuildWorkflow(config []byte) *sdk.WorkflowSpecFactory {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "ryan",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	triggerCfg := basictrigger.TriggerConfig{Name: "trigger", Number: 100}
 	_ = triggerCfg.New(workflow)

--- a/pkg/workflows/wasm/host/wasm_test.go
+++ b/pkg/workflows/wasm/host/wasm_test.go
@@ -29,32 +29,36 @@ import (
 )
 
 const (
-	successBinaryLocation    = "test/success/cmd/testmodule.wasm"
-	successBinaryCmd         = "test/success/cmd"
-	failureBinaryLocation    = "test/fail/cmd/testmodule.wasm"
-	failureBinaryCmd         = "test/fail/cmd"
-	oomBinaryLocation        = "test/oom/cmd/testmodule.wasm"
-	oomBinaryCmd             = "test/oom/cmd"
-	sleepBinaryLocation      = "test/sleep/cmd/testmodule.wasm"
-	sleepBinaryCmd           = "test/sleep/cmd"
-	filesBinaryLocation      = "test/files/cmd/testmodule.wasm"
-	filesBinaryCmd           = "test/files/cmd"
-	dirsBinaryLocation       = "test/dirs/cmd/testmodule.wasm"
-	dirsBinaryCmd            = "test/dirs/cmd"
-	httpBinaryLocation       = "test/http/cmd/testmodule.wasm"
-	httpBinaryCmd            = "test/http/cmd"
-	envBinaryLocation        = "test/env/cmd/testmodule.wasm"
-	envBinaryCmd             = "test/env/cmd"
-	logBinaryLocation        = "test/log/cmd/testmodule.wasm"
-	logBinaryCmd             = "test/log/cmd"
-	fetchBinaryLocation      = "test/fetch/cmd/testmodule.wasm"
-	fetchBinaryCmd           = "test/fetch/cmd"
-	fetchlimitBinaryLocation = "test/fetchlimit/cmd/testmodule.wasm"
-	fetchlimitBinaryCmd      = "test/fetchlimit/cmd"
-	randBinaryLocation       = "test/rand/cmd/testmodule.wasm"
-	randBinaryCmd            = "test/rand/cmd"
-	emitBinaryLocation       = "test/emit/cmd/testmodule.wasm"
-	emitBinaryCmd            = "test/emit/cmd"
+	successBinaryLocation      = "test/success/cmd/testmodule.wasm"
+	successBinaryCmd           = "test/success/cmd"
+	failureBinaryLocation      = "test/fail/cmd/testmodule.wasm"
+	failureBinaryCmd           = "test/fail/cmd"
+	oomBinaryLocation          = "test/oom/cmd/testmodule.wasm"
+	oomBinaryCmd               = "test/oom/cmd"
+	sleepBinaryLocation        = "test/sleep/cmd/testmodule.wasm"
+	sleepBinaryCmd             = "test/sleep/cmd"
+	filesBinaryLocation        = "test/files/cmd/testmodule.wasm"
+	filesBinaryCmd             = "test/files/cmd"
+	dirsBinaryLocation         = "test/dirs/cmd/testmodule.wasm"
+	dirsBinaryCmd              = "test/dirs/cmd"
+	httpBinaryLocation         = "test/http/cmd/testmodule.wasm"
+	httpBinaryCmd              = "test/http/cmd"
+	envBinaryLocation          = "test/env/cmd/testmodule.wasm"
+	envBinaryCmd               = "test/env/cmd"
+	logBinaryLocation          = "test/log/cmd/testmodule.wasm"
+	logBinaryCmd               = "test/log/cmd"
+	fetchBinaryLocation        = "test/fetch/cmd/testmodule.wasm"
+	fetchBinaryCmd             = "test/fetch/cmd"
+	fetchlimitBinaryLocation   = "test/fetchlimit/cmd/testmodule.wasm"
+	fetchlimitBinaryCmd        = "test/fetchlimit/cmd"
+	randBinaryLocation         = "test/rand/cmd/testmodule.wasm"
+	randBinaryCmd              = "test/rand/cmd"
+	emitBinaryLocation         = "test/emit/cmd/testmodule.wasm"
+	emitBinaryCmd              = "test/emit/cmd"
+	computePanicBinaryLocation = "test/computepanic/cmd/testmodule.wasm"
+	computePanicBinaryCmd      = "test/computepanic/cmd"
+	buildErrorBinaryLocation   = "test/builderr/cmd/testmodule.wasm"
+	buildErrorBinaryCmd        = "test/builderr/cmd"
 )
 
 func createTestBinary(outputPath, path string, uncompressed bool, t *testing.T) []byte {
@@ -157,6 +161,23 @@ func Test_GetWorkflowSpec_Timeout(t *testing.T) {
 	)
 	// panic
 	assert.ErrorContains(t, err, "wasm trap: interrupt")
+}
+
+func Test_GetWorkflowSpec_BuildError(t *testing.T) {
+	t.Parallel()
+	ctx := tests.Context(t)
+	binary := createTestBinary(buildErrorBinaryCmd, buildErrorBinaryLocation, true, t)
+
+	_, err := GetWorkflowSpec(
+		ctx,
+		&ModuleConfig{
+			Logger:         logger.Test(t),
+			IsUncompressed: true,
+		},
+		binary,
+		[]byte(""),
+	)
+	assert.ErrorContains(t, err, "oops")
 }
 
 func Test_Compute_Logs(t *testing.T) {
@@ -348,6 +369,37 @@ func Test_Compute_Emit(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "failed to create emission")
 	})
+}
+
+func Test_Compute_PanicIsRecovered(t *testing.T) {
+	t.Parallel()
+	binary := createTestBinary(computePanicBinaryCmd, computePanicBinaryLocation, true, t)
+
+	ctx := tests.Context(t)
+	m, err := NewModule(&ModuleConfig{
+		Logger:         logger.Test(t),
+		IsUncompressed: true,
+	}, binary)
+	require.NoError(t, err)
+
+	m.Start()
+
+	req := &wasmpb.Request{
+		Id: uuid.New().String(),
+		Message: &wasmpb.Request_ComputeRequest{
+			ComputeRequest: &wasmpb.ComputeRequest{
+				Request: &capabilitiespb.CapabilityRequest{
+					Inputs: &valuespb.Map{},
+					Config: &valuespb.Map{},
+					Metadata: &capabilitiespb.RequestMetadata{
+						ReferenceId: "transform",
+					},
+				},
+			},
+		},
+	}
+	_, err = m.Run(ctx, req)
+	assert.ErrorContains(t, err, "invalid memory address or nil pointer dereference")
 }
 
 func Test_Compute_Fetch(t *testing.T) {

--- a/pkg/workflows/wasm/host/wasm_test.go
+++ b/pkg/workflows/wasm/host/wasm_test.go
@@ -91,7 +91,7 @@ func Test_GetWorkflowSpec(t *testing.T) {
 	ctx := tests.Context(t)
 	binary := createTestBinary(successBinaryCmd, successBinaryLocation, true, t)
 
-	spec, err := GetWorkflowSpec(
+	_, err := GetWorkflowSpec(
 		ctx,
 		&ModuleConfig{
 			Logger:         logger.Test(t),
@@ -101,9 +101,6 @@ func Test_GetWorkflowSpec(t *testing.T) {
 		[]byte(""),
 	)
 	require.NoError(t, err)
-
-	assert.Equal(t, spec.Name, "tester")
-	assert.Equal(t, spec.Owner, "ryan")
 }
 
 func Test_GetWorkflowSpec_UncompressedBinary(t *testing.T) {
@@ -111,7 +108,7 @@ func Test_GetWorkflowSpec_UncompressedBinary(t *testing.T) {
 	ctx := tests.Context(t)
 	binary := createTestBinary(successBinaryCmd, successBinaryLocation, false, t)
 
-	spec, err := GetWorkflowSpec(
+	_, err := GetWorkflowSpec(
 		ctx,
 		&ModuleConfig{
 			Logger:         logger.Test(t),
@@ -121,9 +118,6 @@ func Test_GetWorkflowSpec_UncompressedBinary(t *testing.T) {
 		[]byte(""),
 	)
 	require.NoError(t, err)
-
-	assert.Equal(t, spec.Name, "tester")
-	assert.Equal(t, spec.Owner, "ryan")
 }
 
 func Test_GetWorkflowSpec_BinaryErrors(t *testing.T) {

--- a/pkg/workflows/wasm/runner_test.go
+++ b/pkg/workflows/wasm/runner_test.go
@@ -87,12 +87,7 @@ func Test_Runner_Config(t *testing.T) {
 }
 
 func TestRunner_Run_ExecuteCompute(t *testing.T) {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "cedric",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	trigger := basictrigger.TriggerConfig{Name: "trigger", Number: 100}.New(workflow)
 	computeFn := func(sdk sdk.Runtime, outputs basictrigger.TriggerOutputs) (bool, error) {
@@ -157,12 +152,7 @@ func TestRunner_Run_ExecuteCompute(t *testing.T) {
 }
 
 func TestRunner_Run_GetWorkflowSpec(t *testing.T) {
-	workflow := sdk.NewWorkflowSpecFactory(
-		sdk.NewWorkflowParams{
-			Name:  "tester",
-			Owner: "cedric",
-		},
-	)
+	workflow := sdk.NewWorkflowSpecFactory()
 
 	trigger := basictrigger.TriggerConfig{Name: "trigger", Number: 100}.New(workflow)
 	// Define and add a target to the workflow


### PR DESCRIPTION
- Add a recovery handler to the runner's Run method. This means we preserve stack traces and will help debugging.
- Allow users to explicitly error with an error via ExitWithError.
- Remove owner and name from the factory constructor.