### PR TITLE
Add/refactor the code generation for from values.Value package.

### DIFF
--- a/pkg/values/README.md
+++ b/pkg/values/README.md
@@ -9,9 +9,13 @@ Use the installer package to ensure that the chainlink-protos commit always matc
 
 ## ProtocGen
 The `ProtocGen` struct allows you to directly compile a file or to specify a CRE capabilities using a helper `CapabilityConfig`.
+
 Use of the `CapabilityConfig` requires the `ProtocHelper` field to be set.
 
+The CRE uses the chainlink-protos repository, especially, and capabilities are used in both the cre-sdk-go and capabilities repositories.
+Adding a different package with its own go.mod to isolate that logic would require an extra commit in this repository to update the protos repository.
+The first would be to update this package, the second to update the consumer.
 
 ## InstallProtocGenToDir
 
-This function allows you to install additional plugins for protoc. See comments on the function for more information. 
+This function allows you to install additional plugins for protoc. See comments on the function for more information.

--- a/pkg/values/README.md
+++ b/pkg/values/README.md
@@ -1,0 +1,17 @@
+# About this package
+
+This package is separate from the main module, so it can be imported by the CRE SDK without unnecessary dependencies.
+
+To update the chainlink-protos commit, update the variable chainlinkProtosVersion in installer/pkg/consts.go.
+
+# installer
+Use the installer package to ensure that the chainlink-protos commit always matches the version used in this package.
+
+## ProtocGen
+The `ProtocGen` struct allows you to directly compile a file or to specify a CRE capabilities using a helper `CapabilityConfig`.
+Use of the `CapabilityConfig` requires the `ProtocHelper` field to be set.
+
+
+## InstallProtocGenToDir
+
+This function allows you to install additional plugins for protoc. See comments on the function for more information. 

--- a/pkg/values/installer/main.go
+++ b/pkg/values/installer/main.go
@@ -3,7 +3,9 @@ package main
 import "github.com/smartcontractkit/chainlink-common/pkg/values/installer/pkg"
 
 func main() {
-	if err := (&pkg.ProtocGen{}).Generate("values/v1/values.proto", "."); err != nil {
+	gen := &pkg.ProtocGen{}
+
+	if err := gen.GenerateFile("values/v1/values.proto", "."); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/values/installer/pkg/capability_config.go
+++ b/pkg/values/installer/pkg/capability_config.go
@@ -1,0 +1,41 @@
+package pkg
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strconv"
+)
+
+type CapabilityConfig struct {
+	Category      string
+	Pkg           string
+	MajorVersion  int
+	PreReleaseTag string
+	Files         []string
+}
+
+func (c *CapabilityConfig) FullProtoFiles() []string {
+	protoDir := path.Join("capabilities", c.Category, c.Pkg, "v"+strconv.Itoa(c.MajorVersion)+c.PreReleaseTag)
+	fullFiles := make([]string, len(c.Files))
+	for i, file := range c.Files {
+		fullFiles[i] = path.Join(protoDir, file)
+	}
+	return fullFiles
+}
+
+func (c *CapabilityConfig) Validate() error {
+	if c.Category == "" {
+		return errors.New("category must not be empty")
+	}
+	if c.Pkg == "" {
+		return errors.New("pkg must not be empty")
+	}
+	if c.MajorVersion < 1 {
+		return fmt.Errorf("major-version must be >= 1, got %d", c.MajorVersion)
+	}
+	if len(c.Files) == 0 {
+		return errors.New("files must not be empty")
+	}
+	return nil
+}

--- a/pkg/values/installer/pkg/capability_config_test.go
+++ b/pkg/values/installer/pkg/capability_config_test.go
@@ -1,0 +1,110 @@
+package pkg_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/values/installer/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFullProtoFiles(t *testing.T) {
+	t.Run("Production version", func(t *testing.T) {
+		config := &pkg.CapabilityConfig{
+			Category:     "data",
+			Pkg:          "analytics",
+			MajorVersion: 2,
+			Files:        []string{"query.proto", "response.proto"},
+		}
+
+		expected := []string{
+			filepath.Join("capabilities", "data", "analytics", "v2", "query.proto"),
+			filepath.Join("capabilities", "data", "analytics", "v2", "response.proto"),
+		}
+
+		assert.Equal(t, expected, config.FullProtoFiles())
+	})
+
+	t.Run("Prerelease version", func(t *testing.T) {
+		config := &pkg.CapabilityConfig{
+			Category:      "data",
+			Pkg:           "analytics",
+			MajorVersion:  2,
+			Files:         []string{"query.proto", "response.proto"},
+			PreReleaseTag: "alpha",
+		}
+
+		expected := []string{
+			filepath.Join("capabilities", "data", "analytics", "v2alpha", "query.proto"),
+			filepath.Join("capabilities", "data", "analytics", "v2alpha", "response.proto"),
+		}
+
+		assert.Equal(t, expected, config.FullProtoFiles())
+	})
+}
+
+func TestCapabilityConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     pkg.CapabilityConfig
+		wantErr string
+	}{
+		{
+			name: "valid config",
+			cfg: pkg.CapabilityConfig{
+				Category:     "scheduler",
+				Pkg:          "cron",
+				MajorVersion: 1,
+				Files:        []string{"a.proto"},
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing category",
+			cfg: pkg.CapabilityConfig{
+				Pkg:          "cron",
+				MajorVersion: 1,
+				Files:        []string{"a.proto"},
+			},
+			wantErr: "category must not be empty",
+		},
+		{
+			name: "missing pkg",
+			cfg: pkg.CapabilityConfig{
+				Category:     "scheduler",
+				MajorVersion: 1,
+				Files:        []string{"a.proto"},
+			},
+			wantErr: "pkg must not be empty",
+		},
+		{
+			name: "invalid major version",
+			cfg: pkg.CapabilityConfig{
+				Category: "scheduler",
+				Pkg:      "cron",
+				Files:    []string{"a.proto"},
+			},
+			wantErr: "major-version must be >= 1, got 0",
+		},
+		{
+			name: "missing files",
+			cfg: pkg.CapabilityConfig{
+				Category:     "scheduler",
+				Pkg:          "cron",
+				MajorVersion: 1,
+			},
+			wantErr: "files must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/values/installer/pkg/consts.go
+++ b/pkg/values/installer/pkg/consts.go
@@ -1,3 +1,3 @@
 package pkg
 
-const chainlinkProtosVersion = "cre-sdk/v1alpha.2"
+const chainlinkProtosVersion = "cre-sdk/v1alpha.3"

--- a/pkg/values/installer/pkg/installer.go
+++ b/pkg/values/installer/pkg/installer.go
@@ -1,0 +1,74 @@
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// InstallProtocGenToDir installs the pkg plugin to .tools. It'll download it from the same commit as sameVersion.
+func InstallProtocGenToDir(pkgName, sameVersion string) error {
+	fmt.Printf("Finding version to use for %s\n.", pkgName)
+	pluginVersion, err := getVersion(sameVersion, ".")
+	if err != nil {
+		return err
+	}
+
+	pluginDir, err := downloadPlugin(pkgName, pluginVersion)
+	if err != nil {
+		return err
+	}
+
+	return buildPlugin(pluginDir)
+}
+
+func getVersion(of, dir string) (string, error) {
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Version}}", of)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get version of %s in directory %s: %w\nOutput: %s", of, dir, err, out)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+func downloadPlugin(pkgName, version string) (string, error) {
+	fmt.Printf("Downloading plugin version %s\n", version)
+	cmd := exec.Command("go", "mod", "download", "-json", fmt.Sprintf("%s@%s", pkgName, version))
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to download module: %w\nOutput: %s", err, out)
+	}
+
+	var mod struct{ Dir string }
+	if err = json.Unmarshal(out, &mod); err != nil {
+		return "", fmt.Errorf("failed to parse go mod download output: %w", err)
+	}
+
+	return mod.Dir, nil
+}
+
+func buildPlugin(pluginDir string) error {
+	toolsDir, err := filepath.Abs(".tools")
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path for .tools: %w", err)
+	}
+
+	if err = os.MkdirAll(toolsDir, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create .tools directory: %w", err)
+	}
+
+	fmt.Println("Building plugin")
+	cmd := exec.Command("go", "build", "-o", toolsDir, ".")
+	cmd.Dir = pluginDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to build plugin: %w\nOutput: %s", err, out)
+	}
+
+	return nil
+}

--- a/pkg/values/installer/pkg/installer.go
+++ b/pkg/values/installer/pkg/installer.go
@@ -25,6 +25,22 @@ func InstallProtocGenToDir(pkgName, sameVersion string) error {
 	return buildPlugin(pluginDir)
 }
 
+// InstallProtocGenFromThisMod installs the pkg plugin to .tools. It'll download it from the latest git commit of the current module.
+func InstallProtocGenFromThisMod(pkgName string) error {
+	pluginVersion, err := run("git", ".", "log", "-n", "1", "--pretty=format:%H")
+	if err != nil {
+		return fmt.Errorf("failed to get current commit hash: %w", err)
+	}
+
+	pluginVersion = strings.TrimSpace(pluginVersion)
+	pluginDir, err := downloadPlugin(pkgName, pluginVersion)
+	if err != nil {
+		return err
+	}
+
+	return buildPlugin(pluginDir)
+}
+
 func getVersion(of, dir string) (string, error) {
 	cmd := exec.Command("go", "list", "-m", "-f", "{{.Version}}", of)
 	cmd.Dir = dir

--- a/pkg/values/installer/pkg/protoc_gen.go
+++ b/pkg/values/installer/pkg/protoc_gen.go
@@ -190,10 +190,14 @@ func checkoutClProtosRef(repoPath string) error {
 		}
 	}
 
-	// TODO check why this didn't fetch...
+	// Reset to head so that fetch and checkout won't fail
+	if _, err := run("git", repoPath, "reset", "--hard", "HEAD"); err != nil {
+		return fmt.Errorf("failed to reset chainlink-protos repo: %v", err)
+	}
+
 	if _, err := run("git", repoPath, "rev-parse", "--verify", "--quiet", chainlinkProtosVersion); err != nil {
-		if out, err := run("git", repoPath, "fetch", "origin"); err != nil {
-			return fmt.Errorf("failed to fetch: %v\n%s", err, out)
+		if out, err := run("git", repoPath, "fetch"); err != nil {
+			return fmt.Errorf("failed to fetch: %v\nIf you're not working on the main branch, you may need to track that branch in proto_vendor/chainlink-protos, this tool will not do that for you to avoid accidental non-main commits\n%s", err, out)
 		}
 	}
 

--- a/pkg/values/installer/pkg/protoc_helper.go
+++ b/pkg/values/installer/pkg/protoc_helper.go
@@ -1,0 +1,8 @@
+package pkg
+
+type ProtocHelper interface {
+	// FullGoPackageName specifies a go package name for the capability.
+	FullGoPackageName(c *CapabilityConfig) string
+	// SdkPgk returns where the base SDK and metadata protos are generated
+	SdkPgk() string
+}


### PR DESCRIPTION
This will be used as I merge the SDK split. 

NOTE: some code is duplicated as I will be removing the older generation code when it's no longer referenced, after the SDK split :)

Context branches:

[capabilites](https://github.com/smartcontractkit/capabilities/tree/rtinianov_local_proto_gen)
[common](https://github.com/smartcontractkit/chainlink-common/tree/rtinianov_use_raw_sdk_for_module_tests)
[CRE SDK](https://github.com/smartcontractkit/cre-sdk-go/tree/rtinianov_movingEverything)


Step-by-step for capabilities once everything is checked in.

https://smartcontract-it.atlassian.net/wiki/spaces/BCF/pages/edit-v2/1609826324?draftShareId=c5a8b34d-c3ac-4d71-abf3-09a00baa35ba