### PR TITLE
[CAPPL-782] Handle user logs independently of system logs

### DIFF
--- a/pkg/workflows/wasm/host/execution.go
+++ b/pkg/workflows/wasm/host/execution.go
@@ -79,14 +79,16 @@ func (e *execution[T]) awaitCapabilities(ctx context.Context, acr *sdkpb.AwaitCa
 }
 
 func (e *execution[T]) log(caller *wasmtime.Caller, ptr int32, ptrlen int32) {
-	lggr := e.module.cfg.Logger
 	b, innerErr := wasmRead(caller, ptr, ptrlen)
 	if innerErr != nil {
-		lggr.Errorf("error calling log: %s", innerErr)
+		e.module.cfg.Logger.Errorf("error calling log: %s", innerErr)
 		return
 	}
-
-	lggr.Info(string(b))
+	innerErr = e.executor.EmitUserLog(string(b))
+	if innerErr != nil {
+		e.module.cfg.Logger.Errorf("error emitting user log: %s", innerErr)
+		return
+	}
 }
 
 func (e *execution[T]) getSeed(mode int32) int64 {

--- a/pkg/workflows/wasm/host/mock_execution_helper_test.go
+++ b/pkg/workflows/wasm/host/mock_execution_helper_test.go
@@ -83,6 +83,52 @@ func (_c *MockExecutionHelper_CallCapability_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// EmitUserLog provides a mock function with given fields: log
+func (_m *MockExecutionHelper) EmitUserLog(log string) error {
+	ret := _m.Called(log)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EmitUserLog")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(log)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockExecutionHelper_EmitUserLog_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EmitUserLog'
+type MockExecutionHelper_EmitUserLog_Call struct {
+	*mock.Call
+}
+
+// EmitUserLog is a helper method to define mock.On call
+//   - log string
+func (_e *MockExecutionHelper_Expecter) EmitUserLog(log interface{}) *MockExecutionHelper_EmitUserLog_Call {
+	return &MockExecutionHelper_EmitUserLog_Call{Call: _e.mock.On("EmitUserLog", log)}
+}
+
+func (_c *MockExecutionHelper_EmitUserLog_Call) Run(run func(log string)) *MockExecutionHelper_EmitUserLog_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockExecutionHelper_EmitUserLog_Call) Return(_a0 error) *MockExecutionHelper_EmitUserLog_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockExecutionHelper_EmitUserLog_Call) RunAndReturn(run func(string) error) *MockExecutionHelper_EmitUserLog_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetDONTime provides a mock function with no fields
 func (_m *MockExecutionHelper) GetDONTime() time.Time {
 	ret := _m.Called()
@@ -128,51 +174,6 @@ func (_c *MockExecutionHelper_GetDONTime_Call) RunAndReturn(run func() time.Time
 	return _c
 }
 
-// GetID provides a mock function with no fields
-func (_m *MockExecutionHelper) GetID() string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetID")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// MockExecutionHelper_GetID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetID'
-type MockExecutionHelper_GetID_Call struct {
-	*mock.Call
-}
-
-// GetID is a helper method to define mock.On call
-func (_e *MockExecutionHelper_Expecter) GetID() *MockExecutionHelper_GetID_Call {
-	return &MockExecutionHelper_GetID_Call{Call: _e.mock.On("GetID")}
-}
-
-func (_c *MockExecutionHelper_GetID_Call) Run(run func()) *MockExecutionHelper_GetID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockExecutionHelper_GetID_Call) Return(_a0 string) *MockExecutionHelper_GetID_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockExecutionHelper_GetID_Call) RunAndReturn(run func() string) *MockExecutionHelper_GetID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetNodeTime provides a mock function with no fields
 func (_m *MockExecutionHelper) GetNodeTime() time.Time {
 	ret := _m.Called()
@@ -214,6 +215,51 @@ func (_c *MockExecutionHelper_GetNodeTime_Call) Return(_a0 time.Time) *MockExecu
 }
 
 func (_c *MockExecutionHelper_GetNodeTime_Call) RunAndReturn(run func() time.Time) *MockExecutionHelper_GetNodeTime_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetWorkflowExecutionID provides a mock function with no fields
+func (_m *MockExecutionHelper) GetWorkflowExecutionID() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWorkflowExecutionID")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockExecutionHelper_GetWorkflowExecutionID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetWorkflowExecutionID'
+type MockExecutionHelper_GetWorkflowExecutionID_Call struct {
+	*mock.Call
+}
+
+// GetWorkflowExecutionID is a helper method to define mock.On call
+func (_e *MockExecutionHelper_Expecter) GetWorkflowExecutionID() *MockExecutionHelper_GetWorkflowExecutionID_Call {
+	return &MockExecutionHelper_GetWorkflowExecutionID_Call{Call: _e.mock.On("GetWorkflowExecutionID")}
+}
+
+func (_c *MockExecutionHelper_GetWorkflowExecutionID_Call) Run(run func()) *MockExecutionHelper_GetWorkflowExecutionID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockExecutionHelper_GetWorkflowExecutionID_Call) Return(_a0 string) *MockExecutionHelper_GetWorkflowExecutionID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockExecutionHelper_GetWorkflowExecutionID_Call) RunAndReturn(run func() string) *MockExecutionHelper_GetWorkflowExecutionID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -96,11 +96,13 @@ type ExecutionHelper interface {
 	// CallCapability blocking call to the Workflow Engine
 	CallCapability(ctx context.Context, request *sdkpb.CapabilityRequest) (*sdkpb.CapabilityResponse, error)
 
-	GetID() string
+	GetWorkflowExecutionID() string
 
 	GetNodeTime() time.Time
 
 	GetDONTime() time.Time
+
+	EmitUserLog(log string) error
 }
 
 type module struct {
@@ -492,8 +494,8 @@ func runWasm[I, O proto.Message](
 
 	h := fnv.New64a()
 	if helper != nil {
-		id := helper.GetID()
-		_, _ = h.Write([]byte(id))
+		executionId := helper.GetWorkflowExecutionID()
+		_, _ = h.Write([]byte(executionId))
 	}
 
 	donSeed := int64(h.Sum64())

--- a/pkg/workflows/wasm/host/wasm_nodag_test.go
+++ b/pkg/workflows/wasm/host/wasm_nodag_test.go
@@ -9,10 +9,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/protoc/pkg/test_capabilities/nodeaction"
 	sdkpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -73,7 +71,7 @@ func Test_NoDag_Run(t *testing.T) {
 	t.Run("OK executes happy path with two awaits", func(t *testing.T) {
 		ctx := t.Context()
 		wantResponse := strings.Join(wordList, "")
-		lggr, observer := logger.TestObserved(t, zapcore.InfoLevel)
+		lggr := logger.Test(t)
 		mc := &ModuleConfig{
 			Logger:         lggr,
 			IsUncompressed: true,
@@ -85,7 +83,12 @@ func Test_NoDag_Run(t *testing.T) {
 		defer m.Close()
 
 		mockExecutionHelper := NewMockExecutionHelper(t)
-		mockExecutionHelper.EXPECT().GetID().Return("Id")
+		mockExecutionHelper.EXPECT().EmitUserLog(mock.Anything).Return(nil).Run(
+			func(msg string) {
+				require.True(t, strings.Contains(msg, "Hi"))
+			},
+		)
+		mockExecutionHelper.EXPECT().GetWorkflowExecutionID().Return("Id")
 
 		// wrap some common payload
 		newWantedCapResponse := func(i int) *sdkpb.CapabilityResponse {
@@ -127,10 +130,6 @@ func Test_NoDag_Run(t *testing.T) {
 
 		response, err := m.Execute(ctx, req, mockExecutionHelper)
 		require.NoError(t, err)
-
-		logs := observer.TakeAll()
-		require.Len(t, logs, 1)
-		assert.True(t, strings.Contains(logs[0].Message, "Hi"))
 
 		switch output := response.Result.(type) {
 		case *wasmpb.ExecutionResult_Value:
@@ -200,7 +199,12 @@ func Test_NoDag_MultipleTriggers_Run(t *testing.T) {
 		defer m.Close()
 
 		mockExecutionHelper := NewMockExecutionHelper(t)
-		mockExecutionHelper.EXPECT().GetID().Return("Id")
+		mockExecutionHelper.EXPECT().EmitUserLog(mock.Anything).Return(nil).Run(
+			func(msg string) {
+				require.True(t, strings.Contains(msg, "Hi"))
+			},
+		)
+		mockExecutionHelper.EXPECT().GetWorkflowExecutionID().Return("Id")
 
 		newWantedCapResponse := func(i int) *sdkpb.CapabilityResponse {
 			action := &basicaction.Outputs{AdaptedThing: wordList[i]}
@@ -259,7 +263,7 @@ func Test_NoDag_Random(t *testing.T) {
 	t.Parallel()
 
 	mc := defaultNoDAGModCfg(t)
-	lggr, observed := logger.TestObserved(t, zapcore.DebugLevel)
+	lggr := logger.Test(t)
 	mc.Logger = lggr
 
 	binary := createTestBinary(nodagRandomBinaryCmd, nodagRandomBinaryLocation, true, t)
@@ -270,7 +274,7 @@ func Test_NoDag_Random(t *testing.T) {
 	// Test binary executes node mode code conditionally based on the value >= 100
 	anyId := "Id"
 	gte100Exec := NewMockExecutionHelper(t)
-	gte100Exec.EXPECT().GetID().Return(anyId)
+	gte100Exec.EXPECT().GetWorkflowExecutionID().Return(anyId)
 	gte100 := &nodeaction.NodeOutputs{OutputThing: 120}
 	gte100Payload, err := anypb.New(gte100)
 	require.NoError(t, err)
@@ -303,11 +307,8 @@ func Test_NoDag_Random(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Same execution id gives the same randoms, even if random is called in node mode", func(t *testing.T) {
-		// Clear from any previous test
-		observed.TakeAll()
-
 		lt100Exec := NewMockExecutionHelper(t)
-		lt100Exec.EXPECT().GetID().Return(anyId)
+		lt100Exec.EXPECT().GetWorkflowExecutionID().Return(anyId)
 		lt100 := &nodeaction.NodeOutputs{OutputThing: 120}
 		lt100Payload, err := anypb.New(lt100)
 		require.NoError(t, err)
@@ -331,7 +332,7 @@ func Test_NoDag_Random(t *testing.T) {
 		require.NoError(t, err)
 
 		gte100Exec2 := NewMockExecutionHelper(t)
-		gte100Exec2.EXPECT().GetID().Return("differentId")
+		gte100Exec2.EXPECT().GetWorkflowExecutionID().Return("differentId")
 
 		gte100Exec2.EXPECT().CallCapability(mock.Anything, mock.Anything).Return(&sdkpb.CapabilityResponse{
 			Response: &sdkpb.CapabilityResponse_Payload{
@@ -358,7 +359,7 @@ func defaultNoDAGModCfg(t testing.TB) *ModuleConfig {
 
 func getTriggersSpec(t *testing.T, m ModuleV2, config []byte) (*sdkpb.TriggerSubscriptionRequest, error) {
 	helper := NewMockExecutionHelper(t)
-	helper.EXPECT().GetID().Return("Id")
+	helper.EXPECT().GetWorkflowExecutionID().Return("Id")
 	execResult, err := m.Execute(t.Context(), &wasmpb.ExecuteRequest{
 		Config:  config,
 		Request: &wasmpb.ExecuteRequest_Subscribe{Subscribe: &emptypb.Empty{}},


### PR DESCRIPTION
1. Push user logs into a separate endpoint instead of the default logger.
2. Rename GetID() -> GetWorkflowExecutionID()
