### PR TITLE
pkg/services/promhealth: new isolated package for prometheus health reporting

### DIFF
--- a/pkg/loop/server.go
+++ b/pkg/loop/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/config/build"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/promhealth"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/pg"
 )
@@ -145,7 +146,7 @@ func (s *Server) start() error {
 		return fmt.Errorf("error starting prometheus server: %w", err)
 	}
 
-	s.checker = services.NewChecker("", "")
+	s.checker = promhealth.NewChecker("", "")
 	if err := s.checker.Start(); err != nil {
 		return fmt.Errorf("error starting health checker: %w", err)
 	}

--- a/pkg/services/promhealth/promhealth.go
+++ b/pkg/services/promhealth/promhealth.go
@@ -1,0 +1,53 @@
+package promhealth
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+)
+
+var (
+	healthStatus = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "health",
+			Help: "Health status by service",
+		},
+		[]string{"service_id"},
+	)
+	uptimeSeconds = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "uptime_seconds",
+			Help: "Uptime of the application measured in seconds",
+		},
+	)
+	version = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "version",
+			Help: "Application version information",
+		},
+		[]string{"version", "commit"},
+	)
+)
+
+// NewChecker returns a *services.HealthChecker with hooks for prometheus metrics.
+func NewChecker(ver, sha string) *services.HealthChecker {
+	return services.HealthCheckerConfig{
+		Ver: ver,
+		Sha: sha,
+		AddUptime: func(d time.Duration) {
+			uptimeSeconds.Add(d.Seconds())
+		},
+		IncVersion: func(ver string, sha string) {
+			version.WithLabelValues(ver, sha).Inc()
+		},
+		SetStatus: func(name string, value int) {
+			healthStatus.WithLabelValues(name).Set(float64(value))
+		},
+		Delete: func(name string) {
+			healthStatus.DeleteLabelValues(name)
+		},
+	}.New()
+}


### PR DESCRIPTION
Isolating the prometheus metrics in a separate package has the effect of removing prometheus packages that are interfering with users of `package services`. This does not break the API, but it does change the behavior of the old constructors to become no-ops.

Supports:
- https://github.com/smartcontractkit/chainlink/pull/17037
- https://github.com/smartcontractkit/capabilities/pull/88