### PR TITLE
pkg/loop/internal/net: treat Close specially from clientConn

### DIFF
--- a/pkg/services/servicetest/run.go
+++ b/pkg/services/servicetest/run.go
@@ -28,7 +28,10 @@ type TestingT interface {
 func Run[R Runnable](tb TestingT, r R) R {
 	tb.Helper()
 	require.NoError(tb, r.Start(tests.Context(tb)), "service failed to start")
-	tb.Cleanup(func() { assert.NoError(tb, r.Close(), "error closing service") })
+	tb.Cleanup(func() {
+		tb.Helper()
+		assert.NoError(tb, r.Close(), "error closing service")
+	})
 	return r
 }
 


### PR DESCRIPTION
`clientConn` handles silently refreshing connections for unavailable plugins, but the code was inadvertently being activated on `Close` calls, when we don't actually want to refresh the connection. This PR updates the `clientConn.Invoke` method to recognize `Close` calls and treat them differently.
```
==================
WARNING: DATA RACE
Read at 0x00c000200523 by goroutine 943:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:101[8](https://github.com/smartcontractkit/chainlink-common/actions/runs/12148628118/job/33877483917?pr=959#step:6:9) +0xcd
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1011 +0xa4
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1062 +0x6a
  testing.(*T).Logf()
      <autogenerated>:1 +0x6[9](https://github.com/smartcontractkit/chainlink-common/actions/runs/12148628118/job/33877483917?pr=959#step:6:10)
  go.uber.org/zap/zaptest.TestingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zaptest/logger.go:146 +0x11d
  go.uber.org/zap/zaptest.(*TestingWriter).Write()
      <autogenerated>:1 +0x74
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/core.go:99 +0x192
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:253 +0x1ef
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:355 +0x12f
  go.uber.org/zap.(*SugaredLogger).Errorw()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:269 +0xa4
  github.com/smartcontractkit/chainlink-common/pkg/logger.(*logger).Errorw()
      <autogenerated>:1 +0x1f
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net.(*BrokerExt).Serve.func1()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/net/broker.go:120 +0x3fc

Previous write at 0x00c000200523 by goroutine 30:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1677 +0x8fa
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.23.3/x64/src/runtime/panic.go:605 +0x5d
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44

Goroutine 943 (running) created at:
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net.(*BrokerExt).Serve()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/net/broker.go:116 +0x484
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net.(*BrokerExt).ServeNew()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/net/broker.go:[10](https://github.com/smartcontractkit/chainlink-common/actions/runs/12148628118/job/33877483917?pr=959#step:6:11)2 +0x18a
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/reportingplugin/ocr3.(*ReportingPluginServiceClient).NewReportingPluginFactory.func1()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/core/services/reportingplugin/ocr3/reporting_plugin_service.go:74 +0x9a4
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net.(*clientConn).refresh.func1()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/net/client.go:107 +0x136
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net.(*clientConn).refresh()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/net/client.go:133 +0x536
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net.(*clientConn).Invoke()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/net/client.go:62 +0x204
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/pb.(*serviceClient).Close()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/pb/relayer_grpc.pb.go:1080 +0x13b
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin.(*ServiceClient).Close()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/goplugin/service.go:43 +0x1e1
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/core/services/reportingplugin/ocr3.(*reportingPluginFactoryClient).Close()
      <autogenerated>:1 +0x46
  github.com/smartcontractkit/chainlink-common/pkg/types/core.OCR3ReportingPluginFactory.Close()
      <autogenerated>:1 +0x3a
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin.(*PluginService[go.shape.*uint8,go.shape.interface { Close() error; HealthReport() map[string]error; Name() string; NewReportingPlugin(context.Context, github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types.ReportingPluginConfig) (github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types.ReportingPlugin[[]uint8], github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types.ReportingPluginInfo, error); Ready() error; Start(context.Context) error }]).Close.func1()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/goplugin/plugin_service.go:192 +0x126
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StopOnce()
      /home/runner/work/chainlink-common/chainlink-common/pkg/services/state.go:132 +0x159
  github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin.(*PluginService[go.shape.*uint8,go.shape.interface { Close() error; HealthReport() map[string]error; Name() string; NewReportingPlugin(context.Context, github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types.ReportingPluginConfig) (github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types.ReportingPlugin[[]uint8], github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types.ReportingPluginInfo, error); Ready() error; Start(context.Context) error }]).Close()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/internal/goplugin/plugin_service.go:186 +0xe4
  github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins/ocr3.(*LOOPPService).Close()
      <autogenerated>:1 +0x38
  github.com/smartcontractkit/chainlink-common/pkg/services/servicetest.Run[go.shape.*uint8].func1()
      /home/runner/work/chainlink-common/chainlink-common/pkg/services/servicetest/run.go:31 +0x72
  testing.(*common).Cleanup.func1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:[11](https://github.com/smartcontractkit/chainlink-common/actions/runs/12148628118/job/33877483917?pr=959#step:6:12)76 +0x179
  testing.(*common).runCleanup()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:[13](https://github.com/smartcontractkit/chainlink-common/actions/runs/12148628118/job/33877483917?pr=959#step:6:14)54 +0x261
  testing.tRunner.func2()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1684 +0x50
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.23.3/x64/src/runtime/panic.go:605 +0x5d
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44

Goroutine 30 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x825
  github.com/smartcontractkit/chainlink-common/pkg/loop/reportingplugins/ocr3.TestLOOPPService()
      /home/runner/work/chainlink-common/chainlink-common/pkg/loop/reportingplugins/ocr3/loopp_service_test.go:57 +0xed
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:[16](https://github.com/smartcontractkit/chainlink-common/actions/runs/12148628118/job/33877483917?pr=959#step:6:17)90 +0x226
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:[17](https://github.com/smartcontractkit/chainlink-common/actions/runs/12148628118/job/33877483917?pr=959#step:6:18)43 +0x44
==================
```