### PR TITLE
Update standard tests, since we're no longer wrapping simple consensus

### DIFF
--- a/pkg/workflows/wasm/host/standard_test.go
+++ b/pkg/workflows/wasm/host/standard_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	valuespb "github.com/smartcontractkit/chainlink-common/pkg/values/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
-	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host/internal/rawsdk"
 )
 
 // See the README.md in standard_tests for more information.
@@ -173,14 +172,8 @@ func TestStandardModeSwitch(t *testing.T) {
 			return time.Now(), nil
 		}).Maybe()
 		mockExecutionHelper.EXPECT().CallCapability(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, request *pb.CapabilityRequest) (*pb.CapabilityResponse, error) {
-			response := values.NewString("hi")
-			mapProto := &valuespb.Map{
-				Fields: map[string]*valuespb.Value{
-					rawsdk.ConsensusResponseMapKeyMetadata: {Value: &valuespb.Value_StringValue{StringValue: "test_metadata"}},
-					rawsdk.ConsensusResponseMapKeyPayload:  values.Proto(response),
-				},
-			}
-			payload, err := anypb.New(&valuespb.Value{Value: &valuespb.Value_MapValue{MapValue: mapProto}})
+			response := values.Proto(values.NewString("hi"))
+			payload, err := anypb.New(response)
 			require.NoError(t, err)
 			return &pb.CapabilityResponse{
 				Response: &pb.CapabilityResponse_Payload{


### PR DESCRIPTION
I forgot to push the second commit in my prior PR. The result is unused, so the raw sdk doesn't decode it, that's why it passes without a real SDK.