### PR TITLE
(obs-lib): split instant and query type instant. add table panel options

### DIFF
--- a/observability-lib/grafana/alerts.go
+++ b/observability-lib/grafana/alerts.go
@@ -9,6 +9,12 @@ import (
 	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
 )
 
+type RuleQueryType string
+
+const (
+	RuleQueryTypeInstant RuleQueryType = "instant"
+)
+
 type RuleQuery struct {
 	Expr         string
 	RefID        string
@@ -16,6 +22,7 @@ type RuleQuery struct {
 	LegendFormat string
 	TimeRange    int64
 	Instant      bool
+	QueryType    RuleQueryType
 }
 
 func newRuleQuery(query RuleQuery) *alerting.QueryBuilder {
@@ -37,8 +44,11 @@ func newRuleQuery(query RuleQuery) *alerting.QueryBuilder {
 		RefId(query.RefID)
 
 	if query.Instant {
-		model.QueryType("instant")
 		model.Instant()
+	}
+
+	if query.QueryType != "" {
+		model.QueryType(string(query.QueryType))
 	}
 
 	return res.Model(model)

--- a/observability-lib/grafana/panels.go
+++ b/observability-lib/grafana/panels.go
@@ -536,7 +536,16 @@ type SortByOptions struct {
 	Desc        *bool
 }
 
+type FooterReducer string
+
+const (
+	FooterReducerSum FooterReducer = "sum"
+)
+
 type FooterOptions struct {
+	Show             bool
+	Reducer          FooterReducer
+	Fields           []string
 	EnablePagination bool
 }
 
@@ -598,10 +607,17 @@ func NewTablePanel(options *TablePanelOptions) *Panel {
 	}
 
 	if options.Footer != nil {
-		newPanel.Footer(
-			common.NewTableFooterOptionsBuilder().
-				EnablePagination(options.Footer.EnablePagination),
-		)
+		footer := common.NewTableFooterOptionsBuilder().
+			Show(options.Footer.Show).
+			EnablePagination(options.Footer.EnablePagination)
+
+		if options.Footer.Reducer != "" && options.Footer.Fields != nil {
+			footer.
+				Reducer([]string{string(options.Footer.Reducer)}).
+				Fields(options.Footer.Fields)
+		}
+
+		newPanel.Footer(footer)
 	}
 
 	if options.SortBy != nil {

--- a/observability-lib/grafana/panels.go
+++ b/observability-lib/grafana/panels.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"github.com/grafana/grafana-foundation-sdk/go/alerting"
 	"github.com/grafana/grafana-foundation-sdk/go/bargauge"
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
 	"github.com/grafana/grafana-foundation-sdk/go/common"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
 	"github.com/grafana/grafana-foundation-sdk/go/gauge"
@@ -16,12 +17,19 @@ import (
 	"github.com/smartcontractkit/chainlink-common/observability-lib/grafana/businessvariable"
 )
 
+type QueryType string
+
+const (
+	QueryTypeInstant QueryType = "instant"
+)
+
 type Query struct {
-	Expr    string
-	Legend  string
-	Instant bool
-	Min     float64
-	Format  prometheus.PromQueryFormat
+	Expr      string
+	Legend    string
+	Instant   bool
+	Min       float64
+	Format    prometheus.PromQueryFormat
+	QueryType QueryType
 }
 
 func newQuery(query Query) *prometheus.DataqueryBuilder {
@@ -32,6 +40,9 @@ func newQuery(query Query) *prometheus.DataqueryBuilder {
 
 	if query.Instant {
 		res.Instant()
+	}
+	if query.QueryType != "" {
+		res.QueryType(string(query.QueryType))
 	}
 
 	return res
@@ -520,8 +531,20 @@ func NewGaugePanel(options *GaugePanelOptions) *Panel {
 	}
 }
 
+type SortByOptions struct {
+	DisplayName string
+	Desc        *bool
+}
+
+type FooterOptions struct {
+	EnablePagination bool
+}
+
 type TablePanelOptions struct {
 	*PanelOptions
+	Filterable bool
+	Footer     *FooterOptions
+	SortBy     []*SortByOptions
 }
 
 func NewTablePanel(options *TablePanelOptions) *Panel {
@@ -535,7 +558,8 @@ func NewTablePanel(options *TablePanelOptions) *Panel {
 		Span(options.Span).
 		Height(options.Height).
 		Unit(options.Unit).
-		NoValue(options.NoValue)
+		NoValue(options.NoValue).
+		Filterable(options.Filterable)
 
 	if options.Interval != "" {
 		newPanel.Interval(options.Interval)
@@ -571,6 +595,28 @@ func NewTablePanel(options *TablePanelOptions) *Panel {
 
 	if options.ColorScheme != "" {
 		newPanel.ColorScheme(dashboard.NewFieldColorBuilder().Mode(options.ColorScheme))
+	}
+
+	if options.Footer != nil {
+		newPanel.Footer(
+			common.NewTableFooterOptionsBuilder().
+				EnablePagination(options.Footer.EnablePagination),
+		)
+	}
+
+	if options.SortBy != nil {
+		var sortBy []cog.Builder[common.TableSortByFieldState]
+		for _, sb := range options.SortBy {
+			tableSortBy := common.NewTableSortByFieldStateBuilder().
+				DisplayName(sb.DisplayName)
+
+			if sb.Desc != nil {
+				tableSortBy.Desc(*sb.Desc)
+			}
+
+			sortBy = append(sortBy, tableSortBy)
+		}
+		newPanel.SortBy(sortBy)
 	}
 
 	return &Panel{


### PR DESCRIPTION
- Split the instant property and query type instant into two different options. These look like two different properties and should not be controlled by a single option
- Add EnablePagination, Filterable, and SortBy to Table Panel