### PR TITLE
O11Y-1068 - add observability team to codeowners for observability-lib

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 
 * @smartcontractkit/foundations
 
-/observability-lib/ @Atrax1
+/observability-lib/ @Atrax1 @smartcontractkit/observability
 
 /pkg/capabilities/ @smartcontractkit/keystone @smartcontractkit/capabilities-team
 /pkg/codec/ @smartcontractkit/bix-framework @smartcontractkit/foundations @nolag 


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message

--> 
Since the observability team is going to be leveraging this library for dashboards as code, we are adding ourselves to the owners along with @Atrax1

[O11Y-1068](https://smartcontract-it.atlassian.net/browse/O11Y-1068)

