### PR TITLE
Proposal for Custom Beholder Messages

### DIFF
--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -665,7 +665,7 @@ func createLogFn(logger logger.Logger) func(caller *wasmtime.Caller, ptr int32, 
 
 type unimplementedMessageEmitter struct{}
 
-func (u *unimplementedMessageEmitter) Emit(context.Context, string) error {
+func (u *unimplementedMessageEmitter) Emit(context.Context, any) error {
 	return errors.New("unimplemented")
 }
 

--- a/pkg/workflows/wasm/host/module_test.go
+++ b/pkg/workflows/wasm/host/module_test.go
@@ -19,11 +19,11 @@ import (
 )
 
 type mockMessageEmitter struct {
-	e      func(context.Context, string, map[string]string) error
+	e      func(context.Context, any, map[string]string) error
 	labels map[string]string
 }
 
-func (m *mockMessageEmitter) Emit(ctx context.Context, msg string) error {
+func (m *mockMessageEmitter) Emit(ctx context.Context, msg any) error {
 	return m.e(ctx, msg, m.labels)
 }
 
@@ -41,7 +41,7 @@ func (m *mockMessageEmitter) Labels() map[string]string {
 	return m.labels
 }
 
-func newMockMessageEmitter(e func(context.Context, string, map[string]string) error) custmsg.MessageEmitter {
+func newMockMessageEmitter(e func(context.Context, any, map[string]string) error) custmsg.MessageEmitter {
 	return &mockMessageEmitter{e: e}
 }
 
@@ -65,7 +65,7 @@ func Test_createEmitFn(t *testing.T) {
 		emitFn := createEmitFn(
 			logger.Test(t),
 			store,
-			newMockMessageEmitter(func(ctx context.Context, _ string, _ map[string]string) error {
+			newMockMessageEmitter(func(ctx context.Context, _ any, _ map[string]string) error {
 				v := ctx.Value(ctxKey)
 				assert.Equal(t, ctxValue, v)
 				return nil
@@ -106,7 +106,7 @@ func Test_createEmitFn(t *testing.T) {
 		emitFn := createEmitFn(
 			logger.Test(t),
 			store,
-			newMockMessageEmitter(func(_ context.Context, _ string, _ map[string]string) error {
+			newMockMessageEmitter(func(_ context.Context, _ any, _ map[string]string) error {
 				return nil
 			}),
 			unsafeReaderFunc(func(_ *wasmtime.Caller, _, _ int32) ([]byte, error) {
@@ -176,7 +176,7 @@ func Test_createEmitFn(t *testing.T) {
 		emitFn := createEmitFn(
 			logger.Test(t),
 			store,
-			newMockMessageEmitter(func(_ context.Context, _ string, _ map[string]string) error {
+			newMockMessageEmitter(func(_ context.Context, _ any, _ map[string]string) error {
 				return assert.AnError
 			}),
 			unsafeReaderFunc(func(_ *wasmtime.Caller, _, _ int32) ([]byte, error) {

--- a/pkg/workflows/wasm/host/wasm_test.go
+++ b/pkg/workflows/wasm/host/wasm_test.go
@@ -271,7 +271,7 @@ func Test_Compute_Emit(t *testing.T) {
 			Logger:         lggr,
 			Fetch:          fetchFunc,
 			IsUncompressed: true,
-			Labeler: newMockMessageEmitter(func(gotCtx context.Context, msg string, kvs map[string]string) error {
+			Labeler: newMockMessageEmitter(func(gotCtx context.Context, msg any, kvs map[string]string) error {
 				t.Helper()
 
 				v := ctx.Value(ctxKey)
@@ -301,7 +301,7 @@ func Test_Compute_Emit(t *testing.T) {
 			Logger:         lggr,
 			Fetch:          fetchFunc,
 			IsUncompressed: true,
-			Labeler: newMockMessageEmitter(func(_ context.Context, msg string, kvs map[string]string) error {
+			Labeler: newMockMessageEmitter(func(_ context.Context, msg any, kvs map[string]string) error {
 				t.Helper()
 
 				assert.Equal(t, "testing emit", msg)
@@ -343,7 +343,7 @@ func Test_Compute_Emit(t *testing.T) {
 			Logger:         lggr,
 			Fetch:          fetchFunc,
 			IsUncompressed: true,
-			Labeler: newMockMessageEmitter(func(_ context.Context, msg string, labels map[string]string) error {
+			Labeler: newMockMessageEmitter(func(_ context.Context, msg any, labels map[string]string) error {
 				return nil
 			}), // never called
 		}, binary)
@@ -1265,7 +1265,7 @@ func TestModule_MaxResponseSizeBytesLimit(t *testing.T) {
 		ctx := tests.Context(t)
 		binary := createTestBinary(emitBinaryCmd, emitBinaryLocation, true, t)
 
-		emitter := newMockMessageEmitter(func(gotCtx context.Context, msg string, kvs map[string]string) error {
+		emitter := newMockMessageEmitter(func(gotCtx context.Context, msg any, kvs map[string]string) error {
 			return errors.New("some error")
 		})
 		// an emitter response with an error "some error" when marshaled is 14 bytes
@@ -1301,7 +1301,7 @@ func TestModule_MaxResponseSizeBytesLimit(t *testing.T) {
 		ctx := tests.Context(t)
 		binary := createTestBinary(emitBinaryCmd, emitBinaryLocation, true, t)
 
-		emitter := newMockMessageEmitter(func(gotCtx context.Context, msg string, kvs map[string]string) error {
+		emitter := newMockMessageEmitter(func(gotCtx context.Context, msg any, kvs map[string]string) error {
 			return errors.New("some error")
 		})
 


### PR DESCRIPTION
The default custom message utility uses a `BaseMessage` proto with the message data expected to be a string and labels added to the proto message.

Instead, a proto message itself can be sent where the message and schema details are packaged together by an interface. This promotes the design that any particular entity can be emitted given that it satisfies the interface.

As a temporary measure, the `Emit` interface accepts an `any` type to allow for existing string types or the `ProtoMessage` interface. This could be reworked using generics on the `Labeler`.

One more upcoming feature of beholder is the ability to have delivery guarantees as an option. This will require mechanisms for retry, possibly with persistence. The `Labeler` entity could be expanded for this use case.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
