### PR TITLE
fix llo aggregator timestamp for cache contract encoding

### DIFF
--- a/pkg/capabilities/consensus/ocr3/datafeeds/feeds_aggregator.go
+++ b/pkg/capabilities/consensus/ocr3/datafeeds/feeds_aggregator.go
@@ -174,7 +174,7 @@ func (a *dataFeedsAggregator) Aggregate(lggr logger.Logger, previousOutcome *typ
 		return nil, err
 	}
 
-	var toWrap []any
+	toWrap := make([]any, 0, len(reportsNeedingUpdate))
 	for _, report := range reportsNeedingUpdate {
 		feedID := datastreams.FeedID(report.FeedID).Bytes()
 		remappedID := a.config.Feeds[datastreams.FeedID(report.FeedID)].RemappedID

--- a/pkg/capabilities/consensus/ocr3/datafeeds/feeds_aggregator_test.go
+++ b/pkg/capabilities/consensus/ocr3/datafeeds/feeds_aggregator_test.go
@@ -3,6 +3,7 @@ package datafeeds_test
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"math"
 	"math/big"
 	"testing"
 
@@ -209,7 +210,7 @@ func TestDataFeedsAggregator_ParseConfig(t *testing.T) {
 		require.Equal(t, heartbeatA, parsedConfig.Feeds[feedIDA].Heartbeat)
 		require.Equal(t, deviationB, parsedConfig.Feeds[feedIDB].Deviation)
 		require.Equal(t, heartbeatB, parsedConfig.Feeds[feedIDB].Heartbeat)
-		require.Equal(t, allowedPartialStaleness, parsedConfig.AllowedPartialStaleness)
+		require.InEpsilon(t, allowedPartialStaleness, parsedConfig.AllowedPartialStaleness, math.SmallestNonzeroFloat64)
 	})
 
 	t.Run("invalid ID", func(t *testing.T) {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This change fixes the LLO aggregration timestamp output by the OCR3 capability.

Upstream, the LLO plugin creates stream prices with nanosecond precision. Downstream the Data feeds contract requires seconds  https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/data-feeds/DataFeedsCache.sol#L44

The encoder silently truncated the underlaying uint64 to uint32 and corrupts the data. 

This change uses time.Time internally to make the intention clear and explicitly converts the LLO nanosecond format to the Feed second format
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
