### PR TITLE
chore: adds unit tests and clearer error message on failure

### DIFF
--- a/pkg/capabilities/utils_test.go
+++ b/pkg/capabilities/utils_test.go
@@ -43,6 +43,22 @@ func TestFromValueOrAny(t *testing.T) {
 		var out pb.TriggerEvent
 		_, err := capabilities.FromValueOrAny(nil, nil, &out)
 		require.Error(t, err)
+		require.ErrorIs(t, err, capabilities.ErrNeitherValueNorAny)
+	})
+
+	t.Run("with nil map", func(t *testing.T) {
+		var out pb.TriggerEvent
+		req := capabilities.TriggerRegistrationRequest{}
+		_, err := capabilities.FromValueOrAny(req.Config, req.Payload, &out)
+		require.Error(t, err)
+		require.ErrorIs(t, err, capabilities.ErrNeitherValueNorAny)
+	})
+
+	t.Run("with nil any other values", func(t *testing.T) {
+		var out pb.TriggerEvent
+		_, err := capabilities.FromValueOrAny(new(values.Int64), nil, &out)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to transform value to proto")
 	})
 
 	t.Run("emptybp works", func(t *testing.T) {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

passing a nil concrete type to the transform did not previously return the expected error.  this PR names the expected error, checks for the case of a nil `*values.Map` and adds context to the error in other failure modes.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
