### PR TITLE
CapabilityExecutor interface for Module/Host

### DIFF
--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -115,7 +115,8 @@ type CapabilityRequest struct {
 	ConfigPayload *anypb.Any
 
 	// The method to call for no DAG workflows
-	Method string
+	Method       string
+	CapabilityId string
 }
 
 type RegisterToWorkflowRequest struct {

--- a/pkg/capabilities/pb/capabilities.pb.go
+++ b/pkg/capabilities/pb/capabilities.pb.go
@@ -272,6 +272,7 @@ type CapabilityRequest struct {
 	ConfigPayload *anypb.Any `protobuf:"bytes,5,opt,name=configPayload,proto3" json:"configPayload,omitempty"`
 	// Used for no DAG SDK
 	Method        string `protobuf:"bytes,6,opt,name=method,proto3" json:"method,omitempty"`
+	CapabilityId  string `protobuf:"bytes,7,opt,name=capabilityId,proto3" json:"capabilityId,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -344,6 +345,13 @@ func (x *CapabilityRequest) GetConfigPayload() *anypb.Any {
 func (x *CapabilityRequest) GetMethod() string {
 	if x != nil {
 		return x.Method
+	}
+	return ""
+}
+
+func (x *CapabilityRequest) GetCapabilityId() string {
+	if x != nil {
+		return x.CapabilityId
 	}
 	return ""
 }
@@ -1082,14 +1090,15 @@ const file_capabilities_pb_capabilities_proto_rawDesc = "" +
 	"\x0fworkflow_don_id\x18\x06 \x01(\rR\rworkflowDonId\x12=\n" +
 	"\x1bworkflow_don_config_version\x18\a \x01(\rR\x18workflowDonConfigVersion\x12!\n" +
 	"\freference_id\x18\b \x01(\tR\vreferenceId\x122\n" +
-	"\x15decoded_workflow_name\x18\t \x01(\tR\x13decodedWorkflowNameJ\x04\b\x05\x10\x06\"\x9c\x02\n" +
+	"\x15decoded_workflow_name\x18\t \x01(\tR\x13decodedWorkflowNameJ\x04\b\x05\x10\x06\"\xc0\x02\n" +
 	"\x11CapabilityRequest\x129\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x1d.capabilities.RequestMetadataR\bmetadata\x12#\n" +
 	"\x06config\x18\x02 \x01(\v2\v.values.MapR\x06config\x12#\n" +
 	"\x06inputs\x18\x03 \x01(\v2\v.values.MapR\x06inputs\x12.\n" +
 	"\apayload\x18\x04 \x01(\v2\x14.google.protobuf.AnyR\apayload\x12:\n" +
 	"\rconfigPayload\x18\x05 \x01(\v2\x14.google.protobuf.AnyR\rconfigPayload\x12\x16\n" +
-	"\x06method\x18\x06 \x01(\tR\x06method\"\xe2\x01\n" +
+	"\x06method\x18\x06 \x01(\tR\x06method\x12\"\n" +
+	"\fcapabilityId\x18\a \x01(\tR\fcapabilityId\"\xe2\x01\n" +
 	"\x1aTriggerRegistrationRequest\x12\x1c\n" +
 	"\ttriggerId\x18\x01 \x01(\tR\ttriggerId\x129\n" +
 	"\bmetadata\x18\x02 \x01(\v2\x1d.capabilities.RequestMetadataR\bmetadata\x12#\n" +

--- a/pkg/capabilities/pb/capabilities.proto
+++ b/pkg/capabilities/pb/capabilities.proto
@@ -55,6 +55,7 @@ message CapabilityRequest {
   google.protobuf.Any configPayload = 5;
   // Used for no DAG SDK
   string method = 6;
+  string capabilityId = 7;
 }
 
 message TriggerRegistrationRequest {

--- a/pkg/capabilities/pb/capabilities_helpers.go
+++ b/pkg/capabilities/pb/capabilities_helpers.go
@@ -68,6 +68,7 @@ func CapabilityRequestToProto(req capabilities.CapabilityRequest) *CapabilityReq
 		Config:        values.ProtoMap(config),
 		Payload:       req.Payload,
 		Method:        req.Method,
+		CapabilityId:  req.CapabilityId,
 		ConfigPayload: req.ConfigPayload,
 	}
 }
@@ -126,6 +127,7 @@ func CapabilityRequestFromProto(pr *CapabilityRequest) (capabilities.CapabilityR
 		Inputs:        inputs,
 		Payload:       pr.Payload,
 		Method:        pr.Method,
+		CapabilityId:  pr.CapabilityId,
 		ConfigPayload: pr.ConfigPayload,
 	}
 	return req, nil

--- a/pkg/capabilities/pb/capabilities_helpers_test.go
+++ b/pkg/capabilities/pb/capabilities_helpers_test.go
@@ -104,6 +104,8 @@ func TestMarshalUnmarshalRequest(t *testing.T) {
 			TypeUrl: "example.com/type",
 			Value:   []byte("any-bytes"),
 		},
+		Method:       "call-it",
+		CapabilityId: "test-capability-id",
 	}
 
 	raw, err := pb.MarshalCapabilityRequest(req)

--- a/pkg/workflows/wasm/host/mocks/module_v2.go
+++ b/pkg/workflows/wasm/host/mocks/module_v2.go
@@ -5,6 +5,7 @@ package mocks
 import (
 	context "context"
 
+	host "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 	mock "github.com/stretchr/testify/mock"
 
 	pb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/v2/pb"
@@ -155,6 +156,52 @@ func (_c *ModuleV2_IsLegacyDAG_Call) Return(_a0 bool) *ModuleV2_IsLegacyDAG_Call
 }
 
 func (_c *ModuleV2_IsLegacyDAG_Call) RunAndReturn(run func() bool) *ModuleV2_IsLegacyDAG_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetCapabilityExecutor provides a mock function with given fields: handler
+func (_m *ModuleV2) SetCapabilityExecutor(handler host.CapabilityExecutor) error {
+	ret := _m.Called(handler)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetCapabilityExecutor")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(host.CapabilityExecutor) error); ok {
+		r0 = rf(handler)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ModuleV2_SetCapabilityExecutor_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetCapabilityExecutor'
+type ModuleV2_SetCapabilityExecutor_Call struct {
+	*mock.Call
+}
+
+// SetCapabilityExecutor is a helper method to define mock.On call
+//   - handler host.CapabilityExecutor
+func (_e *ModuleV2_Expecter) SetCapabilityExecutor(handler interface{}) *ModuleV2_SetCapabilityExecutor_Call {
+	return &ModuleV2_SetCapabilityExecutor_Call{Call: _e.mock.On("SetCapabilityExecutor", handler)}
+}
+
+func (_c *ModuleV2_SetCapabilityExecutor_Call) Run(run func(handler host.CapabilityExecutor)) *ModuleV2_SetCapabilityExecutor_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(host.CapabilityExecutor))
+	})
+	return _c
+}
+
+func (_c *ModuleV2_SetCapabilityExecutor_Call) Return(_a0 error) *ModuleV2_SetCapabilityExecutor_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ModuleV2_SetCapabilityExecutor_Call) RunAndReturn(run func(host.CapabilityExecutor) error) *ModuleV2_SetCapabilityExecutor_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bytecodealliance/wasmtime-go/v28"
 	"google.golang.org/protobuf/proto"
 
+	cappb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
@@ -133,6 +134,13 @@ type ModuleV2 interface {
 
 	// V2/"NoDAG" API - request either the list of Trigger Subscriptions or launch workflow execution
 	Execute(ctx context.Context, request *wasmpb.ExecuteRequest) (*wasmpb.ExecutionResult, error)
+	SetCapabilityExecutor(handler CapabilityExecutor) error
+}
+
+// Implemented by the Engine
+type CapabilityExecutor interface {
+	// blocking call to the Engine
+	CallCapability(ctx context.Context, request *cappb.CapabilityRequest) (*cappb.CapabilityResponse, error)
 }
 
 type module struct {
@@ -569,6 +577,10 @@ func runWasm[I idMessage, O proto.Message](
 	default:
 		return o, err
 	}
+}
+
+func (m *module) SetCapabilityExecutor(handler CapabilityExecutor) error {
+	return errors.New("not implemented")
 }
 
 func containsCode(err error, code int) bool {


### PR DESCRIPTION
Also adding a new field: CapabilityRequest.CapabilityId, which is now needed to be passed to the Engine.