### PR TITLE
Library for JSON-RPC JWT Creation and Verification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/bytecodealliance/wasmtime-go/v28 v28.0.0
 	github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.16.1
 	github.com/cloudevents/sdk-go/v2 v2.16.1
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/dominikbraun/graph v0.23.0
 	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/dominikbraun/graph v0.23.0 h1:TdZB4pPqCLFxYhdyMFb1TBdFxp8XLcJfTTBQucVPgCo=
 github.com/dominikbraun/graph v0.23.0/go.mod h1:yOjYyogZLY1LSG9E33JWZJiq5k83Qy2C6POAuiViluc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/pkg/jsonrpc2/types_test.go
+++ b/pkg/jsonrpc2/types_test.go
@@ -26,7 +26,7 @@ func TestTypes(t *testing.T) {
 		}
 		digest, err := req.Digest()
 		require.NoError(t, err)
-		require.Equal(t, "01025753dbedc82b0771489d77f87b4fe8bbe7255be218caafce6704cc4b45a6", digest)
+		require.Equal(t, "0d390d82191fcc4fe7b321124f55e3880bf3f754c725d10bcc0668cebf6a6ded", digest)
 	})
 
 	t.Run("Request.Digest - JSON marshal error", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestResponseDigest(t *testing.T) {
 		digest, err := resp.Digest()
 		require.NoError(t, err)
 		require.NotEmpty(t, digest)
-		require.Equal(t, "1dcc380a15b81b33bda5b69b8ea1e01671a7633cdc989df65e68c53aba587087", digest)
+		require.Equal(t, "cfa8212d72dd8414d120b8e49d0173fe37ac7fb815fc9d582724ea865645aec5", digest)
 	})
 
 	t.Run("Response.Digest - with error", func(t *testing.T) {
@@ -93,7 +93,7 @@ func TestResponseDigest(t *testing.T) {
 		digest, err := resp.Digest()
 		require.NoError(t, err)
 		require.NotEmpty(t, digest)
-		require.Equal(t, "df7b0b7347b46915adab6e50b4c9475fc42106dd61c8d2340b7dec260248204c", digest)
+		require.Equal(t, "597ac3b0a7659eabd02527779218b69fec5434afbc1c077d1bcecf8c1ae014f6", digest)
 	})
 
 	t.Run("Response.Digest - JSON marshal error", func(t *testing.T) {
@@ -111,5 +111,257 @@ func TestResponseDigest(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error marshaling JSON")
 		require.Empty(t, digest)
+	})
+}
+
+func TestNormalize(t *testing.T) {
+	t.Run("Normalize - primitive types", func(t *testing.T) {
+		str := "hello"
+		normalizedStr, err := Normalize(str)
+		require.NoError(t, err)
+		require.Equal(t, str, normalizedStr)
+
+		num := 42
+		normalizedNum, err := Normalize(num)
+		require.NoError(t, err)
+		require.Equal(t, num, normalizedNum)
+
+		b := true
+		normalizedBool, err := Normalize(b)
+		require.NoError(t, err)
+		require.Equal(t, b, normalizedBool)
+	})
+
+	t.Run("Normalize - map with sorted keys", func(t *testing.T) {
+		input := map[string]interface{}{
+			"zebra": "animal",
+			"apple": "fruit",
+			"car":   "vehicle",
+		}
+
+		normalized, err := Normalize(input)
+		require.NoError(t, err)
+
+		expected := map[string]interface{}{
+			"apple": "fruit",
+			"car":   "vehicle",
+			"zebra": "animal",
+		}
+		require.Equal(t, expected, normalized)
+	})
+
+	t.Run("Normalize - nested map", func(t *testing.T) {
+		input := map[string]interface{}{
+			"outer": map[string]interface{}{
+				"z": "last",
+				"a": "first",
+			},
+		}
+
+		normalized, err := Normalize(input)
+		require.NoError(t, err)
+
+		expected := map[string]interface{}{
+			"outer": map[string]interface{}{
+				"a": "first",
+				"z": "last",
+			},
+		}
+		require.Equal(t, expected, normalized)
+	})
+
+	t.Run("Normalize - slice", func(t *testing.T) {
+		input := []interface{}{"hello", 42, true}
+
+		normalized, err := Normalize(input)
+		require.NoError(t, err)
+
+		expected := []interface{}{"hello", 42, true}
+		require.Equal(t, expected, normalized)
+	})
+
+	t.Run("Normalize - slice with nested maps", func(t *testing.T) {
+		input := []interface{}{
+			map[string]interface{}{
+				"z": "last",
+				"a": "first",
+			},
+			"simple string",
+		}
+
+		normalized, err := Normalize(input)
+		require.NoError(t, err)
+
+		expected := []interface{}{
+			map[string]interface{}{
+				"a": "first",
+				"z": "last",
+			},
+			"simple string",
+		}
+		require.Equal(t, expected, normalized)
+	})
+
+	t.Run("Normalize - complex nested structure", func(t *testing.T) {
+		input := map[string]interface{}{
+			"users": []interface{}{
+				map[string]interface{}{
+					"name": "John",
+					"age":  30,
+					"address": map[string]interface{}{
+						"zip":    "12345",
+						"city":   "NYC",
+						"street": "Main St",
+					},
+				},
+			},
+			"config": map[string]interface{}{
+				"timeout": 5000,
+				"debug":   true,
+			},
+		}
+
+		normalized, err := Normalize(input)
+		require.NoError(t, err)
+
+		expected := map[string]interface{}{
+			"config": map[string]interface{}{
+				"debug":   true,
+				"timeout": 5000,
+			},
+			"users": []interface{}{
+				map[string]interface{}{
+					"address": map[string]interface{}{
+						"city":   "NYC",
+						"street": "Main St",
+						"zip":    "12345",
+					},
+					"age":  30,
+					"name": "John",
+				},
+			},
+		}
+		require.Equal(t, expected, normalized)
+	})
+
+	t.Run("Normalize - nil value", func(t *testing.T) {
+		var input interface{}
+		normalized, err := Normalize(input)
+		require.NoError(t, err)
+		require.Nil(t, normalized)
+	})
+
+	t.Run("Normalize - empty map", func(t *testing.T) {
+		input := map[string]interface{}{}
+		normalized, err := Normalize(input)
+		require.NoError(t, err)
+		require.Equal(t, input, normalized)
+	})
+
+	t.Run("Normalize - empty slice", func(t *testing.T) {
+		input := []interface{}{}
+		normalized, err := Normalize(input)
+		require.NoError(t, err)
+		require.Equal(t, input, normalized)
+	})
+}
+
+func TestDigestConsistency(t *testing.T) {
+	t.Run("Request digest consistency with different param order", func(t *testing.T) {
+		req1 := Request[map[string]interface{}]{
+			Version: JsonRpcVersion,
+			ID:      "test",
+			Method:  "test.method",
+			Params: &map[string]interface{}{
+				"z": "last",
+				"a": "first",
+				"m": "middle",
+			},
+		}
+
+		req2 := Request[map[string]interface{}]{
+			Version: JsonRpcVersion,
+			ID:      "test",
+			Method:  "test.method",
+			Params: &map[string]interface{}{
+				"a": "first",
+				"m": "middle",
+				"z": "last",
+			},
+		}
+
+		digest1, err1 := req1.Digest()
+		digest2, err2 := req2.Digest()
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.Equal(t, digest1, digest2, "Digests should be equal regardless of param order")
+	})
+
+	t.Run("Response digest consistency with different result order", func(t *testing.T) {
+		resp1 := Response[map[string]interface{}]{
+			Version: JsonRpcVersion,
+			ID:      "test",
+			Result: &map[string]interface{}{
+				"z": "last",
+				"a": "first",
+			},
+		}
+
+		resp2 := Response[map[string]interface{}]{
+			Version: JsonRpcVersion,
+			ID:      "test",
+			Result: &map[string]interface{}{
+				"a": "first",
+				"z": "last",
+			},
+		}
+
+		digest1, err1 := resp1.Digest()
+		digest2, err2 := resp2.Digest()
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.Equal(t, digest1, digest2, "Digests should be equal regardless of result order")
+	})
+
+	t.Run("Auth field excluded from digest", func(t *testing.T) {
+		type ParamsType struct {
+			Value string `json:"value"`
+		}
+
+		req1 := Request[ParamsType]{
+			Version: JsonRpcVersion,
+			ID:      "test",
+			Method:  "test.method",
+			Params:  &ParamsType{Value: "test"},
+			Auth:    "token123",
+		}
+
+		req2 := Request[ParamsType]{
+			Version: JsonRpcVersion,
+			ID:      "test",
+			Method:  "test.method",
+			Params:  &ParamsType{Value: "test"},
+			Auth:    "differentToken456",
+		}
+
+		req3 := Request[ParamsType]{
+			Version: JsonRpcVersion,
+			ID:      "test",
+			Method:  "test.method",
+			Params:  &ParamsType{Value: "test"},
+			// No Auth field
+		}
+
+		digest1, err1 := req1.Digest()
+		digest2, err2 := req2.Digest()
+		digest3, err3 := req3.Digest()
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.NoError(t, err3)
+		require.Equal(t, digest1, digest2, "Digests should be equal regardless of Auth token")
+		require.Equal(t, digest1, digest3, "Digests should be equal whether Auth is present or not")
 	})
 }

--- a/pkg/types/gateway/jwt.go
+++ b/pkg/types/gateway/jwt.go
@@ -1,0 +1,180 @@
+package gateway
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	secp "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	secpecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+	"github.com/golang-jwt/jwt/v5"
+
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+)
+
+var SigningMethodES256K *SigningMethodSecp256k1
+
+func init() {
+	SigningMethodES256K = &SigningMethodSecp256k1{}
+	// golang-jwt library does not support ES256K (ECDSA on the secp256k1 curve)
+	// so registering a custom implementation of the signing method here
+	jwt.RegisterSigningMethod(SigningMethodES256K.Alg(), func() jwt.SigningMethod {
+		return SigningMethodES256K
+	})
+}
+
+// SigningMethodSecp256k1 implements the ES256K signing method for JWT
+type SigningMethodSecp256k1 struct{}
+
+func (m *SigningMethodSecp256k1) Alg() string {
+	return "ES256K"
+}
+
+func (m *SigningMethodSecp256k1) Sign(signingString string, key interface{}) ([]byte, error) {
+	var ecdsaKey *ecdsa.PrivateKey
+	switch k := key.(type) {
+	case *ecdsa.PrivateKey:
+		ecdsaKey = k
+	default:
+		return nil, jwt.ErrInvalidKeyType
+	}
+	hasher := sha256.New()
+	hasher.Write([]byte(signingString))
+	hash := hasher.Sum(nil)
+
+	secpPrivKey := secp.PrivKeyFromBytes(ecdsaKey.D.Bytes())
+	signature := secpecdsa.Sign(secpPrivKey, hash)
+
+	return signature.Serialize(), nil
+}
+
+func (m *SigningMethodSecp256k1) Verify(signingString string, signature []byte, key interface{}) error {
+	var ecdsaKey *ecdsa.PublicKey
+	switch k := key.(type) {
+	case *ecdsa.PublicKey:
+		ecdsaKey = k
+	default:
+		return jwt.ErrInvalidKeyType
+	}
+
+	hasher := sha256.New()
+	hasher.Write([]byte(signingString))
+	hash := hasher.Sum(nil)
+
+	secpPubKey, err := secp.ParsePubKey(append([]byte{0x04}, append(ecdsaKey.X.Bytes(), ecdsaKey.Y.Bytes()...)...))
+	if err != nil {
+		return err
+	}
+	sig, err := secpecdsa.ParseDERSignature(signature)
+	if err != nil {
+		return err
+	}
+	if !sig.Verify(hash, secpPubKey) {
+		return jwt.ErrSignatureInvalid
+	}
+
+	return nil
+}
+
+type JWTClaims struct {
+	Digest string `json:"digest"`
+	jwt.RegisteredClaims
+}
+
+// CreateRequestJWT creates a signed JWT for a JSON-RPC request
+// JWT has 3 parts: header, payload, and signature as shown below
+// header:
+//
+//	{
+//		alg: "ES256K",
+//		typ: "JWT"
+//	}
+//
+// payload:
+//
+//	{
+//		digest: "<request-digest>"
+//		iss: "<compressed-public-key>",
+//		exp: <timestamp>,
+//		iat: <timestamp>
+//	}
+//
+// signature: ECDSA signature of the header and payload using the private key
+func CreateRequestJWT[T any](req jsonrpc.Request[T], key *ecdsa.PrivateKey, expiryDuration time.Duration) (string, error) {
+	if key == nil {
+		return "", errors.New("private key cannot be nil")
+	}
+	digest, err := req.Digest()
+	if err != nil {
+		return "", err
+	}
+	now := time.Now()
+	compressed, err := compressedECDSAPubKey(&key.PublicKey)
+	if err != nil {
+		return "", err
+	}
+	claims := JWTClaims{
+		Digest: digest,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    hex.EncodeToString(compressed),
+			ExpiresAt: jwt.NewNumericDate(now.Add(expiryDuration)),
+			IssuedAt:  jwt.NewNumericDate(now),
+		},
+	}
+
+	token := jwt.NewWithClaims(SigningMethodES256K, claims)
+	return token.SignedString(key)
+}
+
+// VerifyRequestJWT verifies a signed JWT for a JSON-RPC request
+// It verifies the signature, checks the issuer, validates the digest
+// and performs all validations done by jwt.ParseWithClaims() including expiration checks
+func VerifyRequestJWT[T any](tokenString string, key *ecdsa.PublicKey, req jsonrpc.Request[T]) (*JWTClaims, error) {
+	if key == nil {
+		return nil, errors.New("public key cannot be nil")
+	}
+	token, err := jwt.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*SigningMethodSecp256k1); !ok {
+			return nil, jwt.ErrSignatureInvalid
+		}
+		return key, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := token.Claims.(*JWTClaims)
+	if !ok {
+		return nil, jwt.ErrTokenInvalidClaims
+	}
+	if !token.Valid {
+		return nil, jwt.ErrTokenInvalidClaims
+	}
+	compressed, err := compressedECDSAPubKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if claims.Issuer != hex.EncodeToString(compressed) {
+		return nil, jwt.ErrTokenInvalidIssuer
+	}
+	reqDigest, err := req.Digest()
+	if err != nil {
+		return nil, err
+	}
+	if claims.Digest != reqDigest {
+		return nil, errors.New("JWT digest does not match request digest")
+	}
+	return claims, nil
+}
+
+func compressedECDSAPubKey(pubKey *ecdsa.PublicKey) ([]byte, error) {
+	if pubKey == nil || pubKey.X == nil || pubKey.Y == nil {
+		return nil, errors.New("invalid public key")
+	}
+	var x, y secp256k1.FieldVal
+	x.SetByteSlice(pubKey.X.Bytes())
+	y.SetByteSlice(pubKey.Y.Bytes())
+	return secp.NewPublicKey(&x, &y).SerializeCompressed(), nil
+}

--- a/pkg/types/gateway/jwt_test.go
+++ b/pkg/types/gateway/jwt_test.go
@@ -1,0 +1,599 @@
+package gateway
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	secp "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+
+	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
+)
+
+func TestES256K(t *testing.T) {
+	privKey, err := secp.GeneratePrivateKey()
+	require.NoError(t, err)
+	privKeyBytes := privKey.Key.Bytes()
+	ecdsaPrivKey := &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: secp.S256(),
+			X:     privKey.PubKey().X(),
+			Y:     privKey.PubKey().Y(),
+		},
+		D: new(big.Int).SetBytes(privKeyBytes[:]),
+	}
+
+	t.Run("ES256K JWT creation and verification", func(t *testing.T) {
+		req := jsonrpc.Request[map[string]interface{}]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "test-es256k",
+			Method:  "test.method",
+			Params: &map[string]interface{}{
+				"param1": "value1",
+				"param2": 42,
+			},
+		}
+
+		tokenString, err := CreateRequestJWT(req, ecdsaPrivKey, time.Hour)
+		require.NoError(t, err)
+		require.NotEmpty(t, tokenString)
+
+		claims, err := VerifyRequestJWT(tokenString, &ecdsaPrivKey.PublicKey, req)
+		require.NoError(t, err)
+		require.NotNil(t, claims)
+
+		expectedDigest, err := req.Digest()
+		require.NoError(t, err)
+		require.Equal(t, expectedDigest, claims.Digest)
+
+		parts := strings.Split(tokenString, ".")
+		require.Len(t, parts, 3, "JWT should have 3 parts")
+
+		headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+		require.NoError(t, err)
+
+		var header map[string]interface{}
+		err = json.Unmarshal(headerBytes, &header)
+		require.NoError(t, err)
+
+		require.Equal(t, "ES256K", header["alg"])
+	})
+
+	t.Run("ES256K signature verification", func(t *testing.T) {
+		// Test the signing method directly
+		signingMethod := SigningMethodES256K
+		require.Equal(t, "ES256K", signingMethod.Alg())
+
+		testString := "test.signing.string"
+
+		signature, err := signingMethod.Sign(testString, ecdsaPrivKey)
+		require.NoError(t, err)
+		require.NotEmpty(t, signature)
+
+		err = signingMethod.Verify(testString, signature, &ecdsaPrivKey.PublicKey)
+		require.NoError(t, err)
+	})
+
+	t.Run("ES256K wrong key verification fails", func(t *testing.T) {
+		privKey2, err := secp.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		privKey2Bytes := privKey2.Key.Bytes()
+		ecdsaPrivKey2 := &ecdsa.PrivateKey{
+			PublicKey: ecdsa.PublicKey{
+				Curve: secp.S256(),
+				X:     privKey2.PubKey().X(),
+				Y:     privKey2.PubKey().Y(),
+			},
+			D: new(big.Int).SetBytes(privKey2Bytes[:]),
+		}
+
+		req := jsonrpc.Request[string]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "test-wrong-key",
+			Method:  "test.method",
+			Params:  func() *string { s := "test"; return &s }(),
+		}
+		tokenString, err := CreateRequestJWT(req, ecdsaPrivKey, time.Hour)
+		require.NoError(t, err)
+
+		// Try to verify with second key (should fail)
+		_, err = VerifyRequestJWT(tokenString, &ecdsaPrivKey2.PublicKey, req)
+		require.Error(t, err)
+	})
+}
+
+func TestCreateRequestJWT(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(secp.S256(), rand.Reader)
+	require.NoError(t, err)
+
+	t.Run("successful JWT creation", func(t *testing.T) {
+		req := jsonrpc.Request[map[string]interface{}]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "test-id",
+			Method:  "test.method",
+			Params: &map[string]interface{}{
+				"param1": "value1",
+				"param2": 42,
+			},
+		}
+
+		expiryDuration := time.Hour
+		tokenString, err := CreateRequestJWT(req, privateKey, expiryDuration)
+		require.NoError(t, err)
+		require.NotEmpty(t, tokenString)
+
+		token, err := jwt.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return &privateKey.PublicKey, nil
+		})
+		require.NoError(t, err)
+		require.True(t, token.Valid)
+
+		claims, ok := token.Claims.(*JWTClaims)
+		require.True(t, ok)
+		require.NotEmpty(t, claims.Digest)
+		require.NotEmpty(t, claims.Issuer)
+		require.NotNil(t, claims.ExpiresAt)
+		require.NotNil(t, claims.IssuedAt)
+
+		expectedDigest, err := req.Digest()
+		require.NoError(t, err)
+		require.Equal(t, expectedDigest, claims.Digest)
+
+		compressed, err := compressedECDSAPubKey(&privateKey.PublicKey)
+		require.NoError(t, err)
+		require.Equal(t, hex.EncodeToString(compressed), claims.Issuer)
+		expectedExpiry := claims.IssuedAt.Add(expiryDuration)
+		require.WithinDuration(t, expectedExpiry, claims.ExpiresAt.Time, time.Second)
+	})
+
+	t.Run("different expiry durations", func(t *testing.T) {
+		testParam := "test-param"
+		req := jsonrpc.Request[string]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "test-id",
+			Method:  "test.method",
+			Params:  &testParam,
+		}
+
+		testCases := []time.Duration{
+			time.Minute,
+			time.Hour,
+			24 * time.Hour,
+			7 * 24 * time.Hour,
+		}
+
+		for _, duration := range testCases {
+			t.Run(duration.String(), func(t *testing.T) {
+				tokenString, err := CreateRequestJWT(req, privateKey, duration)
+				require.NoError(t, err)
+
+				token, err := jwt.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+					return &privateKey.PublicKey, nil
+				})
+				require.NoError(t, err)
+
+				claims := token.Claims.(*JWTClaims)
+				expectedExpiry := claims.IssuedAt.Add(duration)
+				require.WithinDuration(t, expectedExpiry, claims.ExpiresAt.Time, time.Second)
+			})
+		}
+	})
+
+	t.Run("invalid request - digest failure", func(t *testing.T) {
+		// Create a request with unmarshalable data
+		type UnmarshalableType struct {
+			Channel chan string `json:"channel"`
+		}
+		req := jsonrpc.Request[UnmarshalableType]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "test-id",
+			Method:  "test.method",
+			Params: &UnmarshalableType{
+				Channel: make(chan string),
+			},
+		}
+
+		_, err := CreateRequestJWT(req, privateKey, time.Hour)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error marshaling JSON")
+	})
+
+	t.Run("nil private key", func(t *testing.T) {
+		testParam := "test-param"
+		req := jsonrpc.Request[string]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "test-id",
+			Method:  "test.method",
+			Params:  &testParam,
+		}
+
+		_, err := CreateRequestJWT(req, nil, time.Hour)
+		require.Error(t, err)
+	})
+
+	t.Run("different curve", func(t *testing.T) {
+		// Generate a key with a different curve (P256 instead of secp256k1)
+		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		testParam := "test-param"
+		req := jsonrpc.Request[string]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "test-id",
+			Method:  "test.method",
+			Params:  &testParam,
+		}
+
+		tokenString, err := CreateRequestJWT(req, privateKey, time.Hour)
+		require.NoError(t, err)
+
+		_, err = jwt.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return &privateKey.PublicKey, nil
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid public key")
+	})
+}
+
+func TestVerifyRequestJWT(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(secp.S256(), rand.Reader)
+	require.NoError(t, err)
+
+	// Create a valid token for testing
+	testParam := "test-param"
+	req := jsonrpc.Request[string]{
+		Version: jsonrpc.JsonRpcVersion,
+		ID:      "test-id",
+		Method:  "test.method",
+		Params:  &testParam,
+	}
+	validToken, err := CreateRequestJWT(req, privateKey, time.Hour)
+	require.NoError(t, err)
+
+	t.Run("successful verification", func(t *testing.T) {
+		claims, err := VerifyRequestJWT(validToken, &privateKey.PublicKey, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, claims)
+		require.NotEmpty(t, claims.Digest)
+		require.NotEmpty(t, claims.Issuer)
+
+		expectedDigest, err := req.Digest()
+		require.NoError(t, err)
+		require.Equal(t, expectedDigest, claims.Digest)
+
+		compressed, err := compressedECDSAPubKey(&privateKey.PublicKey)
+		require.NoError(t, err)
+		require.Equal(t, hex.EncodeToString(compressed), claims.Issuer)
+	})
+
+	t.Run("wrong public key", func(t *testing.T) {
+		wrongKey, err := ecdsa.GenerateKey(secp.S256(), rand.Reader)
+		require.NoError(t, err)
+
+		_, err = VerifyRequestJWT(validToken, &wrongKey.PublicKey, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature is invalid")
+	})
+
+	t.Run("malformed token", func(t *testing.T) {
+		_, err := VerifyRequestJWT("invalid.token.format", &privateKey.PublicKey, req)
+		require.Error(t, err)
+	})
+
+	t.Run("expired token", func(t *testing.T) {
+		expiredToken, err := CreateRequestJWT(req, privateKey, -time.Hour)
+		require.NoError(t, err)
+
+		_, err = VerifyRequestJWT(expiredToken, &privateKey.PublicKey, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "token is expired")
+	})
+
+	t.Run("invalid signing method", func(t *testing.T) {
+		// Create a token with HMAC instead of ECDSA
+		claims := JWTClaims{
+			Digest: "test-digest",
+			RegisteredClaims: jwt.RegisteredClaims{
+				Issuer:    "test-issuer",
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenString, err := token.SignedString([]byte("secret"))
+		require.NoError(t, err)
+
+		_, err = VerifyRequestJWT(tokenString, &privateKey.PublicKey, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature is invalid")
+	})
+
+	t.Run("token with wrong issuer", func(t *testing.T) {
+		// Create a token with the wrong issuer
+		digest, err := req.Digest()
+		require.NoError(t, err)
+
+		claims := JWTClaims{
+			Digest: digest,
+			RegisteredClaims: jwt.RegisteredClaims{
+				Issuer:    "wrong-issuer",
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+			},
+		}
+		token := jwt.NewWithClaims(SigningMethodES256K, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		_, err = VerifyRequestJWT(tokenString, &privateKey.PublicKey, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid issuer")
+	})
+
+	t.Run("nil public key", func(t *testing.T) {
+		_, err := VerifyRequestJWT(validToken, nil, req)
+		require.Error(t, err)
+	})
+
+	t.Run("token with invalid claims type", func(t *testing.T) {
+		// Create a token with standard claims instead of JWTClaims
+		standardClaims := jwt.RegisteredClaims{
+			Issuer:    "test-issuer",
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		}
+		token := jwt.NewWithClaims(SigningMethodES256K, standardClaims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		_, err = VerifyRequestJWT(tokenString, &privateKey.PublicKey, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid issuer")
+	})
+
+	t.Run("digest mismatch - different request", func(t *testing.T) {
+		// Create a different request with different digest
+		differentParam := "different-param"
+		differentReq := jsonrpc.Request[string]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "different-id",
+			Method:  "different.method",
+			Params:  &differentParam,
+		}
+
+		// Try to verify the token against the different request
+		_, err := VerifyRequestJWT(validToken, &privateKey.PublicKey, differentReq)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JWT digest does not match request digest")
+	})
+
+	t.Run("digest mismatch - modified request params", func(t *testing.T) {
+		// Create a request with same structure but different params
+		modifiedParam := "modified-test-param"
+		modifiedReq := jsonrpc.Request[string]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "test-id",
+			Method:  "test.method",
+			Params:  &modifiedParam,
+		}
+
+		// Try to verify the token against the modified request
+		_, err := VerifyRequestJWT(validToken, &privateKey.PublicKey, modifiedReq)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JWT digest does not match request digest")
+	})
+
+	t.Run("digest mismatch - wrong digest in JWT", func(t *testing.T) {
+		// Create a token with wrong digest
+		compressed, err := compressedECDSAPubKey(&privateKey.PublicKey)
+		require.NoError(t, err)
+
+		claims := JWTClaims{
+			Digest: "wrong-digest-hash",
+			RegisteredClaims: jwt.RegisteredClaims{
+				Issuer:    hex.EncodeToString(compressed),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+			},
+		}
+		token := jwt.NewWithClaims(SigningMethodES256K, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		_, err = VerifyRequestJWT(tokenString, &privateKey.PublicKey, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JWT digest does not match request digest")
+	})
+
+	t.Run("request digest calculation failure", func(t *testing.T) {
+		// Create a request with unmarshalable data
+		type UnmarshalableType struct {
+			Channel chan string `json:"channel"`
+		}
+		invalidReq := jsonrpc.Request[UnmarshalableType]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "test-id",
+			Method:  "test.method",
+			Params: &UnmarshalableType{
+				Channel: make(chan string),
+			},
+		}
+
+		_, err := VerifyRequestJWT(validToken, &privateKey.PublicKey, invalidReq)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error marshaling JSON")
+	})
+}
+
+func TestCompressedECDSAPubKey(t *testing.T) {
+	t.Run("valid public key", func(t *testing.T) {
+		privateKey, err := ecdsa.GenerateKey(secp.S256(), rand.Reader)
+		require.NoError(t, err)
+
+		compressed, err := compressedECDSAPubKey(&privateKey.PublicKey)
+		require.NoError(t, err)
+		require.NotEmpty(t, compressed)
+
+		// Compressed keys should be 33 bytes (1 byte prefix + 32 bytes X coordinate)
+		require.Equal(t, 33, len(compressed))
+		// The first byte should be 0x02 or 0x03 (compression prefix)
+		require.True(t, compressed[0] == 0x02 || compressed[0] == 0x03)
+	})
+
+	t.Run("nil public key", func(t *testing.T) {
+		_, err := compressedECDSAPubKey(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid public key")
+	})
+
+	t.Run("public key with nil X", func(t *testing.T) {
+		pubKey := &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     nil,
+			Y:     nil,
+		}
+		_, err := compressedECDSAPubKey(pubKey)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid public key")
+	})
+
+	t.Run("consistency test", func(t *testing.T) {
+		privateKey, err := ecdsa.GenerateKey(secp.S256(), rand.Reader)
+		require.NoError(t, err)
+
+		// Call the function multiple times with the same key
+		compressed1, err1 := compressedECDSAPubKey(&privateKey.PublicKey)
+		require.NoError(t, err1)
+		compressed2, err2 := compressedECDSAPubKey(&privateKey.PublicKey)
+		require.NoError(t, err2)
+		require.Equal(t, compressed1, compressed2)
+	})
+}
+
+func TestJWTEndToEnd(t *testing.T) {
+	t.Run("complete flow", func(t *testing.T) {
+		// Generate key pair
+		privateKey, err := ecdsa.GenerateKey(secp.S256(), rand.Reader)
+		require.NoError(t, err)
+
+		// Create a request
+		req := jsonrpc.Request[map[string]interface{}]{
+			Version: jsonrpc.JsonRpcVersion,
+			ID:      "e2e-test",
+			Method:  "trigger.action",
+			Params: &map[string]interface{}{
+				"action":    "send_email",
+				"recipient": "test@example.com",
+				"data": map[string]interface{}{
+					"subject": "Test Email",
+					"body":    "This is a test email",
+					"urgent":  true,
+				},
+			},
+		}
+
+		tokenString, err := CreateRequestJWT(req, privateKey, time.Hour)
+		require.NoError(t, err)
+		claims, err := VerifyRequestJWT(tokenString, &privateKey.PublicKey, req)
+		require.NoError(t, err)
+
+		expectedDigest, err := req.Digest()
+		require.NoError(t, err)
+		require.Equal(t, expectedDigest, claims.Digest)
+
+		compressed, err := compressedECDSAPubKey(&privateKey.PublicKey)
+		require.NoError(t, err)
+		require.Equal(t, hex.EncodeToString(compressed), claims.Issuer)
+
+		require.True(t, claims.ExpiresAt.After(time.Now()))
+		require.True(t, claims.IssuedAt.Before(time.Now().Add(time.Second)))
+	})
+
+	t.Run("different request types", func(t *testing.T) {
+		privateKey, err := ecdsa.GenerateKey(secp.S256(), rand.Reader)
+		require.NoError(t, err)
+
+		testCases := []struct {
+			name string
+			req  interface{}
+		}{
+			{
+				name: "string params",
+				req: func() jsonrpc.Request[string] {
+					param := "simple string parameter"
+					return jsonrpc.Request[string]{
+						Version: jsonrpc.JsonRpcVersion,
+						ID:      "string-test",
+						Method:  "test.string",
+						Params:  &param,
+					}
+				}(),
+			},
+			{
+				name: "int params",
+				req: func() jsonrpc.Request[int] {
+					param := 42
+					return jsonrpc.Request[int]{
+						Version: jsonrpc.JsonRpcVersion,
+						ID:      "int-test",
+						Method:  "test.int",
+						Params:  &param,
+					}
+				}(),
+			},
+			{
+				name: "slice params",
+				req: func() jsonrpc.Request[[]string] {
+					param := []string{"item1", "item2", "item3"}
+					return jsonrpc.Request[[]string]{
+						Version: jsonrpc.JsonRpcVersion,
+						ID:      "slice-test",
+						Method:  "test.slice",
+						Params:  &param,
+					}
+				}(),
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				var tokenString string
+				var err error
+				var claims *JWTClaims
+
+				switch req := tc.req.(type) {
+				case jsonrpc.Request[string]:
+					tokenString, err = CreateRequestJWT(req, privateKey, time.Hour)
+					require.NoError(t, err)
+					require.NotEmpty(t, tokenString)
+					claims, err = VerifyRequestJWT(tokenString, &privateKey.PublicKey, req)
+				case jsonrpc.Request[int]:
+					tokenString, err = CreateRequestJWT(req, privateKey, time.Hour)
+					require.NoError(t, err)
+					require.NotEmpty(t, tokenString)
+					claims, err = VerifyRequestJWT(tokenString, &privateKey.PublicKey, req)
+				case jsonrpc.Request[[]string]:
+					tokenString, err = CreateRequestJWT(req, privateKey, time.Hour)
+					require.NoError(t, err)
+					require.NotEmpty(t, tokenString)
+					claims, err = VerifyRequestJWT(tokenString, &privateKey.PublicKey, req)
+				}
+
+				require.NoError(t, err)
+				require.NotNil(t, claims)
+				require.NotEmpty(t, claims.Digest)
+			})
+		}
+	})
+}


### PR DESCRIPTION
- introduce create and verify methods for JSON-RPC JWT tokens
- implement `ES256K` signing algo because it's not natively supported by golang-jwt library
- make Digest() methods deterministic for JSON-RPC request and responses by sorting keys