### PR TITLE
Expose NoValue option on BarGauge and Gauge panels

### DIFF
--- a/observability-lib/grafana/panels.go
+++ b/observability-lib/grafana/panels.go
@@ -454,6 +454,7 @@ func NewBarGaugePanel(options *BarGaugePanelOptions) *Panel {
 		Description(options.Description).
 		Transparent(options.Transparent).
 		Span(options.Span).
+		NoValue(options.NoValue).
 		Height(options.Height).
 		Unit(options.Unit).
 		ReduceOptions(
@@ -528,6 +529,7 @@ func NewGaugePanel(options *GaugePanelOptions) *Panel {
 		Description(options.Description).
 		Transparent(options.Transparent).
 		Span(options.Span).
+		NoValue(options.NoValue).
 		Height(options.Height).
 		Unit(options.Unit).
 		ReduceOptions(


### PR DESCRIPTION
This PR adds support for the `NoValue` field (the text shown when a series has no data) to both the BarGauge and Gauge panel builders. Previously other panels were respecting `PanelOptions.NoValue` except these two

