### PR TITLE
fix: fix the problem of call of Unmarshal passes non-pointer as secon…

### DIFF
--- a/pkg/loop/internal/reportingplugin/median/median.go
+++ b/pkg/loop/internal/reportingplugin/median/median.go
@@ -173,7 +173,8 @@ func (m *pluginMedianServer) NewMedianFactory(ctx context.Context, request *pb.N
 
 	var deviationFuncDefinition map[string]any
 	if len(request.DeviationFuncDefinition) > 0 {
-		if err = json.Unmarshal(request.DeviationFuncDefinition, deviationFuncDefinition); err != nil {
+		deviationFuncDefinition = make(map[string]any)
+		if err = json.Unmarshal(request.DeviationFuncDefinition, &deviationFuncDefinition); err != nil {
 			m.CloseAll(dsRes, juelsRes, gasPriceSubunitsRes, providerRes, errorLogRes)
 			return nil, fmt.Errorf("failed to unmarshal deviationFuncDefinition: %w", err)
 		}


### PR DESCRIPTION
The second argument must be a pointer type, otherwise it won't work as intended.


### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
