### PR TITLE
feat(grafana): add transforms

### DIFF
--- a/observability-lib/grafana/panels.go
+++ b/observability-lib/grafana/panels.go
@@ -79,15 +79,10 @@ func newThresholds(options *ThresholdOptions) *dashboard.ThresholdsConfigBuilder
 	return builder
 }
 
-type TransformOptions struct {
-	ID      string
-	Options map[string]any
-}
-
-func newTransform(options *TransformOptions) dashboard.DataTransformerConfig {
+func newTransform(transform *Transform) dashboard.DataTransformerConfig {
 	return dashboard.DataTransformerConfig{
-		Id:      options.ID,
-		Options: options.Options,
+		Id:      transform.ID,
+		Options: transform.Options,
 	}
 }
 
@@ -137,7 +132,7 @@ type PanelOptions struct {
 	MaxDataPoints *float64
 	Query         []Query
 	Threshold     *ThresholdOptions
-	Transform     *TransformOptions
+	Transforms    []*Transform
 	ColorScheme   dashboard.FieldColorModeId
 	Interval      string
 }
@@ -263,8 +258,10 @@ func NewStatPanel(options *StatPanelOptions) *Panel {
 		newPanel.Thresholds(newThresholds(options.Threshold))
 	}
 
-	if options.Transform != nil {
-		newPanel.WithTransformation(newTransform(options.Transform))
+	if options.Transforms != nil {
+		for _, transform := range options.Transforms {
+			newPanel.WithTransformation(newTransform(transform))
+		}
 	}
 
 	if options.ColorScheme != "" {
@@ -369,8 +366,10 @@ func NewTimeSeriesPanel(options *TimeSeriesPanelOptions) *Panel {
 		newPanel.DrawStyle(options.DrawStyle)
 	}
 
-	if options.Transform != nil {
-		newPanel.WithTransformation(newTransform(options.Transform))
+	if options.Transforms != nil {
+		for _, transform := range options.Transforms {
+			newPanel.WithTransformation(newTransform(transform))
+		}
 	}
 
 	if options.ColorScheme != "" {
@@ -450,8 +449,10 @@ func NewBarGaugePanel(options *BarGaugePanelOptions) *Panel {
 		newPanel.Thresholds(newThresholds(options.Threshold))
 	}
 
-	if options.Transform != nil {
-		newPanel.WithTransformation(newTransform(options.Transform))
+	if options.Transforms != nil {
+		for _, transform := range options.Transforms {
+			newPanel.WithTransformation(newTransform(transform))
+		}
 	}
 
 	if options.Orientation != "" {
@@ -511,8 +512,10 @@ func NewGaugePanel(options *GaugePanelOptions) *Panel {
 		newPanel.Thresholds(newThresholds(options.Threshold))
 	}
 
-	if options.Transform != nil {
-		newPanel.WithTransformation(newTransform(options.Transform))
+	if options.Transforms != nil {
+		for _, transform := range options.Transforms {
+			newPanel.WithTransformation(newTransform(transform))
+		}
 	}
 
 	return &Panel{
@@ -565,8 +568,10 @@ func NewTablePanel(options *TablePanelOptions) *Panel {
 		newPanel.Thresholds(newThresholds(options.Threshold))
 	}
 
-	if options.Transform != nil {
-		newPanel.WithTransformation(newTransform(options.Transform))
+	if options.Transforms != nil {
+		for _, transform := range options.Transforms {
+			newPanel.WithTransformation(newTransform(transform))
+		}
 	}
 
 	if options.ColorScheme != "" {
@@ -644,8 +649,10 @@ func NewLogPanel(options *LogPanelOptions) *Panel {
 		newPanel.Thresholds(newThresholds(options.Threshold))
 	}
 
-	if options.Transform != nil {
-		newPanel.WithTransformation(newTransform(options.Transform))
+	if options.Transforms != nil {
+		for _, transform := range options.Transforms {
+			newPanel.WithTransformation(newTransform(transform))
+		}
 	}
 
 	if options.ColorScheme != "" {
@@ -699,8 +706,10 @@ func NewHeatmapPanel(options *HeatmapPanelOptions) *Panel {
 		newPanel.Thresholds(newThresholds(options.Threshold))
 	}
 
-	if options.Transform != nil {
-		newPanel.WithTransformation(newTransform(options.Transform))
+	if options.Transforms != nil {
+		for _, transform := range options.Transforms {
+			newPanel.WithTransformation(newTransform(transform))
+		}
 	}
 
 	if options.ColorScheme != "" {

--- a/observability-lib/grafana/transforms.go
+++ b/observability-lib/grafana/transforms.go
@@ -1,0 +1,93 @@
+package grafana
+
+type Transform struct {
+	ID      string
+	Options map[string]any
+}
+
+type JoinByFieldMode string
+
+const (
+	JoinByFieldModeOuter        JoinByFieldMode = "outer"
+	JoinByFieldModeOuterTabular JoinByFieldMode = "outerTabular"
+	JoinByFieldModeOuterInner   JoinByFieldMode = "inner"
+)
+
+type JoinByFieldTransformOptions struct {
+	ByField string
+	Mode    JoinByFieldMode
+}
+
+func NewJoinByFieldTransform(options *JoinByFieldTransformOptions) *Transform {
+	return &Transform{
+		ID: "joinByField",
+		Options: map[string]any{
+			"byField": options.ByField,
+			"mode":    options.Mode,
+		},
+	}
+}
+
+type OrganizeTransformOptions struct {
+	ExcludeByName map[string]bool
+	IndexByName   map[string]int
+	RenameByName  map[string]string
+	IncludeByName map[string]bool
+}
+
+func NewOrganizeTransform(options *OrganizeTransformOptions) *Transform {
+	return &Transform{
+		ID: "organize",
+		Options: map[string]any{
+			"excludeByName": options.ExcludeByName,
+			"indexByName":   options.IndexByName,
+			"renameByName":  options.RenameByName,
+			"includeByName": options.IncludeByName,
+		},
+	}
+}
+
+type ConversionOptions struct {
+	TargetField string
+}
+
+type Conversion map[string]any
+
+type TimeConversionOptions struct {
+	*ConversionOptions
+}
+
+func NewTimeConversion(options *TimeConversionOptions) *Conversion {
+	return &Conversion{
+		"targetField":     options.TargetField,
+		"destinationType": "time",
+	}
+}
+
+type ConvertFieldTypeTransformOptions struct {
+	Conversions []*Conversion
+}
+
+func NewConvertFieldTypeTransform(options *ConvertFieldTypeTransformOptions) *Transform {
+	return &Transform{
+		ID: "convertFieldType",
+		Options: map[string]any{
+			"conversions": options.Conversions,
+		},
+	}
+}
+
+type RenameByRegexTransformOptions struct {
+	Regex         string
+	RenamePattern string
+}
+
+func NewRenameByRegexTransform(options *RenameByRegexTransformOptions) *Transform {
+	return &Transform{
+		ID: "renameByRegex",
+		Options: map[string]any{
+			"regex":         options.Regex,
+			"renamePattern": options.RenamePattern,
+		},
+	}
+}


### PR DESCRIPTION
Introduce Transforms as code instead of free-form text. Also, fix panels limiting to a single Transform.

Example usage:
Before:
```go
Transform: &grafana.TransformOptions{
	ID: "renameByRegex",
	Options: map[string]any{
		"regex":         "/^(.*[\\\\\\/])/",
		"renamePattern": "",
	},
},
```

After:
```go
Transforms: []*grafana.Transform{
	grafana.NewRenameByRegexTransform(&grafana.RenameByRegexTransformOptions{
		Regex:         "/^(.*[\\\\\\/])/",
		RenamePattern: "",
	}),
},
```

Multi-transform usage:
```go
Transforms: []*grafana.Transform{
	grafana.NewJoinByFieldTransform(&grafana.JoinByFieldTransformOptions{
		ByField: "field",
		Mode:    grafana.JoinByFieldModeOuter,
	}),
	grafana.NewOrganizeTransform(&grafana.OrganizeTransformOptions{
		IncludeByName: map[string]bool{
			"fieldA":       true,
			"fieldB":        true,
		},
		RenameByName: map[string]string{
			"Value #A": "fieldA",
			"Value #B": "fieldB",
		},
		IndexByName: map[string]int{
			"Value #B":            0,
			"Value #A":            1,
		},
	}),
	grafana.NewConvertFieldTypeTransform(&grafana.ConvertFieldTypeTransformOptions{
		Conversions: []*grafana.Conversion{
			grafana.NewTimeConversion(&grafana.TimeConversionOptions{
				ConversionOptions: &grafana.ConversionOptions{
					TargetField: "Time",
				},
			}),
		},
	}),
},
```