### PR TITLE
pkg/types/interfacetests: simplify test names

### DIFF
--- a/pkg/types/interfacetests/chain_components_interface_tests.go
+++ b/pkg/types/interfacetests/chain_components_interface_tests.go
@@ -100,9 +100,11 @@ var AnySliceToReadWithoutAnArgument = []uint64{3, 4}
 const AnyExtraValue = 3
 
 func RunContractReaderInterfaceTests[T TestingT[T]](t T, tester ChainComponentsInterfaceTester[T], mockRun bool) {
-	t.Run("GetLatestValue for "+tester.Name(), func(t T) { runContractReaderGetLatestValueInterfaceTests(t, tester, mockRun) })
-	t.Run("BatchGetLatestValues for "+tester.Name(), func(t T) { runContractReaderBatchGetLatestValuesInterfaceTests(t, tester, mockRun) })
-	t.Run("QueryKey for "+tester.Name(), func(t T) { runQueryKeyInterfaceTests(t, tester) })
+	t.Run(tester.Name(), func(t T) {
+		t.Run("GetLatestValue", func(t T) { runContractReaderGetLatestValueInterfaceTests(t, tester, mockRun) })
+		t.Run("BatchGetLatestValues", func(t T) { runContractReaderBatchGetLatestValuesInterfaceTests(t, tester, mockRun) })
+		t.Run("QueryKey", func(t T) { runQueryKeyInterfaceTests(t, tester) })
+	})
 }
 
 func runContractReaderGetLatestValueInterfaceTests[T TestingT[T]](t T, tester ChainComponentsInterfaceTester[T], mockRun bool) {

--- a/pkg/types/interfacetests/utils.go
+++ b/pkg/types/interfacetests/utils.go
@@ -56,14 +56,16 @@ type TestingT[T any] interface {
 // Tests execution utility function that will consider enabled / disabled test cases according to
 // Basic Tester configuration.
 func RunTests[T TestingT[T]](t T, tester BasicTester[T], tests []Testcase[T]) {
-	for _, test := range tests {
-		if !tester.IsDisabled(test.Name) {
-			t.Run(test.Name+" for "+tester.Name(), func(t T) {
-				tester.Setup(t)
-				test.Test(t)
-			})
+	t.Run(tester.Name(), func(t T) {
+		for _, test := range tests {
+			if !tester.IsDisabled(test.Name) {
+				t.Run(test.Name, func(t T) {
+					tester.Setup(t)
+					test.Test(t)
+				})
+			}
 		}
-	}
+	})
 }
 
 // Batch contract write takes a batch call entry and writes it to the chain using the ContractWriter.


### PR DESCRIPTION
Change sub-test names from `Y for X` to `X/Y`