### PR TITLE
protoc outputs the stdout (even if successful) for easier debugging

### DIFF
--- a/pkg/values/installer/pkg/protoc_gen.go
+++ b/pkg/values/installer/pkg/protoc_gen.go
@@ -79,10 +79,14 @@ func (p *ProtocGen) GenerateFile(file, from string) error {
 	}
 
 	args = append(args, file)
-
-	if out, err := run("protoc", from, args...); err != nil {
+	out, err := run("protoc", from, args...)
+	if err != nil {
 		return fmt.Errorf("failed to run protoc: %v\n%s", err, out)
 	}
+	if out == "" {
+		out = "No output"
+	}
+	fmt.Printf("Generated file %q\nexecution output:\n%s\n", file, out)
 
 	return nil
 }
@@ -185,11 +189,11 @@ func (p *ProtocGen) doInit() error {
 func run(command string, path string, args ...string) (string, error) {
 	cmd := exec.Command(command, args...)
 	cmd.Dir = path
-	outuptBytes, err := cmd.CombinedOutput()
+	outputBytes, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("Failed running command\n%s\nfrom path: %s\n%v", cmd.String(), path, err)
+		return "", fmt.Errorf("Failed running command\n%s\nfrom path: %s\nerror:%v\nexecution output:\n%s", cmd.String(), path, err, "\t"+strings.ReplaceAll(string(outputBytes), "\n", "\n\t"))
 	}
-	return strings.TrimSpace(string(outuptBytes)), nil
+	return strings.TrimSpace(string(outputBytes)), nil
 }
 
 func checkoutClProtosRef(repoPath string) error {


### PR DESCRIPTION
Prior usage of the generator make difficult to understand errors, with this, the output will be like follows:


Successful generate:
```
Waiting for lock...
Acquired lock
checking out chainlink-protos version: cre-sdk/v1alpha.7
Generated file "log_trigger.proto"
execution output:
No output

Process finished with exit code 0
```


Successful generate with warnings:
```
Waiting for lock...
Acquired lock
checking out chainlink-protos version: cre-sdk/v1alpha.7
Generated file "log_trigger.proto"
execution output:
log_trigger.proto:6:1: warning: Import values/v1/values.proto is unused.

Process finished with exit code 0
```


Error generate:
```
Waiting for lock...
Acquired lock
checking out chainlink-protos version: cre-sdk/v1alpha.7
panic: failed to run protoc: Failed running command
	/opt/homebrew/bin/protoc -I . -I ../../../. -I /FOLDER/capabilities2/capabilities/proto_vendor/chainlink-protos/cre --go_out=. --go_opt=paths=source_relative --go_opt=Mtools/generator/v1alpha/cre_metadata.proto=github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb --go_opt=Mlibs/monitoring/execution_context.proto=github.com/smartcontractkit/capabilities/libs/monitoring --go_opt=Mcapabilities/blockchain/evm/v1alpha/client.proto=github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/chain-capabilities/evm --go_opt=Mvalues/v1/values.proto=github.com/smartcontractkit/chainlink-common/pkg/values/pb log_trigger.proto
	from path: .
	error:exit status 1
	execution output:
		log_trigger.proto:6:1: warning: Import values/v1/values.proto is unused.
		protoc-gen-go: unable to determine Go import path for "sdk/v1alpha/sdk.proto"
		
		Please specify either:
			• a "go_package" option in the .proto source file, or
			• a "M" argument on the command line.
		
		See https://protobuf.dev/reference/go/go-generated#package for more information.
		
		--go_out: protoc-gen-go: Plugin failed with status code 1.
		
	

goroutine 1 [running]:
main.main()
	/FOLDER/capabilities2/capabilities/chain_capabilities/evm/monitoring/gen/main.go:18 +0x2c8
exit status 2
generate.go:1: running "go": exit status 1
```
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
