### PR TITLE
disable null any check in config

### DIFF
--- a/pkg/capabilities/utils.go
+++ b/pkg/capabilities/utils.go
@@ -22,7 +22,9 @@ func UnwrapRequest(request CapabilityRequest, config proto.Message, value proto.
 
 	_, err = FromValueOrAny(request.Config, request.ConfigPayload, config)
 	if err != nil {
-		return migrated, err
+		// TODO: Engine does not populate the config field in the request object
+		// disabling this check for now
+		return migrated, nil
 	}
 
 	return migrated, nil


### PR DESCRIPTION
This pull request includes a small change to the `pkg/capabilities/utils.go` file. The change disables an error check in the `UnwrapRequest` function due to a [known issue where the engine does not populate the `config` field](https://github.com/smartcontractkit/chainlink/blob/dc71c225a6892d25da08911a66c6c32705118300/core/services/workflows/v2/capability_executor.go#L45-L52) in the request object. A TODO comment has been added to revisit this in the future.