### PR TITLE
Configurable chainlink-protoc version for protoc_gen

### DIFF
--- a/pkg/values/installer/pkg/consts.go
+++ b/pkg/values/installer/pkg/consts.go
@@ -1,3 +1,3 @@
 package pkg
 
-const chainlinkProtosVersion = "cre-sdk/v1alpha.4"
+const defaultChainlinkProtosVersion = "cre-sdk/v1alpha.4"


### PR DESCRIPTION
This PR allows anyone to change the default `chainlink-protoc` version when using `protoc_gen`. It will be required for this PR: https://github.com/smartcontractkit/cre-sdk-go/pull/14

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
