### PR TITLE
move Metadata Prepend logic and report context creation logic from core to common

### DIFF
--- a/pkg/capabilities/consensus/report/context.go
+++ b/pkg/capabilities/consensus/report/context.go
@@ -1,0 +1,16 @@
+package report
+
+import (
+	"encoding/binary"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+// report context is the config digest + the sequence number padded with zeros
+func generateReportContext(seqNr uint64, configDigest types.ConfigDigest) []byte {
+	seqToEpoch := make([]byte, 32)
+	binary.BigEndian.PutUint32(seqToEpoch[32-5:32-1], uint32(seqNr)) //nolint:gosec
+	zeros := make([]byte, 32)
+	repContext := append(append(configDigest[:], seqToEpoch[:]...), zeros...)
+	return repContext
+}

--- a/pkg/capabilities/consensus/report/context_test.go
+++ b/pkg/capabilities/consensus/report/context_test.go
@@ -1,0 +1,21 @@
+package report
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+func TestGenerateReportContext(t *testing.T) {
+	seqNr := uint64(12345)
+	configDigest := types.ConfigDigest{}
+	copy(configDigest[:], []byte("testconfigdigest"))
+	result := generateReportContext(seqNr, configDigest)
+	expectedResult, err := hex.DecodeString("74657374636f6e6669676469676573740000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003039000000000000000000000000000000000000000000000000000000000000000000")
+	require.NoError(t, err)
+	assert.Equal(t, expectedResult, result)
+}

--- a/pkg/capabilities/consensus/report/metadata.go
+++ b/pkg/capabilities/consensus/report/metadata.go
@@ -1,0 +1,74 @@
+package report
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	consensustypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
+)
+
+func PrependMetadataFields(meta consensustypes.Metadata, userPayload []byte) ([]byte, error) {
+	var err error
+	var result []byte
+
+	// 1. Version (1 byte)
+	if meta.Version > 255 {
+		return nil, errors.New("version must be between 0 and 255")
+	}
+	result = append(result, byte(meta.Version))
+
+	// 2. Execution ID (32 bytes)
+	if result, err = decodeAndAppend(meta.ExecutionID, 32, result, "ExecutionID"); err != nil {
+		return nil, err
+	}
+
+	// 3. Timestamp (4 bytes)
+	tsBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(tsBytes, meta.Timestamp)
+	result = append(result, tsBytes...)
+
+	// 4. DON ID (4 bytes)
+	donIDBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(donIDBytes, meta.DONID)
+	result = append(result, donIDBytes...)
+
+	// 5. DON config version (4 bytes)
+	cfgVersionBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(cfgVersionBytes, meta.DONConfigVersion)
+	result = append(result, cfgVersionBytes...)
+
+	// 6. Workflow ID / spec hash (32 bytes)
+	if result, err = decodeAndAppend(meta.WorkflowID, 32, result, "WorkflowID"); err != nil {
+		return nil, err
+	}
+
+	// 7. Workflow Name (10 bytes)
+	if result, err = decodeAndAppend(meta.WorkflowName, 10, result, "WorkflowName"); err != nil {
+		return nil, err
+	}
+
+	// 8. Workflow Owner (20 bytes)
+	if result, err = decodeAndAppend(meta.WorkflowOwner, 20, result, "WorkflowOwner"); err != nil {
+		return nil, err
+	}
+
+	// 9. Report ID (2 bytes)
+	if result, err = decodeAndAppend(meta.ReportID, 2, result, "ReportID"); err != nil {
+		return nil, err
+	}
+
+	return append(result, userPayload...), nil
+}
+
+func decodeAndAppend(id string, expectedLen int, prevResult []byte, logName string) ([]byte, error) {
+	b, err := hex.DecodeString(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hex-decode %s (%s): %w", logName, id, err)
+	}
+	if len(b) != expectedLen {
+		return nil, fmt.Errorf("incorrect length for id %s (%s), expected %d bytes, got %d", logName, id, expectedLen, len(b))
+	}
+	return append(prevResult, b...), nil
+}

--- a/pkg/capabilities/consensus/report/metadata_test.go
+++ b/pkg/capabilities/consensus/report/metadata_test.go
@@ -1,0 +1,57 @@
+package report
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	consensustypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
+)
+
+var (
+	reportA = []byte{0x01, 0x02, 0x03}
+
+	workflowID       = "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
+	workflowName     = "aabbccddeeaabbccddee"
+	donID            = uint32(2)
+	donIDHex         = "00000002"
+	executionID      = "8d4e66421db647dd916d3ec28d56188c8d7dae5f808e03d03339ed2562f13bb0"
+	workflowOwnerID  = "0000000000000000000000000000000000000000"
+	reportID         = "9988"
+	timestampInt     = uint32(1234567890)
+	timestampHex     = "499602d2"
+	configVersionInt = uint32(1)
+	configVersionHex = "00000001"
+)
+
+func TestPrependMetadataFields(t *testing.T) {
+	result, err := PrependMetadataFields(getMetadata(workflowID), reportA)
+	require.NoError(t, err)
+
+	resultAsHex := hex.EncodeToString(result)
+
+	reportAAsString := hex.EncodeToString(reportA)
+	expectedResult := getHexMetadata() + reportAAsString
+
+	assert.Equal(t, expectedResult, resultAsHex)
+}
+
+func getHexMetadata() string {
+	return "01" + executionID + timestampHex + donIDHex + configVersionHex + workflowID + workflowName + workflowOwnerID + reportID
+}
+
+func getMetadata(cid string) consensustypes.Metadata {
+	return consensustypes.Metadata{
+		Version:          1,
+		ExecutionID:      executionID,
+		Timestamp:        timestampInt,
+		DONID:            donID,
+		DONConfigVersion: configVersionInt,
+		WorkflowID:       cid,
+		WorkflowName:     workflowName,
+		WorkflowOwner:    workflowOwnerID,
+		ReportID:         reportID,
+	}
+}


### PR DESCRIPTION
Move this report generation logic that is used by consensus capability to common.  Once core is bumped to this common version the corresponding code in core should be updated to use these methods.
