### PR TITLE
Add nil underlying map check to OCRTriggerEvent

### DIFF
--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -231,6 +231,9 @@ func (e *OCRTriggerEvent) FromMap(m *values.Map) error {
 	if m == nil {
 		return fmt.Errorf("nil map")
 	}
+	if m.Underlying == nil {
+		return fmt.Errorf("nil underlying map")
+	}
 	val, ok := m.Underlying[e.topLevelKey()]
 	if !ok {
 		return fmt.Errorf("missing key: %s", e.topLevelKey())

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -264,7 +264,14 @@ func TestOCRTriggerEvent_ToMapFromMap(t *testing.T) {
 	t.Run("nil map", func(t *testing.T) {
 		event := &OCRTriggerEvent{}
 		err := event.FromMap(nil)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "nil map")
+	})
+	t.Run("nil underlying map", func(t *testing.T) {
+		event := &OCRTriggerEvent{}
+		err := event.FromMap(&values.Map{
+			Underlying: nil,
+		})
+		assert.ErrorContains(t, err, "nil underlying map")
 	})
 
 }


### PR DESCRIPTION
The `FromMap` method in `OCRTriggerEvent` was causing a panic when `m.Underlying` is nil.

```
2025-06-06 13:15:05 panic: runtime error: invalid memory address or nil pointer dereference
2025-06-06 13:15:05 [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1011334]
2025-06-06 13:15:05 
2025-06-06 13:15:05 goroutine 5758 [running]:
2025-06-06 13:15:05 github.com/smartcontractkit/chainlink-common/pkg/capabilities.(*OCRTriggerEvent).FromMap(0x4002185c08, 0x30?)
2025-06-06 13:15:05 /go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.7.1-0.20250603190644-0dcaa6d2cc86/pkg/capabilities/capabilities.go:239 +0x64
2025-06-06 13:15:05 github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation.(*signedReportRemoteAggregator).Aggregate(0x400111f440, {0x0, 0x0}, {0x400302d980?, 0x4001e66d00?, 0x40?})
2025-06-06 13:15:05 /chainlink/core/capabilities/remote/aggregation/signed_report.go:66 +0x194
2025-06-06 13:15:05 github.com/smartcontractkit/chainlink/v2/core/capabilities/remote.(*triggerSubscriber).Receive(0x400b198780, {0x40004c1750?, 0x4007b6e930?}, 0x400a2725a0)
2025-06-06 13:15:05 /chainlink/core/capabilities/remote/trigger_subscriber.go:225 +0xda0
2025-06-06 13:15:05 github.com/smartcontractkit/chainlink/v2/core/capabilities/remote.(*dispatcher).SetReceiver.func1()
2025-06-06 13:15:05 /chainlink/core/capabilities/remote/dispatcher.go:128 +0xac
2025-06-06 13:15:05 created by github.com/smartcontractkit/chainlink/v2/core/capabilities/remote.(*dispatcher).SetReceiver in goroutine 2823
2025-06-06 13:15:05 /chainlink/core/capabilities/remote/dispatcher.go:120 +0x230
```