### PR TITLE
fix(services): do not cancel context for fn

### DIFF
--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -69,8 +69,7 @@ func (e *Engine) Go(fn func(context.Context)) {
 	e.wg.Add(1)
 	go func() {
 		defer e.wg.Done()
-		ctx, cancel := e.StopChan.NewCtx()
-		defer cancel()
+		ctx, _ := e.StopChan.NewCtx()
 		fn(ctx)
 	}()
 }

--- a/pkg/services/service_test.go
+++ b/pkg/services/service_test.go
@@ -1,0 +1,56 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSvc struct {
+	Service
+	eng *Engine
+}
+
+// Test_EngineGo verifies that a function launced by Engine.Go exists until the
+// parent context is done and the engine's stop channel is closed.
+func Test_EngineGo(t *testing.T) {
+	lggr := logger.Test(t)
+	started := make(chan struct{})
+	closed := make(chan struct{})
+
+	m := mockSvc{}
+
+	blocker := func(ctx context.Context) {
+		<-started
+		<-ctx.Done()
+		<-m.eng.StopChan
+		close(closed)
+	}
+
+	start := func(ctx context.Context) error {
+		close(started)
+		m.eng.Go(blocker)
+		return nil
+	}
+
+	close := func() error {
+		<-closed
+		return nil
+	}
+
+	svc, eng := Config{
+		Name:  "test-service",
+		Start: start,
+		Close: close,
+	}.NewServiceEngine(lggr)
+
+	m.eng = eng
+
+	err := svc.Start(t.Context())
+	require.NoError(t, err)
+
+	err = svc.Close()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

`Engine.Go` launches a go routine to call `fn(ctx)` but immediately cancels the context once `fn` returns.  This is not correct as `fn` itself may launch go routines that assume they will only be canceled when the stop channel is closed.  The fix is to remove `defer cancel()` and only cancel the passed context when the service's stop channel is closed.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
