### PR TITLE
testutils: Pass a runtime to the test runner

### DIFF
--- a/pkg/capabilities/cli/cmd/generator_test.go
+++ b/pkg/capabilities/cli/cmd/generator_test.go
@@ -268,7 +268,7 @@ func TestTypeGeneration(t *testing.T) {
 
 func TestMockGeneration(t *testing.T) {
 	t.Run("Basic trigger", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		capMock := basictriggertest.Trigger(runner, func() (basictrigger.TriggerOutputs, error) {
 			return basictrigger.TriggerOutputs{}, nil
 		})
@@ -280,7 +280,7 @@ func TestMockGeneration(t *testing.T) {
 	})
 
 	t.Run("Basic action", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 
 		// nolint value is never used but it's assigned to mock to verify the type
 		capMock := basicactiontest.Action(runner, func(_ basicaction.ActionInputs) (basicaction.ActionOutputs, error) {
@@ -300,7 +300,7 @@ func TestMockGeneration(t *testing.T) {
 	})
 
 	t.Run("Basic target", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		capMock := basictargettest.Target(runner, func(_ basictarget.TargetInputs) error {
 			return nil
 		})
@@ -312,7 +312,7 @@ func TestMockGeneration(t *testing.T) {
 	})
 
 	t.Run("References", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 
 		// nolint value is never used but it's assigned to mock to verify the type
 		capMock := referenceactiontest.Action(runner, func(_ referenceaction.SomeInputs) (referenceaction.SomeOutputs, error) {
@@ -332,7 +332,7 @@ func TestMockGeneration(t *testing.T) {
 	})
 
 	t.Run("External references", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 
 		// nolint value is never used but it's assigned to mock to verify the type
 		capMock := externalreferenceactiontest.Action(runner, func(_ referenceaction.SomeInputs) (referenceaction.SomeOutputs, error) {
@@ -355,7 +355,7 @@ func TestMockGeneration(t *testing.T) {
 	// no need to test nesting, we don't generate anything different for the mock's
 
 	t.Run("Array action", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		// nolint value is never used but it's assigned to mock to verify the type
 		capMock := arrayactiontest.Action(runner, func(_ arrayaction.ActionInputs) ([]arrayaction.ActionOutputsElem, error) {
 			return []arrayaction.ActionOutputsElem{}, nil

--- a/pkg/workflows/sdk/testutils/runner.go
+++ b/pkg/workflows/sdk/testutils/runner.go
@@ -14,14 +14,18 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
 )
 
-func NewRunner(ctx context.Context) *Runner {
+func NewRunner(ctx context.Context, runtime sdk.Runtime) *Runner {
+	if runtime == nil {
+		runtime = &NoopRuntime{}
+	}
+
 	return &Runner{
 		ctx:          ctx,
 		registry:     map[string]capabilities.ExecutableCapability{},
 		results:      runnerResults{},
 		idToStep:     map[string]sdk.StepDefinition{},
 		dependencies: map[string][]string{},
-		runtime:      &NoopRuntime{},
+		runtime:      runtime,
 	}
 }
 

--- a/pkg/workflows/sdk/testutils/runner_test.go
+++ b/pkg/workflows/sdk/testutils/runner_test.go
@@ -34,7 +34,7 @@ func TestRunner(t *testing.T) {
 		helper := &testHelper{t: t}
 		workflow := createBasicTestWorkflow(helper.transformTrigger)
 
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 
 		triggerMock, actionMock, consensusMock, targetMock := setupAllRunnerMocks(t, runner)
 
@@ -92,7 +92,7 @@ func TestRunner(t *testing.T) {
 			Schedule:   "oneAtATime",
 		}.New(workflow, "chainwriter@1.0.0", chainwriter.TargetInput{SignedReport: consensus})
 
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		_, _, _, targetMock := setupAllRunnerMocks(t, runner)
 
 		runner.Run(workflow)
@@ -104,7 +104,7 @@ func TestRunner(t *testing.T) {
 	t.Run("Run returns errors if capabilities were registered multiple times", func(t *testing.T) {
 		helper := &testHelper{t: t}
 		workflow := createBasicTestWorkflow(helper.transformTrigger)
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		setupAllRunnerMocks(t, runner)
 		setupAllRunnerMocks(t, runner)
 
@@ -118,7 +118,7 @@ func TestRunner(t *testing.T) {
 			return false, expectedErr
 		})
 
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 
 		basictriggertest.Trigger(runner, func() (basictrigger.TriggerOutputs, error) {
 			return basictrigger.TriggerOutputs{CoolOutput: "cool"}, nil
@@ -141,7 +141,7 @@ func TestRunner(t *testing.T) {
 		helper := &testHelper{t: t}
 		workflow := createBasicTestWorkflow(helper.transformTrigger)
 
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 
 		basictriggertest.Trigger(runner, func() (basictrigger.TriggerOutputs, error) {
 			return basictrigger.TriggerOutputs{CoolOutput: "cool"}, nil
@@ -159,7 +159,7 @@ func TestRunner(t *testing.T) {
 	})
 
 	t.Run("Run registers and unregisters from capabilities", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 
 		workflow, testTriggerConfig, testTargetConfig := registrationWorkflow()
 
@@ -178,7 +178,7 @@ func TestRunner(t *testing.T) {
 	})
 
 	t.Run("Run captures register errors", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 
 		workflow, _, _ := registrationWorkflow()
 
@@ -196,7 +196,7 @@ func TestRunner(t *testing.T) {
 	})
 
 	t.Run("Run captures unregister errors", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 
 		workflow, _, _ := registrationWorkflow()
 
@@ -214,7 +214,7 @@ func TestRunner(t *testing.T) {
 	})
 
 	t.Run("GetRegisteredMock returns the mock for a step", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		expected := basicactiontest.ActionForStep(runner, "action", func(input basicaction.ActionInputs) (basicaction.ActionOutputs, error) {
 			return basicaction.ActionOutputs{}, nil
 		})
@@ -229,7 +229,7 @@ func TestRunner(t *testing.T) {
 	})
 
 	t.Run("GetRegisteredMock returns a default mock if step wasn't specified", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		expected := basicactiontest.Action(runner, func(input basicaction.ActionInputs) (basicaction.ActionOutputs, error) {
 			return basicaction.ActionOutputs{}, nil
 		})
@@ -238,7 +238,7 @@ func TestRunner(t *testing.T) {
 	})
 
 	t.Run("GetRegisteredMock returns nil if no mock was registered", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		referenceactiontest.Action(runner, func(input referenceaction.SomeInputs) (referenceaction.SomeOutputs, error) {
 			return referenceaction.SomeOutputs{}, nil
 		})
@@ -246,7 +246,7 @@ func TestRunner(t *testing.T) {
 	})
 
 	t.Run("GetRegisteredMock returns nil if no mock was registered for a step", func(t *testing.T) {
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		differentStep := basicactiontest.ActionForStep(runner, "step", func(input basicaction.ActionInputs) (basicaction.ActionOutputs, error) {
 			return basicaction.ActionOutputs{}, nil
 		})
@@ -281,7 +281,7 @@ func TestCompute(t *testing.T) {
 			return actual, nil
 		})
 
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		basictriggertest.Trigger(runner, func() (basictrigger.TriggerOutputs, error) {
 			return basictrigger.TriggerOutputs{CoolOutput: "100"}, nil
 		})
@@ -304,7 +304,7 @@ func TestCompute(t *testing.T) {
 			return c, nil
 		})
 
-		runner := testutils.NewRunner(tests.Context(t))
+		runner := testutils.NewRunner(tests.Context(t), &testutils.NoopRuntime{})
 		secretToken := "superSuperSecretToken"
 		runner.Secrets = map[string]string{
 			"fidelity": secretToken,


### PR DESCRIPTION
In this PR, we're updating the `testutils.NewRunner` function signature to accept an optional runtime parameter. If a nil value is passed, the `NoopRuntime` is used.

This change will allow test authors to implement their own handlers for:

- Fetch
- Logger
- Emitter