### PR TITLE
Change element extractor to not initialise slice elem for nil values

### DIFF
--- a/pkg/codec/element_extractor.go
+++ b/pkg/codec/element_extractor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -134,6 +135,12 @@ func expandMap(extractMap map[string]any, key string, _ *ElementExtractorLocatio
 	}
 
 	rItem := reflect.ValueOf(item)
+	// Must be one of these Kinds to check IsNil, this check is not same as item == nil check.
+	if slices.Contains([]reflect.Kind{reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice}, rItem.Kind()) && rItem.IsNil() {
+		extractMap[key] = reflect.MakeSlice(reflect.SliceOf(rItem.Type()), 0, 0).Interface()
+		return nil
+	}
+
 	slice := reflect.MakeSlice(reflect.SliceOf(rItem.Type()), 1, 1)
 	slice.Index(0).Set(rItem)
 	extractMap[key] = slice.Interface()

--- a/pkg/codec/element_extractor_test.go
+++ b/pkg/codec/element_extractor_test.go
@@ -26,6 +26,13 @@ func TestElementExtractor(t *testing.T) {
 		D uint64
 	}
 
+	type nilFields struct {
+		A *int64
+		B string
+		C *testStruct
+		D []testStruct
+	}
+
 	type nestedTestStruct struct {
 		A string
 		B testStruct
@@ -128,6 +135,27 @@ func TestElementExtractor(t *testing.T) {
 		iInput.FieldByName("A").Set(reflect.ValueOf([]string{"A"}))
 		iInput.FieldByName("C").Set(reflect.ValueOf([]int64{20}))
 		iInput.FieldByName("D").Set(reflect.ValueOf([]uint64{30}))
+		assert.Equal(t, iInput.Interface(), newInput)
+	})
+
+	t.Run("TransformToOnChain and TransformToOffChain works on nil ptr by initialising empty values", func(t *testing.T) {
+		inputType, err := extractor.RetypeToOffChain(reflect.TypeOf(nilFields{}), "")
+		require.NoError(t, err)
+
+		iInput := reflect.Indirect(reflect.New(inputType))
+		output, err := extractor.TransformToOnChain(iInput.Interface(), "")
+		require.NoError(t, err)
+
+		expected := nilFields{}
+		assert.Equal(t, expected, output)
+
+		newInput, err := extractor.TransformToOffChain(expected, "")
+		require.NoError(t, err)
+
+		// Lossy modification
+		iInput.FieldByName("A").Set(reflect.ValueOf([]*int64{}))
+		iInput.FieldByName("C").Set(reflect.ValueOf([]*testStruct{}))
+		iInput.FieldByName("D").Set(reflect.ValueOf([][]testStruct{}))
 		assert.Equal(t, iInput.Interface(), newInput)
 	})
 


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Description
Element extractor modifier used to create slices with one element with uninitialised values even when the value to extract was nil. This PR changes that behaviour to create an empty slice instead.


