### PR TITLE
Avoid modifying input buffer while decoding

### DIFF
--- a/pkg/codec/encodings/binary/builder.go
+++ b/pkg/codec/encodings/binary/builder.go
@@ -115,12 +115,16 @@ func (littleBigInt) serializeUnsigned(size int, i *big.Int) ([]byte, error) {
 }
 
 func (littleBigInt) deserializeSigned(size int, b []byte) *big.Int {
-	slices.Reverse(b)
-	bi, _ := bigbigendian.DeserializeSigned(size, b)
+	r := make([]byte, len(b))
+	copy(r, b)
+	slices.Reverse(r)
+	bi, _ := bigbigendian.DeserializeSigned(size, r)
 	return bi
 }
 
 func (littleBigInt) deserializeUnsigned(_ int, b []byte) *big.Int {
-	slices.Reverse(b)
-	return new(big.Int).SetBytes(b)
+	r := make([]byte, len(b))
+	copy(r, b)
+	slices.Reverse(r)
+	return new(big.Int).SetBytes(r)
 }

--- a/pkg/codec/encodings/binary/builder_test.go
+++ b/pkg/codec/encodings/binary/builder_test.go
@@ -1,0 +1,31 @@
+package binary
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForInputBufferCorruption(t *testing.T) {
+	builder := LittleEndian()
+
+	codec, err := builder.BigInt(16, true)
+	require.NoError(t, err)
+
+	myBigInt := big.NewInt(3)
+
+	buf := make([]byte, 0, 16)
+	buf, err = codec.Encode(myBigInt, buf)
+	require.NoError(t, err)
+
+	decoded, _, err := codec.Decode(buf)
+	require.NoError(t, err)
+	require.Equal(t, myBigInt, decoded)
+
+	// decoding from the same buffer again should give same answer
+	decoded, _, err = codec.Decode(buf)
+	require.NoError(t, err)
+	assert.Equal(t, myBigInt, decoded)
+}


### PR DESCRIPTION
Modifying the input buffer can cause unexpected behavior if the same buffer is passed as input to a decoder more than once.
