### PR TITLE
bumping benchmark action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Go Benchmark Action
-        uses: patrickhuie19/benchmark-action@b46d0ce6c3b4bd423380f7d3c6abed389e38ea4a
+        uses: patrickhuie19/benchmark-action@b6d5104868690adeac692f7c860a715fefe604d4
         with:
           benchmarks-pr: 'BenchmarkKeystore_Sign'  # Use benchmarks specified in PR, or default benchmarks
           benchmarks-merge: 'BenchmarkKeystore_Sign' # Default list of benchmarks to run on merges


### PR DESCRIPTION
The previous version of this action had a dependency on actions/cache@v2, bumped to actions/cache@v4
