### PR TITLE
Add ShowAllValues option to Gauge Panels

### DIFF
--- a/observability-lib/grafana/panels.go
+++ b/observability-lib/grafana/panels.go
@@ -440,8 +440,9 @@ func NewTimeSeriesPanel(options *TimeSeriesPanelOptions) *Panel {
 
 type BarGaugePanelOptions struct {
 	*PanelOptions
-	ShowUnfilled bool
-	Orientation  common.VizOrientation
+	ShowUnfilled  bool
+	Orientation   common.VizOrientation
+	ShowAllValues bool
 }
 
 func NewBarGaugePanel(options *BarGaugePanelOptions) *Panel {
@@ -457,7 +458,7 @@ func NewBarGaugePanel(options *BarGaugePanelOptions) *Panel {
 		Unit(options.Unit).
 		ReduceOptions(
 			common.NewReduceDataOptionsBuilder().
-				Calcs([]string{"lastNotNull"}).Values(false),
+				Calcs([]string{"lastNotNull"}).Values(options.ShowAllValues),
 		)
 
 	if options.Interval != "" {
@@ -515,6 +516,7 @@ func NewBarGaugePanel(options *BarGaugePanelOptions) *Panel {
 
 type GaugePanelOptions struct {
 	*PanelOptions
+	ShowAllValues bool
 }
 
 func NewGaugePanel(options *GaugePanelOptions) *Panel {
@@ -530,7 +532,7 @@ func NewGaugePanel(options *GaugePanelOptions) *Panel {
 		Unit(options.Unit).
 		ReduceOptions(
 			common.NewReduceDataOptionsBuilder().
-				Calcs([]string{"lastNotNull"}).Values(false),
+				Calcs([]string{"lastNotNull"}).Values(options.ShowAllValues),
 		)
 
 	if options.Interval != "" {


### PR DESCRIPTION
This PR introduces a new boolean field, ShowAllValues on gauge panels to let users choose between:

- Aggregated mode (default): collapse all series into a single bar using lastNotNull
- Series mode: render one bar per input series

By default `ShowAllValues` is false, preserving existing behavior.