### PR TITLE
fix: enable local beholder connections to loops

### DIFF
--- a/pkg/loop/server.go
+++ b/pkg/loop/server.go
@@ -126,6 +126,7 @@ func (s *Server) start() error {
 			EmitterMaxQueueSize:            s.EnvConfig.TelemetryEmitterMaxQueueSize,
 			ChipIngressEmitterEnabled:      s.EnvConfig.ChipIngressEndpoint != "",
 			ChipIngressEmitterGRPCEndpoint: s.EnvConfig.ChipIngressEndpoint,
+			ChipIngressInsecureConnection:  s.EnvConfig.TelemetryInsecureConnection,
 		}
 
 		if tracingConfig.Enabled {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

Local env fails to send beholder message b/c of  broken TLS handshake.

Change validated locally

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
