### PR TITLE
Adding ByzantineQuorum utility

### DIFF
--- a/pkg/aggregation/quorum.go
+++ b/pkg/aggregation/quorum.go
@@ -1,0 +1,16 @@
+package aggregation
+
+// ByzantineQuorum is a utility to calculated the number of responses from a
+// DON before Byzantine tolerant quorum is achieved.
+// NOTE: Typical usage is when N >= 3f + 1
+//
+// The formula is floor( (N+F)/2 ) + 1.
+// F should be >= 1.
+// If N = 1, a quorum size of 1 is returned.
+// Double check usage for small N and F if N < 3f + 1.
+func ByzantineQuorum(F int, N int) (Q int) {
+	if N == 1 {
+		return 1
+	}
+	return (N+F)/2 + 1
+}

--- a/pkg/aggregation/quorum.go
+++ b/pkg/aggregation/quorum.go
@@ -8,7 +8,7 @@ package aggregation
 // F should be >= 1.
 // If N = 1, a quorum size of 1 is returned.
 // Double check usage for small N and F if N < 3f + 1.
-func ByzantineQuorum(F int, N int) (Q int) {
+func ByzantineQuorum(N int, F int) (Q int) {
 	if N == 1 {
 		return 1
 	}

--- a/pkg/aggregation/quorum_test.go
+++ b/pkg/aggregation/quorum_test.go
@@ -10,11 +10,12 @@ func Test_ByzantineQuorum(t *testing.T) {
 	assert.Equal(t, 1, ByzantineQuorum(1, 1))
 
 	// N = 3F + 1
-	assert.Equal(t, 3, ByzantineQuorum(1, 4))
-	assert.Equal(t, 5, ByzantineQuorum(2, 7))
+	assert.Equal(t, 3, ByzantineQuorum(4, 1))
+	assert.Equal(t, 5, ByzantineQuorum(7, 2))
 
 	// N > 3F + 1
-	assert.Equal(t, 4, ByzantineQuorum(1, 5))
-	assert.Equal(t, 4, ByzantineQuorum(1, 6))
-	assert.Equal(t, 6, ByzantineQuorum(2, 9))
+	assert.Equal(t, 4, ByzantineQuorum(5, 1))
+	assert.Equal(t, 4, ByzantineQuorum(6, 1))
+	assert.Equal(t, 6, ByzantineQuorum(9, 2))
+
 }

--- a/pkg/aggregation/quorum_test.go
+++ b/pkg/aggregation/quorum_test.go
@@ -1,0 +1,20 @@
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ByzantineQuorum(t *testing.T) {
+	assert.Equal(t, 1, ByzantineQuorum(1, 1))
+
+	// N = 3F + 1
+	assert.Equal(t, 3, ByzantineQuorum(1, 4))
+	assert.Equal(t, 5, ByzantineQuorum(2, 7))
+
+	// N > 3F + 1
+	assert.Equal(t, 4, ByzantineQuorum(1, 5))
+	assert.Equal(t, 4, ByzantineQuorum(1, 6))
+	assert.Equal(t, 6, ByzantineQuorum(2, 9))
+}


### PR DESCRIPTION
Sets up the work to change the incorrect F + 1 aggregators in the Don 2 Don layer to a true Byzantine Quorum
