### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/capabilities/consensus/ocr3/aggregators/reduce_aggregator.go
+++ b/pkg/capabilities/consensus/ocr3/aggregators/reduce_aggregator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"slices"
 	"sort"
 	"strconv"
 	"time"
@@ -534,12 +535,7 @@ func formatReport(report map[string]any, format string) (any, error) {
 }
 
 func isOneOf(toCheck string, options []string) bool {
-	for _, option := range options {
-		if toCheck == option {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(options, toCheck)
 }
 
 func NewReduceAggregator(config values.Map) (types.Aggregator, error) {

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/pricegetter.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/pricegetter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/stretchr/testify/assert"
 
@@ -49,12 +50,9 @@ func (s staticPriceGetter) FilterConfiguredTokens(ctx context.Context, tokens []
 
 	for _, tk := range tokens {
 		found := false
-		for _, addr := range s.config.Addresses {
-			if addr == tk {
-				found = true
-				configured = append(configured, tk)
-				break
-			}
+		if slices.Contains(s.config.Addresses, tk) {
+			found = true
+			configured = append(configured, tk)
 		}
 		if !found {
 			unconfigured = append(unconfigured, tk)

--- a/pkg/sqlutil/sqltest/txdb.go
+++ b/pkg/sqlutil/sqltest/txdb.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 
@@ -38,11 +39,9 @@ func RegisterTxDB(dbURL string) error {
 	defer registerMutex.Unlock()
 	drivers := sql.Drivers()
 
-	for _, driver := range drivers {
-		if driver == pg.DriverTxWrappedPostgres {
-			// TxDB driver already registered
-			return nil
-		}
+	if slices.Contains(drivers, pg.DriverTxWrappedPostgres) {
+		// TxDB driver already registered
+		return nil
 	}
 
 	if dbURL != pg.DriverInMemoryPostgres {

--- a/pkg/workflows/secrets/secrets.go
+++ b/pkg/workflows/secrets/secrets.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"golang.org/x/crypto/nacl/box"
@@ -45,12 +46,7 @@ type EncryptedSecretsResult struct {
 }
 
 func ContainsP2pId(p2pId [32]byte, p2pIds [][32]byte) bool {
-	for _, id := range p2pIds {
-		if id == p2pId {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(p2pIds, p2pId)
 }
 
 func EncryptSecretsForNodes(


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

