### PR TITLE
fix chainwriter LOOP plugin service

### DIFF
--- a/pkg/loop/internal/relayer/pluginprovider/contractwriter/contract_writer.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractwriter/contract_writer.go
@@ -121,7 +121,12 @@ func WithServerEncoding(version contractreader.EncodingVersion) ServerOpt {
 }
 
 func (s *Server) SubmitTransaction(ctx context.Context, req *pb.SubmitTransactionRequest) (*emptypb.Empty, error) {
-	err := s.impl.SubmitTransaction(ctx, req.ContractName, req.Method, req.Params, req.TransactionId, req.ToAddress, TxMetaFromProto(req.Meta), req.Value.Int())
+	params := map[string]any{}
+	if err := contractreader.DecodeVersionedBytes(&params, req.Params); err != nil {
+		return nil, err
+	}
+
+	err := s.impl.SubmitTransaction(ctx, req.ContractName, req.Method, params, req.TransactionId, req.ToAddress, TxMetaFromProto(req.Meta), req.Value.Int())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- actually register the ContractWriter, fixing `rpc error: code = Unimplemented desc = unknown service loop.ContractWriter`
- decode the params in the server, which are encoded as VersionedBytes in the client
- 