### PR TITLE
add chip ingress auth

### DIFF
--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -2,7 +2,6 @@ package beholder
 
 import (
 	"context"
-	"crypto"
 	"errors"
 	"fmt"
 	"time"
@@ -214,7 +213,7 @@ func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (*Client, erro
 	if cfg.ChipIngressEmitterEnabled {
 
 		// Generate auth headers if they don't exist yet
-		if len(cfg.AuthHeaders) == 0 && cfg.AuthPrivateKey != nil {
+		if len(cfg.AuthHeaders) == 0 && cfg.'AuthPrivateKey' != nil {
 			var err error
 			cfg.AuthHeaders, err = NewAuthHeaders(cfg.AuthPrivateKey)
 			if err != nil {

--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -211,7 +211,7 @@ func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (*Client, erro
 	// eventually we will remove the dual source emitter and just use chip ingress
 	if cfg.ChipIngressEmitterEnabled {
 		chipIngressOpts := []chipingress.Opt{
-			chipingress.WithTransportCredentials(insecure.NewCredentials()),
+			chipingress.WithTransportCredentials(creds),
 		}
 		
 		// Only add headers if they exist

--- a/pkg/beholder/config.go
+++ b/pkg/beholder/config.go
@@ -1,7 +1,6 @@
 package beholder
 
 import (
-	"crypto"
 	"time"
 
 	otelattr "go.opentelemetry.io/otel/attribute"
@@ -50,7 +49,6 @@ type Config struct {
 
 	// Auth
 	AuthPublicKeyHex string
-	AuthPrivateKey   crypto.Signer
 	AuthHeaders      map[string]string
 }
 
@@ -114,8 +112,6 @@ func DefaultConfig() Config {
 		LogExportInterval:     1 * time.Second,
 		LogMaxQueueSize:       2048,
 		LogBatchProcessor:     true,
-		// Auth
-		AuthHeaders: make(map[string]string),
 	}
 }
 

--- a/pkg/beholder/config.go
+++ b/pkg/beholder/config.go
@@ -1,6 +1,7 @@
 package beholder
 
 import (
+	"crypto"
 	"time"
 
 	otelattr "go.opentelemetry.io/otel/attribute"
@@ -49,6 +50,7 @@ type Config struct {
 
 	// Auth
 	AuthPublicKeyHex string
+	AuthPrivateKey   crypto.Signer
 	AuthHeaders      map[string]string
 }
 
@@ -112,6 +114,8 @@ func DefaultConfig() Config {
 		LogExportInterval:     1 * time.Second,
 		LogMaxQueueSize:       2048,
 		LogBatchProcessor:     true,
+		// Auth
+		AuthHeaders: make(map[string]string),
 	}
 }
 

--- a/pkg/chipingress/client.go
+++ b/pkg/chipingress/client.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 
 	ceformat "github.com/cloudevents/sdk-go/binding/format/protobuf/v2"
 	cepb "github.com/cloudevents/sdk-go/binding/format/protobuf/v2/pb"
@@ -41,6 +42,7 @@ type Opt func(*chipIngressClientConfig)
 type chipIngressClientConfig struct {
 	log                  *zap.Logger
 	transportCredentials credentials.TransportCredentials
+	headers              map[string]string
 }
 
 // NewChipIngressClient creates a new client for the Chip Ingress service with optional configuration.
@@ -58,6 +60,17 @@ func NewChipIngressClient(address string, opts ...Opt) (ChipIngressClient, error
 
 	grpcOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(cfg.transportCredentials),
+	}
+
+	// Add headers as a unary interceptor
+	if len(cfg.headers) > 0 {
+		grpcOpts = append(grpcOpts, grpc.WithUnaryInterceptor(
+			func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+				for k, v := range cfg.headers {
+					ctx = metadata.AppendToOutgoingContext(ctx, k, v)
+				}
+				return invoker(ctx, method, req, reply, cc, opts...)
+			}))
 	}
 
 	conn, err := grpc.NewClient(
@@ -153,6 +166,7 @@ func defaultConfig() chipIngressClientConfig {
 	return chipIngressClientConfig{
 		log:                  zap.NewNop(),
 		transportCredentials: insecure.NewCredentials(),
+		headers:              make(map[string]string),
 	}
 }
 
@@ -167,6 +181,13 @@ func WithLogger(logger *zap.Logger) Opt {
 func WithTransportCredentials(credentials credentials.TransportCredentials) Opt {
 	return func(c *chipIngressClientConfig) {
 		c.transportCredentials = credentials
+	}
+}
+
+// WithHeaders sets the headers for requests to the ChipIngress service.
+func WithHeaders(headers map[string]string) Opt {
+	return func(c *chipIngressClientConfig) {
+		c.headers = headers
 	}
 }
 

--- a/pkg/chipingress/client.go
+++ b/pkg/chipingress/client.go
@@ -166,7 +166,6 @@ func defaultConfig() chipIngressClientConfig {
 	return chipIngressClientConfig{
 		log:                  zap.NewNop(),
 		transportCredentials: insecure.NewCredentials(),
-		headers:              make(map[string]string),
 	}
 }
 


### PR DESCRIPTION
[INFOPLAT-2206](https://smartcontract-it.atlassian.net/jira/software/c/projects/INFOPLAT/boards/260/backlog?assignee=642b4f570d37b222f9f00316&selectedIssue=INFOPLAT-2206)

- adds csa auth to chipingress in the beholder client

### Requires
N/A
### Supports
N/A


[INFOPLAT-2206]: https://smartcontract-it.atlassian.net/browse/INFOPLAT-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ