### PR TITLE
pkg/chipingress: retract v1.0.1

### DIFF
--- a/pkg/chipingress/go.mod
+++ b/pkg/chipingress/go.mod
@@ -27,4 +27,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-retract v1.0.0 // Use v0.0.1 instead
+retract [v1.0.0, v1.0.1]


### PR DESCRIPTION
`github.com/smartcontractkit/chainlink-common/pkg/chipingress@v1.0.0` is retracted in the `go.mod` file, but that must be published in a version >v1.0.0 to be discovered by the tooling (and prevent `latest` from jumping ahead). Therefore we must tag `v1.0.1`, and it must retract itself as well.