### PR TITLE
[CAPPL-620] add MaxFetchResponseSizeBytes to module config

### DIFF
--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -78,6 +78,7 @@ var (
 	defaultMaxFetchRequests          = 5
 	defaultMaxCompressedBinarySize   = 20 * 1024 * 1024  // 20 MB
 	defaultMaxDecompressedBinarySize = 100 * 1024 * 1024 // 100 MB
+	defaultMaxFetchResponseSizeBytes = 5 * 1024 * 1024   // 5 MB
 )
 
 type DeterminismConfig struct {
@@ -96,6 +97,7 @@ type ModuleConfig struct {
 	MaxFetchRequests          int
 	MaxCompressedBinarySize   uint64
 	MaxDecompressedBinarySize uint64
+	MaxFetchResponseSizeBytes uint64
 
 	// Labeler is used to emit messages from the module.
 	Labeler custmsg.MessageEmitter
@@ -177,6 +179,10 @@ func NewModule(modCfg *ModuleConfig, binary []byte, opts ...func(*ModuleConfig))
 
 	if modCfg.MaxDecompressedBinarySize == 0 {
 		modCfg.MaxDecompressedBinarySize = uint64(defaultMaxDecompressedBinarySize)
+	}
+
+	if modCfg.MaxFetchResponseSizeBytes == 0 {
+		modCfg.MaxFetchResponseSizeBytes = uint64(defaultMaxFetchResponseSizeBytes)
 	}
 
 	// Take the max of the min and the configured max memory mbs.


### PR DESCRIPTION
### Description

This pr adds the MaxFetchResponseSizeBytes to the `ModuleConfig` 
[CAPPL-620](https://smartcontract-it.atlassian.net/browse/CAPPL-620)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
