### PR TITLE
O11Y-1066 - Include Type and Id in fields returned from datasource query

### DIFF
--- a/observability-lib/api/datasource.go
+++ b/observability-lib/api/datasource.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -10,16 +11,20 @@ type Datasource struct {
 	ID   uint   `json:"id"`
 	UID  string `json:"uid"`
 	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 // GetDataSourceByName Get a datasource by name
 func (c *Client) GetDataSourceByName(name string) (*Datasource, *resty.Response, error) {
 	var grafanaResp Datasource
 
+	// URL-encode the name to handle special characters and spaces
+	escapedName := url.PathEscape(name)
+
 	resp, err := c.resty.R().
 		SetHeader("Accept", "application/json").
 		SetResult(&grafanaResp).
-		Get(fmt.Sprintf("/api/datasources/name/%s", name))
+		Get(fmt.Sprintf("/api/datasources/name/%s", escapedName))
 
 	if err != nil {
 		return nil, resp, err

--- a/observability-lib/api/datasource_test.go
+++ b/observability-lib/api/datasource_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDataSourceByName(t *testing.T) {
+	expectedName := "VictoriaMetrics - MetricsQL"
+	expectedUID := "123abc"
+	expectedType := "victoriametrics-metrics-datasource"
+	expectedID := uint(1)
+
+	// Create a test HTTP server that mimics Grafana's API
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, fmt.Sprintf("/api/datasources/name/%s", expectedName), r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		t.Logf("received request: %s %s", r.Method, r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{
+			"id": %d,
+			"uid": "%s",
+			"name": "%s",
+			"type": "%s"
+		}`, expectedID, expectedUID, expectedName, expectedType)
+	}))
+	defer ts.Close()
+
+	client := &Client{
+		resty: resty.New().SetBaseURL(ts.URL),
+	}
+
+	ds, resp, err := client.GetDataSourceByName(expectedName)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+	assert.NotNil(t, ds)
+	assert.Equal(t, expectedID, ds.ID)
+	assert.Equal(t, expectedUID, ds.UID)
+	assert.Equal(t, expectedName, ds.Name)
+	assert.Equal(t, expectedType, ds.Type)
+}

--- a/observability-lib/grafana/datasource.go
+++ b/observability-lib/grafana/datasource.go
@@ -3,8 +3,10 @@ package grafana
 import "github.com/smartcontractkit/chainlink-common/observability-lib/api"
 
 type DataSource struct {
+	ID   uint
 	Name string
 	UID  string
+	Type string
 }
 
 func NewDataSource(name, uid string) *DataSource {
@@ -25,5 +27,5 @@ func GetDataSourceFromGrafana(name string, grafanaURL string, grafanaToken strin
 		return nil, err
 	}
 
-	return &DataSource{Name: datasource.Name, UID: datasource.UID}, nil
+	return &DataSource{ID: datasource.ID, Name: datasource.Name, UID: datasource.UID, Type: datasource.Type}, nil
 }


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[O11Y-1066](https://smartcontract-it.atlassian.net/browse/O11Y-1066)
--> 

[O11Y-1066](https://smartcontract-it.atlassian.net/browse/O11Y-1066) - While testing out dashboards as code with our new datasources, I realized we assume prometheus type. Since we will have prometheus + victoria metrics during our transition to victoria, we should support returning type when building dashboards. 

* Include Type, Id in fields returned from the datasource API query to grafana. 
* Add test for datasource. 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->


[O11Y-1066]: https://smartcontract-it.atlassian.net/browse/O11Y-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[O11Y-1066]: https://smartcontract-it.atlassian.net/browse/O11Y-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ