### PR TITLE
Increase max fetch response size for wasm capability

### DIFF
--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -224,8 +224,12 @@ func createFetchFn(
 		if errno != 0 {
 			return sdk.FetchResponse{}, fmt.Errorf("fetch failed with errno %d", errno)
 		}
+
+		l.Info("=== before responseSize is ", len(respBuffer))
+
 		responseSize := binary.LittleEndian.Uint32(resplenBuffer)
 		response := &wasmpb.FetchResponse{}
+		l.Info("=== after responseSize is ", len(respBuffer), " responseSize is ", responseSize)
 		err = proto.Unmarshal(respBuffer[:responseSize], response)
 		if err != nil {
 			return sdk.FetchResponse{}, fmt.Errorf("failed to unmarshal fetch response: %w", err)

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -222,7 +222,6 @@ func createFetchFn(
 		if errno != 0 {
 			return sdk.FetchResponse{}, fmt.Errorf("fetch failed with errno %d", errno)
 		}
-
 		responseSize := binary.LittleEndian.Uint32(resplenBuffer)
 		response := &wasmpb.FetchResponse{}
 		err = proto.Unmarshal(respBuffer[:responseSize], response)

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -34,7 +34,7 @@ type RuntimeConfig struct {
 }
 
 const (
-	defaultMaxFetchResponseSizeBytes = 5 * 1024 * 1024
+	defaultMaxFetchResponseSizeBytes = 5 * 1024 * 6
 )
 
 func defaultRuntimeConfig(id string, md *capabilities.RequestMetadata) *RuntimeConfig {

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -206,7 +206,9 @@ func createFetchFn(
 			return sdk.FetchResponse{}, err
 		}
 
+		l.Info("=== before MaxFetchResponseSizeBytes is ", sdkConfig.MaxFetchResponseSizeBytes)
 		respBuffer := make([]byte, sdkConfig.MaxFetchResponseSizeBytes)
+		l.Info("=== after MaxFetchResponseSizeBytes is ", sdkConfig.MaxFetchResponseSizeBytes)
 		respptr, _, err := bufferToPointerLen(respBuffer)
 		if err != nil {
 			return sdk.FetchResponse{}, err

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -34,7 +34,7 @@ type RuntimeConfig struct {
 }
 
 const (
-	defaultMaxFetchResponseSizeBytes = 5 * 1024 * 6
+	defaultMaxFetchResponseSizeBytes = 5 * 1024 * 1024
 )
 
 func defaultRuntimeConfig(id string, md *capabilities.RequestMetadata) *RuntimeConfig {

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -206,9 +206,7 @@ func createFetchFn(
 			return sdk.FetchResponse{}, err
 		}
 
-		l.Info("=== before MaxFetchResponseSizeBytes is ", sdkConfig.MaxFetchResponseSizeBytes)
 		respBuffer := make([]byte, sdkConfig.MaxFetchResponseSizeBytes)
-		l.Info("=== after MaxFetchResponseSizeBytes is ", sdkConfig.MaxFetchResponseSizeBytes)
 		respptr, _, err := bufferToPointerLen(respBuffer)
 		if err != nil {
 			return sdk.FetchResponse{}, err
@@ -225,11 +223,8 @@ func createFetchFn(
 			return sdk.FetchResponse{}, fmt.Errorf("fetch failed with errno %d", errno)
 		}
 
-		l.Info("=== before responseSize is ", len(respBuffer))
-
 		responseSize := binary.LittleEndian.Uint32(resplenBuffer)
 		response := &wasmpb.FetchResponse{}
-		l.Info("=== after responseSize is ", len(respBuffer), " responseSize is ", responseSize)
 		err = proto.Unmarshal(respBuffer[:responseSize], response)
 		if err != nil {
 			return sdk.FetchResponse{}, fmt.Errorf("failed to unmarshal fetch response: %w", err)

--- a/pkg/workflows/wasm/sdk.go
+++ b/pkg/workflows/wasm/sdk.go
@@ -34,7 +34,7 @@ type RuntimeConfig struct {
 }
 
 const (
-	defaultMaxFetchResponseSizeBytes = 5 * 1024
+	defaultMaxFetchResponseSizeBytes = 5 * 1024 * 1024
 )
 
 func defaultRuntimeConfig(id string, md *capabilities.RequestMetadata) *RuntimeConfig {


### PR DESCRIPTION
Based on slack convo https://chainlink-core.slack.com/archives/C07GQNPVBB5/p1741181660574009?thread_ts=1741148177.928349&cid=C07GQNPVBB5 

The current response size limit is too low and is not letting us serve a production use case. Increasing from 5 kb to 5 mb