### PR TITLE
fix(capabilities): handle nil capability registry in generated server wrapper

### DIFF
--- a/pkg/capabilities/v2/consensus/server/consensus_server_gen.go
+++ b/pkg/capabilities/v2/consensus/server/consensus_server_gen.go
@@ -61,8 +61,11 @@ func (cs *ConsensusServer) Initialise(ctx context.Context, config string, teleme
 func (cs *ConsensusServer) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := cs.capabilityRegistry.Remove(ctx, "offchain_reporting@1.0.0"); err != nil {
-		return err
+
+	if cs.capabilityRegistry != nil {
+		if err := cs.capabilityRegistry.Remove(ctx, "offchain_reporting@1.0.0"); err != nil {
+			return err
+		}
 	}
 
 	return cs.consensusCapability.Close()

--- a/pkg/capabilities/v2/protoc/pkg/templates/server.go.tmpl
+++ b/pkg/capabilities/v2/protoc/pkg/templates/server.go.tmpl
@@ -83,9 +83,12 @@ func (cs *{{.GoName}}Server) Initialise(ctx context.Context, config string, tele
 func (cs *{{.GoName}}Server) Close() error{
     ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-    if err := cs.capabilityRegistry.Remove(ctx, "{{(CapabilityId $service)}}"); err != nil {
-		return err
-	}
+
+    if cs.capabilityRegistry != nil {
+        if err := cs.capabilityRegistry.Remove(ctx, "{{(CapabilityId $service)}}"); err != nil {
+            return err
+        }
+    }
 
 	return cs.{{.GoName|LowerFirst}}Capability.Close()
 }

--- a/pkg/capabilities/v2/protoc/pkg/test_capabilities/actionandtrigger/server/action_and_trigger_server_gen.go
+++ b/pkg/capabilities/v2/protoc/pkg/test_capabilities/actionandtrigger/server/action_and_trigger_server_gen.go
@@ -63,8 +63,11 @@ func (cs *BasicServer) Initialise(ctx context.Context, config string, telemetryS
 func (cs *BasicServer) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := cs.capabilityRegistry.Remove(ctx, "basic-test-action-trigger@1.0.0"); err != nil {
-		return err
+
+	if cs.capabilityRegistry != nil {
+		if err := cs.capabilityRegistry.Remove(ctx, "basic-test-action-trigger@1.0.0"); err != nil {
+			return err
+		}
 	}
 
 	return cs.basicCapability.Close()

--- a/pkg/capabilities/v2/protoc/pkg/test_capabilities/basicaction/server/basic_action_server_gen.go
+++ b/pkg/capabilities/v2/protoc/pkg/test_capabilities/basicaction/server/basic_action_server_gen.go
@@ -60,8 +60,11 @@ func (cs *BasicActionServer) Initialise(ctx context.Context, config string, tele
 func (cs *BasicActionServer) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := cs.capabilityRegistry.Remove(ctx, "basic-test-action@1.0.0"); err != nil {
-		return err
+
+	if cs.capabilityRegistry != nil {
+		if err := cs.capabilityRegistry.Remove(ctx, "basic-test-action@1.0.0"); err != nil {
+			return err
+		}
 	}
 
 	return cs.basicActionCapability.Close()

--- a/pkg/capabilities/v2/protoc/pkg/test_capabilities/basictrigger/server/basic_trigger_server_gen.go
+++ b/pkg/capabilities/v2/protoc/pkg/test_capabilities/basictrigger/server/basic_trigger_server_gen.go
@@ -61,8 +61,11 @@ func (cs *BasicServer) Initialise(ctx context.Context, config string, telemetryS
 func (cs *BasicServer) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := cs.capabilityRegistry.Remove(ctx, "basic-test-trigger@1.0.0"); err != nil {
-		return err
+
+	if cs.capabilityRegistry != nil {
+		if err := cs.capabilityRegistry.Remove(ctx, "basic-test-trigger@1.0.0"); err != nil {
+			return err
+		}
 	}
 
 	return cs.basicCapability.Close()

--- a/pkg/capabilities/v2/protoc/pkg/test_capabilities/mismatched/server/mismatched_server_gen.go
+++ b/pkg/capabilities/v2/protoc/pkg/test_capabilities/mismatched/server/mismatched_server_gen.go
@@ -60,8 +60,11 @@ func (cs *MismatchedServer) Initialise(ctx context.Context, config string, telem
 func (cs *MismatchedServer) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := cs.capabilityRegistry.Remove(ctx, "example@1.0.0"); err != nil {
-		return err
+
+	if cs.capabilityRegistry != nil {
+		if err := cs.capabilityRegistry.Remove(ctx, "example@1.0.0"); err != nil {
+			return err
+		}
 	}
 
 	return cs.mismatchedCapability.Close()

--- a/pkg/capabilities/v2/protoc/pkg/test_capabilities/nodeaction/server/node_action_server_gen.go
+++ b/pkg/capabilities/v2/protoc/pkg/test_capabilities/nodeaction/server/node_action_server_gen.go
@@ -60,8 +60,11 @@ func (cs *BasicActionServer) Initialise(ctx context.Context, config string, tele
 func (cs *BasicActionServer) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := cs.capabilityRegistry.Remove(ctx, "basic-test-node-action@1.0.0"); err != nil {
-		return err
+
+	if cs.capabilityRegistry != nil {
+		if err := cs.capabilityRegistry.Remove(ctx, "basic-test-node-action@1.0.0"); err != nil {
+			return err
+		}
 	}
 
 	return cs.basicActionCapability.Close()

--- a/pkg/capabilities/v2/protoc/pkg/test_capabilities/nodetrigger/server/node_trigger_server_gen.go
+++ b/pkg/capabilities/v2/protoc/pkg/test_capabilities/nodetrigger/server/node_trigger_server_gen.go
@@ -61,8 +61,11 @@ func (cs *NodeEventServer) Initialise(ctx context.Context, config string, teleme
 func (cs *NodeEventServer) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := cs.capabilityRegistry.Remove(ctx, "basic-test-node-trigger@1.0.0"); err != nil {
-		return err
+
+	if cs.capabilityRegistry != nil {
+		if err := cs.capabilityRegistry.Remove(ctx, "basic-test-node-trigger@1.0.0"); err != nil {
+			return err
+		}
 	}
 
 	return cs.nodeEventCapability.Close()

--- a/pkg/capabilities/v2/triggers/cron/server/cron_trigger_server_gen.go
+++ b/pkg/capabilities/v2/triggers/cron/server/cron_trigger_server_gen.go
@@ -61,8 +61,11 @@ func (cs *CronServer) Initialise(ctx context.Context, config string, telemetrySe
 func (cs *CronServer) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := cs.capabilityRegistry.Remove(ctx, "cron-trigger@1.0.0"); err != nil {
-		return err
+
+	if cs.capabilityRegistry != nil {
+		if err := cs.capabilityRegistry.Remove(ctx, "cron-trigger@1.0.0"); err != nil {
+			return err
+		}
 	}
 
 	return cs.cronCapability.Close()


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

it is possible to create a New*Server without a capability registry and also to use the server without calling `Initialize`.  this adds a `nil` check to avoid panic on server shutdown.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
