### PR TITLE
Observability-lib: Add support for BarGauge panels

### DIFF
--- a/observability-lib/grafana/builder.go
+++ b/observability-lib/grafana/builder.go
@@ -84,6 +84,9 @@ func (b *Builder) AddPanel(panel ...*Panel) {
 		} else if item.timeSeriesPanelBuilder != nil {
 			item.timeSeriesPanelBuilder.Id(panelID)
 			b.dashboardBuilder.WithPanel(item.timeSeriesPanelBuilder)
+		} else if item.barGaugePanelBuilder != nil {
+			item.barGaugePanelBuilder.Id(panelID)
+			b.dashboardBuilder.WithPanel(item.barGaugePanelBuilder)
 		} else if item.gaugePanelBuilder != nil {
 			item.gaugePanelBuilder.Id(panelID)
 			b.dashboardBuilder.WithPanel(item.gaugePanelBuilder)


### PR DESCRIPTION
As we were porting over some observability dashboards we realized we need a component that was not yet added here. This adds the bargaugebuilder with the appropriate options for this panel type. 
