### PR TITLE
[INFOPLAT-1592] Address high CPU utilization when telemetry is enabled

### DIFF
--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -14,7 +14,6 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
-	"go.opentelemetry.io/otel/sdk/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/credentials"
@@ -112,9 +111,13 @@ func newGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (*Client, erro
 	// Logger
 	var loggerProcessor sdklog.Processor
 	if cfg.LogBatchProcessor {
+		batchProcessorOpts := []sdklog.BatchProcessorOption{}
+		if cfg.LogExportTimeout > 0 {
+			batchProcessorOpts = append(batchProcessorOpts, sdklog.WithExportTimeout(cfg.LogExportTimeout)) // Default is 30s
+		}
 		loggerProcessor = sdklog.NewBatchProcessor(
 			sharedLogExporter,
-			sdklog.WithExportTimeout(cfg.LogExportTimeout), // Default is 30s
+			batchProcessorOpts...,
 		)
 	} else {
 		loggerProcessor = sdklog.NewSimpleProcessor(sharedLogExporter)
@@ -152,9 +155,13 @@ func newGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (*Client, erro
 	// Message Emitter
 	var messageLogProcessor sdklog.Processor
 	if cfg.EmitterBatchProcessor {
+		batchProcessorOpts := []sdklog.BatchProcessorOption{}
+		if cfg.EmitterExportTimeout > 0 {
+			batchProcessorOpts = append(batchProcessorOpts, sdklog.WithExportTimeout(cfg.EmitterExportTimeout)) // Default is 30s
+		}
 		messageLogProcessor = sdklog.NewBatchProcessor(
 			sharedLogExporter,
-			sdklog.WithExportTimeout(cfg.EmitterExportTimeout), // Default is 30s
+			batchProcessorOpts...,
 		)
 	} else {
 		messageLogProcessor = sdklog.NewSimpleProcessor(sharedLogExporter)
@@ -314,9 +321,12 @@ func newTracerProvider(config Config, resource *sdkresource.Resource, creds cred
 	if err != nil {
 		return nil, err
 	}
-
+	batcherOpts := []sdktrace.BatchSpanProcessorOption{}
+	if config.TraceBatchTimeout > 0 {
+		batcherOpts = append(batcherOpts, sdktrace.WithBatchTimeout(config.TraceBatchTimeout)) // Default is 5s
+	}
 	opts := []sdktrace.TracerProviderOption{
-		sdktrace.WithBatcher(exporter, trace.WithBatchTimeout(config.TraceBatchTimeout)), // Default is 5s
+		sdktrace.WithBatcher(exporter, batcherOpts...),
 		sdktrace.WithResource(resource),
 		sdktrace.WithSampler(
 			sdktrace.ParentBased(

--- a/pkg/loop/config.go
+++ b/pkg/loop/config.go
@@ -142,6 +142,14 @@ func (e *EnvConfig) parse() error {
 		e.TelemetryTraceSampleRatio = getFloat64OrZero(envTelemetryTraceSampleRatio)
 		e.TelemetryAuthHeaders = getMap(envTelemetryAuthHeader)
 		e.TelemetryAuthPubKeyHex = os.Getenv(envTelemetryAuthPubKeyHex)
+		e.TelemetryEmitterBatchProcessor, err = getBool(envTelemetryEmitterBatchProcessor)
+		if err != nil {
+			return fmt.Errorf("failed to parse %s: %w", envTelemetryEmitterBatchProcessor, err)
+		}
+		e.TelemetryEmitterExportTimeout, err = time.ParseDuration(os.Getenv(envTelemetryEmitterExportTimeout))
+		if err != nil {
+			return fmt.Errorf("failed to parse %s: %w", envTelemetryEmitterExportTimeout, err)
+		}
 	}
 	return nil
 }

--- a/pkg/loop/config_test.go
+++ b/pkg/loop/config_test.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"maps"
 	"net/url"
 	"os"
 	"strconv"
@@ -149,13 +150,13 @@ func TestEnvConfig_parse(t *testing.T) {
 					if config.TelemetryCACertFile != tc.expectedTelemetryCACertFile {
 						t.Errorf("Expected telemetryCACertFile %s, got %s", tc.expectedTelemetryCACertFile, config.TelemetryCACertFile)
 					}
-					if !equalOtelAttributes(config.TelemetryAttributes, tc.expectedTelemetryAttributes) {
+					if !maps.Equal(config.TelemetryAttributes, tc.expectedTelemetryAttributes) {
 						t.Errorf("Expected telemetryAttributes %v, got %v", tc.expectedTelemetryAttributes, config.TelemetryAttributes)
 					}
 					if config.TelemetryTraceSampleRatio != tc.expectedTelemetryTraceSampleRatio {
 						t.Errorf("Expected telemetryTraceSampleRatio %f, got %f", tc.expectedTelemetryTraceSampleRatio, config.TelemetryTraceSampleRatio)
 					}
-					if !equalStringMaps(config.TelemetryAuthHeaders, tc.expectedTelemetryAuthHeaders) {
+					if !maps.Equal(config.TelemetryAuthHeaders, tc.expectedTelemetryAuthHeaders) {
 						t.Errorf("Expected telemetryAuthHeaders %v, got %v", tc.expectedTelemetryAuthHeaders, config.TelemetryAuthHeaders)
 					}
 					if config.TelemetryAuthPubKeyHex != tc.expectedTelemetryAuthPubKeyHex {
@@ -171,30 +172,6 @@ func TestEnvConfig_parse(t *testing.T) {
 			}
 		})
 	}
-}
-
-func equalOtelAttributes(a, b OtelAttributes) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k, v := range a {
-		if b[k] != v {
-			return false
-		}
-	}
-	return true
-}
-
-func equalStringMaps(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k, v := range a {
-		if b[k] != v {
-			return false
-		}
-	}
-	return true
 }
 
 func TestEnvConfig_AsCmdEnv(t *testing.T) {

--- a/pkg/loop/config_test.go
+++ b/pkg/loop/config_test.go
@@ -18,34 +18,65 @@ import (
 
 func TestEnvConfig_parse(t *testing.T) {
 	cases := []struct {
-		name                           string
-		envVars                        map[string]string
-		expectError                    bool
-		expectedDatabaseURL            string
-		expectedPrometheusPort         int
-		expectedTracingEnabled         bool
-		expectedTracingCollectorTarget string
-		expectedTracingSamplingRatio   float64
-		expectedTracingTLSCertPath     string
+		name                                   string
+		envVars                                map[string]string
+		expectError                            bool
+		expectedDatabaseURL                    string
+		expectedPrometheusPort                 int
+		expectedTracingEnabled                 bool
+		expectedTracingCollectorTarget         string
+		expectedTracingSamplingRatio           float64
+		expectedTracingTLSCertPath             string
+		expectedTelemetryEnabled               bool
+		expectedTelemetryEndpoint              string
+		expectedTelemetryInsecureConn          bool
+		expectedTelemetryCACertFile            string
+		expectedTelemetryAttributes            OtelAttributes
+		expectedTelemetryTraceSampleRatio      float64
+		expectedTelemetryAuthHeaders           map[string]string
+		expectedTelemetryAuthPubKeyHex         string
+		expectedTelemetryEmitterBatchProcessor bool
+		expectedTelemetryEmitterExportTimeout  time.Duration
 	}{
 		{
 			name: "All variables set correctly",
 			envVars: map[string]string{
-				envDatabaseURL:              "postgres://user:password@localhost:5432/db",
-				envPromPort:                 "8080",
-				envTracingEnabled:           "true",
-				envTracingCollectorTarget:   "some:target",
-				envTracingSamplingRatio:     "1.0",
-				envTracingTLSCertPath:       "internal/test/fixtures/client.pem",
-				envTracingAttribute + "XYZ": "value",
+				envDatabaseURL:                        "postgres://user:password@localhost:5432/db",
+				envPromPort:                           "8080",
+				envTracingEnabled:                     "true",
+				envTracingCollectorTarget:             "some:target",
+				envTracingSamplingRatio:               "1.0",
+				envTracingTLSCertPath:                 "internal/test/fixtures/client.pem",
+				envTracingAttribute + "XYZ":           "value",
+				envTelemetryEnabled:                   "true",
+				envTelemetryEndpoint:                  "example.com/beholder",
+				envTelemetryInsecureConn:              "true",
+				envTelemetryCACertFile:                "foo/bar",
+				envTelemetryAttribute + "foo":         "bar",
+				envTelemetryAttribute + "baz":         "42",
+				envTelemetryTraceSampleRatio:          "0.42",
+				envTelemetryAuthHeader + "header-key": "header-value",
+				envTelemetryAuthPubKeyHex:             "pub-key-hex",
+				envTelemetryEmitterBatchProcessor:     "true",
+				envTelemetryEmitterExportTimeout:      "1s",
 			},
-			expectError:                    false,
-			expectedDatabaseURL:            "postgres://user:password@localhost:5432/db",
-			expectedPrometheusPort:         8080,
-			expectedTracingEnabled:         true,
-			expectedTracingCollectorTarget: "some:target",
-			expectedTracingSamplingRatio:   1.0,
-			expectedTracingTLSCertPath:     "internal/test/fixtures/client.pem",
+			expectError:                            false,
+			expectedDatabaseURL:                    "postgres://user:password@localhost:5432/db",
+			expectedPrometheusPort:                 8080,
+			expectedTracingEnabled:                 true,
+			expectedTracingCollectorTarget:         "some:target",
+			expectedTracingSamplingRatio:           1.0,
+			expectedTracingTLSCertPath:             "internal/test/fixtures/client.pem",
+			expectedTelemetryEnabled:               true,
+			expectedTelemetryEndpoint:              "example.com/beholder",
+			expectedTelemetryInsecureConn:          true,
+			expectedTelemetryCACertFile:            "foo/bar",
+			expectedTelemetryAttributes:            OtelAttributes{"foo": "bar", "baz": "42"},
+			expectedTelemetryTraceSampleRatio:      0.42,
+			expectedTelemetryAuthHeaders:           map[string]string{"header-key": "header-value"},
+			expectedTelemetryAuthPubKeyHex:         "pub-key-hex",
+			expectedTelemetryEmitterBatchProcessor: true,
+			expectedTelemetryEmitterExportTimeout:  1 * time.Second,
 		},
 		{
 			name: "CL_DATABASE_URL parse error",
@@ -106,10 +137,64 @@ func TestEnvConfig_parse(t *testing.T) {
 					if config.TracingTLSCertPath != tc.expectedTracingTLSCertPath {
 						t.Errorf("Expected tracingTLSCertPath %s, got %s", tc.expectedTracingTLSCertPath, config.TracingTLSCertPath)
 					}
+					if config.TelemetryEnabled != tc.expectedTelemetryEnabled {
+						t.Errorf("Expected telemetryEnabled %v, got %v", tc.expectedTelemetryEnabled, config.TelemetryEnabled)
+					}
+					if config.TelemetryEndpoint != tc.expectedTelemetryEndpoint {
+						t.Errorf("Expected telemetryEndpoint %s, got %s", tc.expectedTelemetryEndpoint, config.TelemetryEndpoint)
+					}
+					if config.TelemetryInsecureConnection != tc.expectedTelemetryInsecureConn {
+						t.Errorf("Expected telemetryInsecureConn %v, got %v", tc.expectedTelemetryInsecureConn, config.TelemetryInsecureConnection)
+					}
+					if config.TelemetryCACertFile != tc.expectedTelemetryCACertFile {
+						t.Errorf("Expected telemetryCACertFile %s, got %s", tc.expectedTelemetryCACertFile, config.TelemetryCACertFile)
+					}
+					if !equalOtelAttributes(config.TelemetryAttributes, tc.expectedTelemetryAttributes) {
+						t.Errorf("Expected telemetryAttributes %v, got %v", tc.expectedTelemetryAttributes, config.TelemetryAttributes)
+					}
+					if config.TelemetryTraceSampleRatio != tc.expectedTelemetryTraceSampleRatio {
+						t.Errorf("Expected telemetryTraceSampleRatio %f, got %f", tc.expectedTelemetryTraceSampleRatio, config.TelemetryTraceSampleRatio)
+					}
+					if !equalStringMaps(config.TelemetryAuthHeaders, tc.expectedTelemetryAuthHeaders) {
+						t.Errorf("Expected telemetryAuthHeaders %v, got %v", tc.expectedTelemetryAuthHeaders, config.TelemetryAuthHeaders)
+					}
+					if config.TelemetryAuthPubKeyHex != tc.expectedTelemetryAuthPubKeyHex {
+						t.Errorf("Expected telemetryAuthPubKeyHex %s, got %s", tc.expectedTelemetryAuthPubKeyHex, config.TelemetryAuthPubKeyHex)
+					}
+					if config.TelemetryEmitterBatchProcessor != tc.expectedTelemetryEmitterBatchProcessor {
+						t.Errorf("Expected telemetryEmitterBatchProcessor %v, got %v", tc.expectedTelemetryEmitterBatchProcessor, config.TelemetryEmitterBatchProcessor)
+					}
+					if config.TelemetryEmitterExportTimeout != tc.expectedTelemetryEmitterExportTimeout {
+						t.Errorf("Expected telemetryEmitterExportTimeout %v, got %v", tc.expectedTelemetryEmitterExportTimeout, config.TelemetryEmitterExportTimeout)
+					}
 				}
 			}
 		})
 	}
+}
+
+func equalOtelAttributes(a, b OtelAttributes) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStringMaps(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func TestEnvConfig_AsCmdEnv(t *testing.T) {


### PR DESCRIPTION

**Context** 
 
High CPU usage for Telemetry reported by NOPs running Asset DON node.

Profiles examples taken from DON nodes:

![image](https://github.com/user-attachments/assets/b208e877-896c-4502-881f-a5268591d034)
![image](https://github.com/user-attachments/assets/dbe2b353-fa3b-4d1f-ab2e-65f96188bcd0)

It seems that NewBatchSpanProcessor is the offender

**Description**

- [loop/EnvConfig] parse sets TelemetryEmitterBatchProcessor, TelemetryEmitterExportTimeout
- [beholder/client] BatchProcessor ExportTimeout option is non-zero value

