### PR TITLE
Various updates to Observability Library

### DIFF
--- a/observability-lib/grafana/alerts.go
+++ b/observability-lib/grafana/alerts.go
@@ -35,6 +35,7 @@ func newRuleQuery(query RuleQuery) *alerting.QueryBuilder {
 		RefId(query.RefID)
 
 	if query.Instant {
+		model.QueryType("instant")
 		model.Instant()
 	}
 

--- a/observability-lib/grafana/contact-point.go
+++ b/observability-lib/grafana/contact-point.go
@@ -3,14 +3,23 @@ package grafana
 import "github.com/grafana/grafana-foundation-sdk/go/alerting"
 
 type ContactPointOptions struct {
-	Name     string
-	Type     alerting.ContactPointType
-	Settings map[string]interface{}
+	Name                  string
+	Type                  alerting.ContactPointType
+	Settings              map[string]interface{}
+	DisableResolveMessage bool
+	Uid                   string
 }
 
 func NewContactPoint(options *ContactPointOptions) *alerting.ContactPointBuilder {
-	return alerting.NewContactPointBuilder().
+	builder := alerting.NewContactPointBuilder().
 		Name(options.Name).
 		Type(options.Type).
-		Settings(options.Settings)
+		Settings(options.Settings).
+		DisableResolveMessage(options.DisableResolveMessage)
+
+	if options.Uid != "" {
+		builder.Uid(options.Uid)
+	}
+
+	return builder
 }

--- a/observability-lib/grafana/panels.go
+++ b/observability-lib/grafana/panels.go
@@ -279,6 +279,7 @@ type TimeSeriesPanelOptions struct {
 	ToolTipOptions    *ToolTipOptions
 	ThresholdStyle    common.GraphThresholdsStyleMode
 	DrawStyle         common.GraphDrawStyle
+	StackingMode      common.StackingMode
 }
 
 func NewTimeSeriesPanel(options *TimeSeriesPanelOptions) *Panel {
@@ -300,6 +301,10 @@ func NewTimeSeriesPanel(options *TimeSeriesPanelOptions) *Panel {
 		options.ToolTipOptions = &ToolTipOptions{}
 	}
 
+	if options.StackingMode == "" {
+		options.StackingMode = common.StackingModeNone
+	}
+
 	newPanel := timeseries.NewPanelBuilder().
 		Datasource(datasourceRef(options.Datasource)).
 		Title(*options.Title).
@@ -315,7 +320,11 @@ func NewTimeSeriesPanel(options *TimeSeriesPanelOptions) *Panel {
 		ScaleDistribution(common.NewScaleDistributionConfigBuilder().
 			Type(options.ScaleDistribution),
 		).
-		Tooltip(newToolTip(options.ToolTipOptions))
+		Tooltip(newToolTip(options.ToolTipOptions)).
+		// Time Series Panel Options
+		Stacking(common.NewStackingConfigBuilder().
+			Mode(options.StackingMode),
+		)
 
 	if options.Decimals != nil {
 		newPanel.Decimals(*options.Decimals)

--- a/observability-lib/grafana/variables.go
+++ b/observability-lib/grafana/variables.go
@@ -21,7 +21,9 @@ type VariableOption struct {
 
 type CustomVariableOptions struct {
 	*VariableOption
-	Values map[string]any
+	Values     map[string]any
+	Multi      bool
+	IncludeAll bool
 }
 
 func NewCustomVariable(options *CustomVariableOptions) *dashboard.CustomVariableBuilder {
@@ -38,7 +40,9 @@ func NewCustomVariable(options *CustomVariableOptions) *dashboard.CustomVariable
 			Selected: cog.ToPtr[bool](true),
 			Text:     dashboard.StringOrArrayOfString{String: cog.ToPtr(options.CurrentText)},
 			Value:    dashboard.StringOrArrayOfString{String: cog.ToPtr(options.CurrentValue)},
-		})
+		}).
+		Multi(options.Multi).
+		IncludeAll(options.IncludeAll)
 
 	optionsList := []dashboard.VariableOption{
 		{
@@ -63,7 +67,11 @@ func NewCustomVariable(options *CustomVariableOptions) *dashboard.CustomVariable
 		// Escape commas and colons in the value which are reserved characters for values string
 		cleanValue := strings.ReplaceAll(value.(string), ",", "\\,")
 		cleanValue = strings.ReplaceAll(cleanValue, ":", "\\:")
-		valuesString += key + " : " + cleanValue + " , "
+		valuesString += key
+		if key != cleanValue {
+			valuesString += " : " + cleanValue
+		}
+		valuesString += ", "
 	}
 	variable.Values(dashboard.StringOrMap{String: cog.ToPtr(strings.TrimSuffix(valuesString, ", "))})
 


### PR DESCRIPTION
- Fix alert query type not instant when the query is instant
- Add disable resolve message and uid to contact point
- Add stacking mode to time series panel
- Add multi and include all to custom variable
- Use csv when the variable key and value is the same

Example of variable values:
Before:
`crit : crit , error : error , warn : warn , info : info , debug : debug `
After:
`error, warn, info, debug, crit`

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
