### PR TITLE
testutils: Convert the workflow spec to and from proto in ensureGraph

### DIFF
--- a/pkg/workflows/sdk/testutils/runner.go
+++ b/pkg/workflows/sdk/testutils/runner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/exec"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
+	wasmpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/pb"
 )
 
 func NewRunner(ctx context.Context, runtime sdk.Runtime) *Runner {
@@ -79,7 +80,17 @@ func (r *Runner) Err() error {
 }
 
 func (r *Runner) ensureGraph(spec sdk.WorkflowSpec) error {
-	g, err := workflows.BuildDependencyGraph(spec)
+	proto, err := wasmpb.WorkflowSpecToProto(&spec)
+	if err != nil {
+		return err
+	}
+
+	newspec, err := wasmpb.ProtoToWorkflowSpec(proto)
+	if err != nil {
+		return err
+	}
+
+	g, err := workflows.BuildDependencyGraph(*newspec)
 	if err != nil {
 		return err
 	}

--- a/pkg/workflows/sdk/testutils/runner.go
+++ b/pkg/workflows/sdk/testutils/runner.go
@@ -80,6 +80,8 @@ func (r *Runner) Err() error {
 }
 
 func (r *Runner) ensureGraph(spec sdk.WorkflowSpec) error {
+	// BuildDependencyGraph expects non-aliased types as inputs in order to be able to generate the graph correctly.
+	// Serialize and deserialize the workflow to automatically convert the Spec to a supported format.
 	proto, err := wasmpb.WorkflowSpecToProto(&spec)
 	if err != nil {
 		return err


### PR DESCRIPTION
In this PR, we're modifying the `ensureGraph` function within testutils' Runner to convert the workflow spec to a protobuf, and then back again, to get around an issue I encountered while developing a workflow

Specifically, I was using the read contract capability in my workflow, but when I ran my unit test against the workflow, I got this error:

```
invalid refs map[ConfidenceLevel:finalized Params:map[fundTokenId:0xd4b2f7c3e5f28c8d0a34b17b9ce5d6d7e85a9bcf1e6a7d8e3c2a5f9b8d4e6c3d]] for step read
```

I was using the capability like so:

```
chainRead := readcontract.Config{
			ContractAddress:      config.DataSourceContractAddress,
			ContractName:         config.DataSourceContractName,
			ContractReaderConfig: config.DataSourceContractConfig,
			ReadIdentifier:       fmt.Sprintf("%s-%s-%s", config.DataSourceContractAddress, config.DataSourceContractName, config.DataSourceContractFunction),
		}.New(
			w,
			"read-contract-evm-11155111@1.0.0",
			"read",
			readcontract.ActionInput{
				ConfidenceLevel: sdk.ConstantDefinition("finalized"),
				Params: sdk.ConstantDefinition(readcontract.InputParams{
					"fundTokenId": config.DataSourceFundTokenID,
					"_unused":     cron.Ref(), // TODO: Figure out a nicer way to do this.
				}),
			})
```

And mocking it like this:

```
contractRead := readcontractcaptest.Action(runner, "read-contract-evm-11155111@1.0.0", func(input readcontractcap.Input) (readcontractcap.Output, error) {
		b, err := json.Marshal(map[string]any{
			"nav":         "123",
			"fundTokenId": "0xd4b2f7c3e5f28c8d0a34b17b9ce5d6d7e85a9bcf1e6a7d8e3c2a5f9b8d4e6c3d",
		})

		if err != nil {
			return readcontractcap.Output{}, err
		}

		return readcontractcap.Output{
			LatestValue: b,
		}, nil
	})
```

It seems the issue I encountered is specific to local unit testing only; that is, if I was testing my code remotely I would not have encountered this. 

Therefore, we're adding serializing and deserializing steps to the local test runner to bypass this issue
