### PR TITLE
creating helper for gas unit for WTs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,6 +120,7 @@ require (
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
+	github.com/smartcontractkit/chain-selectors v1.0.62 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250430163438-97d324ef9061 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/shopspring/decimal v1.4.0
+	github.com/smartcontractkit/chain-selectors v1.0.62
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250707214334-e164c13b2f32
 	github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb v0.0.0-20250708135749-8736758474ec
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20250701181457-37bd0d618b58
@@ -120,7 +121,6 @@ require (
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
-	github.com/smartcontractkit/chain-selectors v1.0.62 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250430163438-97d324ef9061 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/smartcontractkit/chain-selectors v1.0.62 h1:KWLEyKQXHxGGHIlUfLrzjYldlB8hBjRZi9GP49WtgYs=
+github.com/smartcontractkit/chain-selectors v1.0.62/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250707214334-e164c13b2f32 h1:+yOhdrImF2R4qnMZQaGWyJ2qd1HhvSHtJjeKJSWplbI=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250707214334-e164c13b2f32/go.mod h1:U1UAbPhy6D7Qz0wHKGPoQO+dpR0hsYjgUz8xwRrmKwI=
 github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb v0.0.0-20250708135749-8736758474ec h1:6XpqaGA2a4ik2zte0bEKeFIgPyHlTQNrVdaIbJWqlks=

--- a/pkg/metering/units.go
+++ b/pkg/metering/units.go
@@ -24,12 +24,12 @@ type unit struct {
 	Unit string
 }
 
-func GasUnitForChain(chainSelector uint64) (string, error) {
+func GasUnitForChain(chainID uint64) (string, error) {
 	  // Getting ChainId based on ChainSelector
-	  _, err := chainselectors.ChainIdFromSelector(2664363617261496610)
+	  selector, err := chainselectors.SelectorFromChainId(chainID)
 	  if err != nil {
 		return "", err
 	  }
 
-	  return fmt.Sprintf("GAS.%d",chainSelector), nil
+	  return fmt.Sprintf("GAS.%d",selector), nil
 }

--- a/pkg/metering/units.go
+++ b/pkg/metering/units.go
@@ -1,11 +1,16 @@
 package metering
 
+import (
+	"fmt"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+)
+
 var (
 	PayloadUnit = unit{Name: "payload", Unit: "bytes"}
 
-	// ComputeUnit is an example. The compute cap will eventually be obsoleted
-	// by the CRE No-DAG SDK.
-	ComputeUnit = unit{Name: "compute", Unit: "seconds"}
+	// ComputeUnit is an example.
+	ComputeUnit = unit{Name: "compute", Unit: "ms"}
 )
 
 // unit provides exported Name and unit fields for
@@ -17,4 +22,14 @@ type unit struct {
 
 	// Unit of the Metering Unit, i.e. bytes, seconds
 	Unit string
+}
+
+func GasUnitForChain(chainSelector uint64) (string, error) {
+	  // Getting ChainId based on ChainSelector
+	  _, err := chainselectors.ChainIdFromSelector(2664363617261496610)
+	  if err != nil {
+		return "", err
+	  }
+
+	  return fmt.Sprintf("GAS.%d",chainSelector), nil
 }


### PR DESCRIPTION
We construct the GAS.[CHAIN-ID] units manually right now: 
* EVM WT: https://github.com/smartcontractkit/chainlink-framework/blob/1d28e35b1341bcfce035668569496f01a1ac7df3/capabilities/writetarget/write_target.go#L363
* Aptos WT: https://github.com/smartcontractkit/chainlink-aptos/pull/273#discussion_r2190779781

We also desire to use the chain-selectors instead. 

This exported helper will be consumed in the WTs to accomplish this. 