### PR TITLE
fix(capabilities): enable long running trigger response transform

### DIFF
--- a/pkg/capabilities/utils_test.go
+++ b/pkg/capabilities/utils_test.go
@@ -2,6 +2,7 @@ package capabilities_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -196,34 +197,219 @@ func TestExecute(t *testing.T) {
 }
 
 func TestRegisterTrigger(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// Validate that if context is not canceled and stop remains open that
+	// all sent events are received and transformed.
+	t.Run("OK channel drained before context cancels", func(t *testing.T) {
+		ctx := t.Context()
+		stop := make(chan struct{})
+		t.Cleanup(func() { close(stop) })
 
-	a, err := anypb.New(&pb.TriggerEvent{Id: "reg"})
-	require.NoError(t, err)
-	req := capabilities.TriggerRegistrationRequest{
-		Metadata: capabilities.RequestMetadata{WorkflowID: "workflow-id"},
-		Payload:  a,
-	}
+		a, err := anypb.New(&pb.TriggerEvent{Id: "reg"})
+		require.NoError(t, err)
+		req := capabilities.TriggerRegistrationRequest{
+			Metadata: capabilities.RequestMetadata{WorkflowID: "workflow-id"},
+			Payload:  a,
+		}
 
-	respCh, err := capabilities.RegisterTrigger[*pb.TriggerEvent, *pb.TriggerEvent](
-		ctx,
-		"type",
-		req,
-		&pb.TriggerEvent{},
-		func(_ context.Context, triggerID string, m capabilities.RequestMetadata, r *pb.TriggerEvent) (<-chan capabilities.TriggerAndId[*pb.TriggerEvent], error) {
-			ch := make(chan capabilities.TriggerAndId[*pb.TriggerEvent], 1)
-			ch <- capabilities.TriggerAndId[*pb.TriggerEvent]{
-				Trigger: &pb.TriggerEvent{Id: "id"},
-				Id:      "trigger-id",
+		wantEvents := 50
+		eventCh := make(chan capabilities.TriggerAndId[*pb.TriggerEvent])
+
+		go func() {
+			defer close(eventCh)
+			for i := range wantEvents {
+				select {
+				case eventCh <- capabilities.TriggerAndId[*pb.TriggerEvent]{
+					Trigger: &pb.TriggerEvent{Id: fmt.Sprintf("id-%d", i+1)},
+					Id:      "trigger-id",
+				}:
+				case <-ctx.Done():
+					return
+				}
 			}
-			assert.Equal(t, "workflow-id", m.WorkflowID)
-			assert.Equal(t, "reg", r.Id)
-			return ch, nil
-		},
-	)
-	require.NoError(t, err)
-	resp := <-respCh
-	assert.Equal(t, "trigger-id", resp.Event.ID)
-	assert.Equal(t, "type", resp.Event.TriggerType)
+		}()
+
+		respCh, err := capabilities.RegisterTrigger(
+			ctx,
+			stop,
+			"type",
+			req,
+			&pb.TriggerEvent{},
+			func(_ context.Context, triggerID string, m capabilities.RequestMetadata, r *pb.TriggerEvent) (<-chan capabilities.TriggerAndId[*pb.TriggerEvent], error) {
+				assert.Equal(t, "workflow-id", m.WorkflowID)
+				assert.Equal(t, "reg", r.Id)
+				return eventCh, nil
+			},
+		)
+		require.NoError(t, err)
+
+		gotEvents := 0
+		for resp := range respCh {
+			gotEvents++
+
+			assert.Equal(t, "trigger-id", resp.Event.ID)
+			assert.Equal(t, "type", resp.Event.TriggerType)
+
+			var gotTrigger pb.TriggerEvent
+			require.NoError(t, resp.Event.Payload.UnmarshalTo(&gotTrigger))
+			require.Equal(t, fmt.Sprintf("id-%d", gotEvents), gotTrigger.Id)
+		}
+		require.Equal(t, wantEvents, gotEvents, fmt.Sprintf("expected %d events, got %d", wantEvents, gotEvents))
+	})
+
+	// Validate that if the original context is canceled, all events are sent
+	// and transformed because the stop channel remains open.
+	t.Run("OK context canceled stop channel open and source channel drained", func(t *testing.T) {
+		// Cancel the context immediately
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		stop := make(chan struct{})
+		t.Cleanup(func() { close(stop) })
+
+		wantEvents := 50
+
+		a, err := anypb.New(&pb.TriggerEvent{Id: "reg"})
+		require.NoError(t, err)
+		req := capabilities.TriggerRegistrationRequest{
+			Metadata: capabilities.RequestMetadata{WorkflowID: "workflow-id"},
+			Payload:  a,
+		}
+
+		eventCh := make(chan capabilities.TriggerAndId[*pb.TriggerEvent])
+		go func() {
+			defer close(eventCh)
+			for i := range wantEvents {
+				select {
+				case eventCh <- capabilities.TriggerAndId[*pb.TriggerEvent]{
+					Trigger: &pb.TriggerEvent{Id: fmt.Sprintf("id-%d", i+1)},
+					Id:      "trigger-id",
+				}:
+				case <-t.Context().Done():
+					return
+				}
+			}
+		}()
+
+		respCh, err := capabilities.RegisterTrigger(
+			ctx,
+			stop,
+			"type",
+			req,
+			&pb.TriggerEvent{},
+			func(_ context.Context, triggerID string, m capabilities.RequestMetadata, r *pb.TriggerEvent) (<-chan capabilities.TriggerAndId[*pb.TriggerEvent], error) {
+				assert.Equal(t, "workflow-id", m.WorkflowID)
+				assert.Equal(t, "reg", r.Id)
+				return eventCh, nil
+			},
+		)
+		require.NoError(t, err)
+
+		gotEvents := 0
+		for resp := range respCh {
+			gotEvents++
+
+			assert.Equal(t, "trigger-id", resp.Event.ID)
+			assert.Equal(t, "type", resp.Event.TriggerType)
+
+			var gotTrigger pb.TriggerEvent
+			require.NoError(t, resp.Event.Payload.UnmarshalTo(&gotTrigger))
+			require.Equal(t, fmt.Sprintf("id-%d", gotEvents), gotTrigger.Id)
+		}
+		require.Equal(t, wantEvents, gotEvents, fmt.Sprintf("expected %d events, got %d", wantEvents, gotEvents))
+	})
+
+	// Validate that if the context is canceled while calling the passed function
+	// that the error is returned.
+	t.Run("NOK context cancels when calling fn", func(t *testing.T) {
+		// Cancel the context immediately
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		stop := make(chan struct{})
+		t.Cleanup(func() { close(stop) })
+
+		a, err := anypb.New(&pb.TriggerEvent{Id: "reg"})
+		require.NoError(t, err)
+		req := capabilities.TriggerRegistrationRequest{
+			Metadata: capabilities.RequestMetadata{WorkflowID: "workflow-id"},
+			Payload:  a,
+		}
+
+		_, err = capabilities.RegisterTrigger(
+			ctx,
+			stop,
+			"type",
+			req,
+			&pb.TriggerEvent{},
+			func(ctx context.Context, triggerID string, m capabilities.RequestMetadata, r *pb.TriggerEvent) (<-chan capabilities.TriggerAndId[*pb.TriggerEvent], error) {
+				return nil, ctx.Err()
+			},
+		)
+		require.Error(t, err)
+	})
+
+	// Validate that closing the stop channel prevents all events from being
+	// sent.
+	t.Run("OK stop prevents draining channel", func(t *testing.T) {
+		ctx := t.Context()
+
+		sentEvents := 50
+		wantEvents := 10
+		stop := make(chan struct{})
+
+		a, err := anypb.New(&pb.TriggerEvent{Id: "reg"})
+		require.NoError(t, err)
+		req := capabilities.TriggerRegistrationRequest{
+			Metadata: capabilities.RequestMetadata{WorkflowID: "workflow-id"},
+			Payload:  a,
+		}
+
+		eventCh := make(chan capabilities.TriggerAndId[*pb.TriggerEvent])
+
+		go func() {
+			defer close(eventCh)
+			for i := range sentEvents {
+				select {
+				case eventCh <- capabilities.TriggerAndId[*pb.TriggerEvent]{
+					Trigger: &pb.TriggerEvent{Id: fmt.Sprintf("id-%d", i+1)},
+					Id:      "trigger-id",
+				}:
+				case <-t.Context().Done():
+					return
+				}
+			}
+		}()
+
+		respCh, err := capabilities.RegisterTrigger(
+			ctx,
+			stop,
+			"type",
+			req,
+			&pb.TriggerEvent{},
+			func(ctx context.Context, triggerID string, m capabilities.RequestMetadata, r *pb.TriggerEvent) (<-chan capabilities.TriggerAndId[*pb.TriggerEvent], error) {
+				assert.Equal(t, "workflow-id", m.WorkflowID)
+				assert.Equal(t, "reg", r.Id)
+				return eventCh, ctx.Err()
+			},
+		)
+		require.NoError(t, err)
+
+		gotEvents := 0
+		for resp := range respCh {
+			gotEvents++
+
+			// close the stop channel to cancel transforming
+			if gotEvents == wantEvents {
+				close(stop)
+			}
+
+			assert.Equal(t, "trigger-id", resp.Event.ID)
+			assert.Equal(t, "type", resp.Event.TriggerType)
+
+			var gotTrigger pb.TriggerEvent
+			require.NoError(t, resp.Event.Payload.UnmarshalTo(&gotTrigger))
+			require.Equal(t, fmt.Sprintf("id-%d", gotEvents), gotTrigger.Id)
+		}
+		require.Equal(t, wantEvents, gotEvents, fmt.Sprintf("expected %d events, got %d", wantEvents, gotEvents))
+	})
 }

--- a/pkg/capabilities/v2/consensus/server/consensus_server_gen.go
+++ b/pkg/capabilities/v2/consensus/server/consensus_server_gen.go
@@ -32,14 +32,17 @@ type ConsensusCapability interface {
 }
 
 func NewConsensusServer(capability ConsensusCapability) *ConsensusServer {
+	stopCh := make(chan struct{})
 	return &ConsensusServer{
-		consensusCapability: consensusCapability{ConsensusCapability: capability},
+		consensusCapability: consensusCapability{ConsensusCapability: capability, stopCh: stopCh},
+		stopCh:              stopCh,
 	}
 }
 
 type ConsensusServer struct {
 	consensusCapability
 	capabilityRegistry core.CapabilitiesRegistry
+	stopCh             chan struct{}
 }
 
 func (cs *ConsensusServer) Initialise(ctx context.Context, config string, telemetryService core.TelemetryService, store core.KeyValueStore, capabilityRegistry core.CapabilitiesRegistry, errorLog core.ErrorLog, pipelineRunner core.PipelineRunnerService, relayerSet core.RelayerSet, oracleFactory core.OracleFactory) error {
@@ -68,6 +71,10 @@ func (cs *ConsensusServer) Close() error {
 		}
 	}
 
+	if cs.stopCh != nil {
+		close(cs.stopCh)
+	}
+
 	return cs.consensusCapability.Close()
 }
 
@@ -81,6 +88,7 @@ func (cs *ConsensusServer) Infos(ctx context.Context) ([]capabilities.Capability
 
 type consensusCapability struct {
 	ConsensusCapability
+	stopCh chan struct{}
 }
 
 func (c *consensusCapability) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {

--- a/pkg/capabilities/v2/protoc/pkg/templates/server.go.tmpl
+++ b/pkg/capabilities/v2/protoc/pkg/templates/server.go.tmpl
@@ -53,14 +53,17 @@ type {{.GoName}}Capability interface {
 }
 
 func New{{.GoName}}Server(capability {{.GoName}}Capability) *{{.GoName}}Server {
+    stopCh := make(chan struct{})
     return &{{.GoName}}Server{
-        {{.GoName|LowerFirst}}Capability:   {{.GoName|LowerFirst}}Capability{ {{.GoName}}Capability: capability},
+        {{.GoName|LowerFirst}}Capability:   {{.GoName|LowerFirst}}Capability{ {{.GoName}}Capability: capability, stopCh: stopCh},
+        stopCh: stopCh,
     }
 }
 
 type {{.GoName}}Server struct {
     {{.GoName|LowerFirst}}Capability
     capabilityRegistry core.CapabilitiesRegistry
+    stopCh chan struct{}
 }
 
 
@@ -90,6 +93,10 @@ func (cs *{{.GoName}}Server) Close() error{
         }
     }
 
+    if cs.stopCh != nil {
+        close(cs.stopCh)
+    }
+
 	return cs.{{.GoName|LowerFirst}}Capability.Close()
 }
 
@@ -104,6 +111,7 @@ func (cs *{{.GoName}}Server) Infos(ctx context.Context) ([]capabilities.Capabili
 
 type {{.GoName|LowerFirst}}Capability struct {
     {{.GoName}}Capability
+    stopCh chan struct{}
 }
 
 func (c *{{.GoName|LowerFirst}}Capability) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {
@@ -121,12 +129,12 @@ func (c *{{.GoName|LowerFirst}}Capability) RegisterTrigger(ctx context.Context, 
         {{- if (isTrigger .) }}
             case "{{.GoName}}":
                 input := &{{name .Input.GoIdent ""}}{}
-                return capabilities.RegisterTrigger(ctx, "{{(CapabilityId $service)}}", request, input, c.{{$service.GoName}}Capability.Register{{.GoName}})
+                return capabilities.RegisterTrigger(ctx, c.stopCh, "{{(CapabilityId $service)}}", request, input, c.{{$service.GoName}}Capability.Register{{.GoName}})
         {{- end }}
         {{- if (MapToUntypedAPI .) }}
             case "":
                 input := &{{name .Input.GoIdent ""}}{}
-                return capabilities.RegisterTrigger(ctx, "{{(CapabilityId $service)}}", request, input, c.{{$service.GoName}}Capability.Register{{.GoName}})
+                return capabilities.RegisterTrigger(ctx, c.stopCh, "{{(CapabilityId $service)}}", request, input, c.{{$service.GoName}}Capability.Register{{.GoName}})
         {{- end }}
         {{- end }}
         	default:

--- a/pkg/capabilities/v2/protoc/pkg/test_capabilities/basictrigger/server/basic_trigger_server_gen.go
+++ b/pkg/capabilities/v2/protoc/pkg/test_capabilities/basictrigger/server/basic_trigger_server_gen.go
@@ -32,14 +32,17 @@ type BasicCapability interface {
 }
 
 func NewBasicServer(capability BasicCapability) *BasicServer {
+	stopCh := make(chan struct{})
 	return &BasicServer{
-		basicCapability: basicCapability{BasicCapability: capability},
+		basicCapability: basicCapability{BasicCapability: capability, stopCh: stopCh},
+		stopCh:          stopCh,
 	}
 }
 
 type BasicServer struct {
 	basicCapability
 	capabilityRegistry core.CapabilitiesRegistry
+	stopCh             chan struct{}
 }
 
 func (cs *BasicServer) Initialise(ctx context.Context, config string, telemetryService core.TelemetryService, store core.KeyValueStore, capabilityRegistry core.CapabilitiesRegistry, errorLog core.ErrorLog, pipelineRunner core.PipelineRunnerService, relayerSet core.RelayerSet, oracleFactory core.OracleFactory) error {
@@ -68,6 +71,10 @@ func (cs *BasicServer) Close() error {
 		}
 	}
 
+	if cs.stopCh != nil {
+		close(cs.stopCh)
+	}
+
 	return cs.basicCapability.Close()
 }
 
@@ -81,6 +88,7 @@ func (cs *BasicServer) Infos(ctx context.Context) ([]capabilities.CapabilityInfo
 
 type basicCapability struct {
 	BasicCapability
+	stopCh chan struct{}
 }
 
 func (c *basicCapability) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {
@@ -94,7 +102,7 @@ func (c *basicCapability) RegisterTrigger(ctx context.Context, request capabilit
 	switch request.Method {
 	case "Trigger":
 		input := &basictrigger.Config{}
-		return capabilities.RegisterTrigger(ctx, "basic-test-trigger@1.0.0", request, input, c.BasicCapability.RegisterTrigger)
+		return capabilities.RegisterTrigger(ctx, c.stopCh, "basic-test-trigger@1.0.0", request, input, c.BasicCapability.RegisterTrigger)
 	default:
 		return nil, fmt.Errorf("trigger %s not found", request.Method)
 	}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

The `RegisterTrigger` function calls the typed `RegisterTrigger` method of a capability and then consumes the returned source channel of trigger events and transforms it into a channel of `TriggerResponse` events.

There was a bug in the `RegisterTrigger` transform in that canceling the parent context also canceled the goroutine transforming the source channel.

This PR addresses the issue by separating the request context from the goroutine by passing a stop channel, which is closed when the server is shutdown.  Adds a stop channel to the generated server, which is closed when the server is closed.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
