### PR TITLE
removing global state for beholder tester

### DIFF
--- a/pkg/utils/tests/beholder.go
+++ b/pkg/utils/tests/beholder.go
@@ -65,6 +65,8 @@ func (b BeholderTester) msgsForKVs(t *testing.T, attrKVs ...any) []beholder.Mess
 
 // Beholder sets the global beholder client as a message collector and returns a tester that provides helper assertion
 // functions on received messages.
+//
+// Beholder affects the whole process, it cannot be used in parallel tests or tests with parallel ancestors.
 func Beholder(t *testing.T) BeholderTester {
 	t.Helper()
 
@@ -102,6 +104,7 @@ func Beholder(t *testing.T) BeholderTester {
 	prevClient := beholder.GetClient()
 	t.Cleanup(func() {
 		beholder.SetClient(prevClient)
+		t.Setenv(packageNameBeholder, packageNameBeholder)
 	})
 	beholder.SetClient(client)
 


### PR DESCRIPTION
* Subtests could accidentally share a beholder testing impl. Assertions on logs would behave unexpectedly as underlying store of messages could contain messages from other tests.

* Global vars set during testing remain in the process for the whole test run. i.e. `go test ./...` would set the beholder tester once. I believe that's why we're observing flakes: https://github.com/smartcontractkit/chainlink/pull/16923#issuecomment-2755512442