### PR TITLE
pkg/loop/cmd/loopinstall: don't clean filepath

### DIFF
--- a/pkg/loop/cmd/loopinstall/install.go
+++ b/pkg/loop/cmd/loopinstall/install.go
@@ -46,9 +46,6 @@ func downloadAndInstallPlugin(pluginType string, pluginIdx int, plugin PluginDef
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
-	// Clean the install path
-	cleanInstallPath := filepath.Clean(installPath)
-
 	// Full module path with git reference
 	fullModulePath := moduleURI
 	if gitRef != "" {
@@ -127,7 +124,7 @@ func downloadAndInstallPlugin(pluginType string, pluginIdx int, plugin PluginDef
 		}
 
 		// Add the install path
-		args = append(args, filepath.Join(cleanInstallPath))
+		args = append(args, installPath)
 
 		cmd := exec.Command("go", args...)
 		cmd.Dir = moduleDir


### PR DESCRIPTION
Leading `./` prefix is meaningful with go. When it is trimmed, the path is interpreted as part of the standard library instead of the relative to the working directory in the current module.

Supports:
- https://github.com/smartcontractkit/chainlink/pull/17867