### PR TITLE
Rename codeowner team from realtime->data-tooling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,5 +15,5 @@
 /pkg/values/ @smartcontractkit/keystone @smartcontractkit/capabilities-team
 /pkg/workflows/ @smartcontractkit/keystone
 /pkg/beholder/ @smartcontractkit/data-tooling
-/pkg/types/ccipocr3 @smartcontractkit/ccip-offchain
+`/pkg/types/ccipocr3 @smartcontractkit/ccip-offchain
 /pkg/types/ccip @smartcontractkit/ccip-offchain

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 * @smartcontractkit/foundations
 
-/pkg/beholder/ @smartcontractkit/realtime
+/pkg/beholder/ @smartcontractkit/data-tooling
 /pkg/capabilities/ @smartcontractkit/keystone @smartcontractkit/capabilities-team
 /pkg/codec/ @smartcontractkit/bix-framework @smartcontractkit/foundations
 /pkg/loop/cmd/loopinstall @smartcontractkit/devex-cicd
@@ -14,4 +14,3 @@
 /pkg/types/ccipocr3 @smartcontractkit/ccip-offchain
 /pkg/values/ @smartcontractkit/keystone @smartcontractkit/capabilities-team
 /pkg/workflows/ @smartcontractkit/keystone
-/pkg/beholder/ @smartcontractkit/data-tooling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,6 @@
 /pkg/types/ccipocr3 @smartcontractkit/ccip-offchain
 /pkg/values/ @smartcontractkit/keystone @smartcontractkit/capabilities-team
 /pkg/workflows/ @smartcontractkit/keystone
+/pkg/beholder/ @smartcontractkit/data-tooling
+/pkg/types/ccipocr3 @smartcontractkit/ccip-offchain
+/pkg/types/ccip @smartcontractkit/ccip-offchain

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,5 +15,3 @@
 /pkg/values/ @smartcontractkit/keystone @smartcontractkit/capabilities-team
 /pkg/workflows/ @smartcontractkit/keystone
 /pkg/beholder/ @smartcontractkit/data-tooling
-`/pkg/types/ccipocr3 @smartcontractkit/ccip-offchain
-/pkg/types/ccip @smartcontractkit/ccip-offchain


### PR DESCRIPTION
Rename teams after restructuring

### Requires
N/A

### Supports
N/A
