### PR TITLE
SRE-1635-Add-panel-overrides

### DIFF
--- a/observability-lib/grafana/overrides.go
+++ b/observability-lib/grafana/overrides.go
@@ -1,0 +1,171 @@
+package grafana
+
+type Override struct {
+	Matcher    *Matcher
+	Properties []*Property
+}
+
+type Matcher struct {
+	ID      string
+	Options any
+}
+
+func NewByNameMatcher(name string) *Matcher {
+	return &Matcher{
+		ID:      "byName",
+		Options: name,
+	}
+}
+
+type MatcherReducer string
+
+const (
+	MatcherReducerLastNotNull MatcherReducer = "lastNotNull"
+)
+
+type MatcherOp string
+
+const (
+	MatcherOpGTE MatcherOp = "gte"
+)
+
+type ByValueMatcherOptions struct {
+	Reducer MatcherReducer
+	Op      MatcherOp
+	Value   float64
+}
+
+func NewByValueMatcher(options *ByValueMatcherOptions) *Matcher {
+	return &Matcher{
+		ID: "byValue",
+		Options: map[string]any{
+			"reducer": options.Reducer,
+			"op":      options.Op,
+			"value":   options.Value,
+		},
+	}
+}
+
+type MatcherType string
+
+const (
+	MatcherTypeTime MatcherType = "time"
+)
+
+func NewByTypeMatcher(t MatcherType) *Matcher {
+	return &Matcher{
+		ID:      "byType",
+		Options: t,
+	}
+}
+
+func NewByRegexpMatcher(regex string) *Matcher {
+	return &Matcher{
+		ID:      "byRegexp",
+		Options: regex,
+	}
+}
+
+func NewByQueryMatcher(refID string) *Matcher {
+	return &Matcher{
+		ID:      "byFrameRefID",
+		Options: refID,
+	}
+}
+
+type Property struct {
+	ID    string
+	Value any
+}
+
+type ColorMode string
+
+const (
+	ColorModeFixed ColorMode = "fixed"
+)
+
+type ColorPropertyOptions struct {
+	Mode       ColorMode
+	FixedColor string
+}
+
+func NewColorProperty(options *ColorPropertyOptions) *Property {
+	return &Property{
+		ID: "color",
+		Value: map[string]any{
+			"mode":       options.Mode,
+			"fixedColor": options.FixedColor,
+		},
+	}
+}
+
+type UnitValue string
+
+const (
+	UnitValueBlock UnitValue = "block"
+)
+
+func NewUnitProperty(value UnitValue) *Property {
+	return &Property{
+		ID:    "unit",
+		Value: value,
+	}
+}
+
+type LinksPropertyOptions struct {
+	TargetBlank bool
+	Title       string
+	URL         string
+}
+
+func NewLinksProperty(options *LinksPropertyOptions) *Property {
+	return &Property{
+		ID: "links",
+		Value: map[string]any{
+			"targetBlank": options.TargetBlank,
+			"title":       options.Title,
+			"url":         options.URL,
+		},
+	}
+}
+
+func NewHiddenProperty(value bool) *Property {
+	return &Property{
+		ID:    "custom.hidden",
+		Value: value,
+	}
+}
+
+func NewWidthProperty(value float64) *Property {
+	return &Property{
+		ID:    "custom.width",
+		Value: value,
+	}
+}
+
+type CellOptionsMode string
+
+const (
+	CellOptionsModeBasic CellOptionsMode = "basic"
+)
+
+type CellOptionsType string
+
+const (
+	CellOptionsTypeColorBackground CellOptionsType = "color-background"
+)
+
+type CellOptionsOptions struct {
+	Mode CellOptionsMode
+	Type CellOptionsType
+}
+
+func NewCellOptions(options *CellOptionsOptions) *Property {
+	return &Property{
+		ID: "custom.cellOptions",
+		Value: map[string]any{
+			"mode": options.Mode,
+			"type": options.Type,
+		},
+	}
+}

--- a/observability-lib/grafana/panels.go
+++ b/observability-lib/grafana/panels.go
@@ -91,6 +91,25 @@ func newTransform(options *TransformOptions) dashboard.DataTransformerConfig {
 	}
 }
 
+func newOverride(override *Override) (matcher dashboard.MatcherConfig, properties []dashboard.DynamicConfigValue) {
+	matcher = dashboard.MatcherConfig{
+		Id:      override.Matcher.ID,
+		Options: override.Matcher.Options,
+	}
+
+	for _, property := range override.Properties {
+		properties = append(
+			properties,
+			dashboard.DynamicConfigValue{
+				Id:    property.ID,
+				Value: property.Value,
+			},
+		)
+	}
+
+	return
+}
+
 type ToolTipOptions struct {
 	Mode      common.TooltipDisplayMode
 	Sort      common.SortOrder
@@ -138,6 +157,7 @@ type PanelOptions struct {
 	Query         []Query
 	Threshold     *ThresholdOptions
 	Transform     *TransformOptions
+	Overrides     []*Override
 	ColorScheme   dashboard.FieldColorModeId
 	Interval      string
 }
@@ -267,6 +287,12 @@ func NewStatPanel(options *StatPanelOptions) *Panel {
 		newPanel.WithTransformation(newTransform(options.Transform))
 	}
 
+	if options.Overrides != nil {
+		for _, override := range options.Overrides {
+			newPanel.WithOverride(newOverride(override))
+		}
+	}
+
 	if options.ColorScheme != "" {
 		newPanel.ColorScheme(dashboard.NewFieldColorBuilder().Mode(options.ColorScheme))
 	}
@@ -373,6 +399,12 @@ func NewTimeSeriesPanel(options *TimeSeriesPanelOptions) *Panel {
 		newPanel.WithTransformation(newTransform(options.Transform))
 	}
 
+	if options.Overrides != nil {
+		for _, override := range options.Overrides {
+			newPanel.WithOverride(newOverride(override))
+		}
+	}
+
 	if options.ColorScheme != "" {
 		newPanel.ColorScheme(dashboard.NewFieldColorBuilder().Mode(options.ColorScheme))
 	}
@@ -454,6 +486,12 @@ func NewBarGaugePanel(options *BarGaugePanelOptions) *Panel {
 		newPanel.WithTransformation(newTransform(options.Transform))
 	}
 
+	if options.Overrides != nil {
+		for _, override := range options.Overrides {
+			newPanel.WithOverride(newOverride(override))
+		}
+	}
+
 	if options.Orientation != "" {
 		newPanel.Orientation(options.Orientation)
 	}
@@ -515,6 +553,12 @@ func NewGaugePanel(options *GaugePanelOptions) *Panel {
 		newPanel.WithTransformation(newTransform(options.Transform))
 	}
 
+	if options.Overrides != nil {
+		for _, override := range options.Overrides {
+			newPanel.WithOverride(newOverride(override))
+		}
+	}
+
 	return &Panel{
 		gaugePanelBuilder: newPanel,
 	}
@@ -567,6 +611,12 @@ func NewTablePanel(options *TablePanelOptions) *Panel {
 
 	if options.Transform != nil {
 		newPanel.WithTransformation(newTransform(options.Transform))
+	}
+
+	if options.Overrides != nil {
+		for _, override := range options.Overrides {
+			newPanel.WithOverride(newOverride(override))
+		}
 	}
 
 	if options.ColorScheme != "" {
@@ -648,6 +698,12 @@ func NewLogPanel(options *LogPanelOptions) *Panel {
 		newPanel.WithTransformation(newTransform(options.Transform))
 	}
 
+	if options.Overrides != nil {
+		for _, override := range options.Overrides {
+			newPanel.WithOverride(newOverride(override))
+		}
+	}
+
 	if options.ColorScheme != "" {
 		newPanel.ColorScheme(dashboard.NewFieldColorBuilder().Mode(options.ColorScheme))
 	}
@@ -701,6 +757,12 @@ func NewHeatmapPanel(options *HeatmapPanelOptions) *Panel {
 
 	if options.Transform != nil {
 		newPanel.WithTransformation(newTransform(options.Transform))
+	}
+
+	if options.Overrides != nil {
+		for _, override := range options.Overrides {
+			newPanel.WithOverride(newOverride(override))
+		}
 	}
 
 	if options.ColorScheme != "" {


### PR DESCRIPTION
Example usage:
```go
Overrides: []*grafana.Override{
	{
		Matcher: grafana.NewByNameMatcher("error"),
		Properties: []*grafana.Property{
			grafana.NewColorProperty(&grafana.ColorPropertyOptions{
				Mode:       grafana.ColorModeFixed,
				FixedColor: "red",
			}),
		},
	}, {
		Matcher: grafana.NewByNameMatcher("info"),
		Properties: []*grafana.Property{
			grafana.NewColorProperty(&grafana.ColorPropertyOptions{
				Mode:       grafana.ColorModeFixed,
				FixedColor: "green",
			}),
		},
	},
},
```