### PR TITLE
[CRE-595] Fix context handling in BeholderLogger

### DIFF
--- a/pkg/custmsg/logger.go
+++ b/pkg/custmsg/logger.go
@@ -8,227 +8,228 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
-const (
-	LogLevelKey                  = "log_level"
-	defaultBeholderEmitTimeoutMs = 100
-)
+const LogLevelKey = "log_level"
 
-type beholderLogger struct {
-	underlying  logger.Logger
-	emitter     MessageEmitter
-	emitTimeout time.Duration
+type LogTaskProcessor interface {
+	Enqueue(func(context.Context))
 }
 
-func NewBeholderLogger(underlying logger.Logger, emitter MessageEmitter) *beholderLogger {
+type beholderLogger struct {
+	underlying logger.Logger
+	emitter    MessageEmitter
+	emitQueue  LogTaskProcessor
+}
+
+func NewBeholderLogger(underlying logger.Logger, emitter MessageEmitter, emitQueue LogTaskProcessor) *beholderLogger {
 	return &beholderLogger{
-		underlying:  logger.Helper(underlying, 1),
-		emitter:     emitter,
-		emitTimeout: defaultBeholderEmitTimeoutMs * time.Millisecond,
+		underlying: logger.Helper(underlying, 1),
+		emitter:    emitter,
+		emitQueue:  emitQueue,
 	}
 }
 
 func (b *beholderLogger) With(args ...any) *beholderLogger {
 	return &beholderLogger{
-		underlying:  logger.With(b.underlying, args...),
-		emitter:     b.emitter.WithMapLabels(getLabelMap(args...)),
-		emitTimeout: b.emitTimeout,
+		underlying: logger.With(b.underlying, args...),
+		emitter:    b.emitter.WithMapLabels(getLabelMap(args...)),
+		emitQueue:  b.emitQueue,
 	}
 }
 
 func (b *beholderLogger) WithEmitTimeout(name string, emitTimeout time.Duration) *beholderLogger {
 	return &beholderLogger{
-		underlying:  b.underlying,
-		emitter:     b.emitter,
-		emitTimeout: emitTimeout,
+		underlying: b.underlying,
+		emitter:    b.emitter,
+		emitQueue:  b.emitQueue,
 	}
 }
 
 func (b *beholderLogger) Named(name string) *beholderLogger {
 	return &beholderLogger{
-		underlying:  logger.Named(b.underlying, name),
-		emitter:     b.emitter,
-		emitTimeout: b.emitTimeout,
+		underlying: logger.Named(b.underlying, name),
+		emitter:    b.emitter,
+		emitQueue:  b.emitQueue,
 	}
 }
 
 func (b *beholderLogger) Debug(args ...any) {
 	b.underlying.Debug(args...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "debug").Emit(ctx, fmt.Sprint(args...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "debug").Emit(ctx, fmt.Sprint(args...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Info(args ...any) {
 	b.underlying.Info(args...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "info").Emit(ctx, fmt.Sprint(args...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "info").Emit(ctx, fmt.Sprint(args...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Warn(args ...any) {
 	b.underlying.Warn(args...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "warn").Emit(ctx, fmt.Sprint(args...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "warn").Emit(ctx, fmt.Sprint(args...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Error(args ...any) {
 	b.underlying.Error(args...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "error").Emit(ctx, fmt.Sprint(args...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "error").Emit(ctx, fmt.Sprint(args...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Panic(args ...any) {
 	b.underlying.Panic(args...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "panic").Emit(ctx, fmt.Sprint(args...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "panic").Emit(ctx, fmt.Sprint(args...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Fatal(args ...any) {
 	b.underlying.Fatal(args...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "fatal").Emit(ctx, fmt.Sprint(args...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "fatal").Emit(ctx, fmt.Sprint(args...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Debugf(format string, values ...any) {
 	b.underlying.Debugf(format, values...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "debug").Emit(ctx, fmt.Sprintf(format, values...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "debug").Emit(ctx, fmt.Sprintf(format, values...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Infof(format string, values ...any) {
 	b.underlying.Infof(format, values...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "info").Emit(ctx, fmt.Sprintf(format, values...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "info").Emit(ctx, fmt.Sprintf(format, values...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Warnf(format string, values ...any) {
 	b.underlying.Warnf(format, values...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "warn").Emit(ctx, fmt.Sprintf(format, values...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "warn").Emit(ctx, fmt.Sprintf(format, values...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Errorf(format string, values ...any) {
 	b.underlying.Errorf(format, values...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "error").Emit(ctx, fmt.Sprintf(format, values...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "error").Emit(ctx, fmt.Sprintf(format, values...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Panicf(format string, values ...any) {
 	b.underlying.Panicf(format, values...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "panic").Emit(ctx, fmt.Sprintf(format, values...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "panic").Emit(ctx, fmt.Sprintf(format, values...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Fatalf(format string, values ...any) {
 	b.underlying.Fatalf(format, values...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "fatal").Emit(ctx, fmt.Sprintf(format, values...))
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "fatal").Emit(ctx, fmt.Sprintf(format, values...))
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Debugw(msg string, keysAndValues ...any) {
 	b.underlying.Debugw(msg, keysAndValues...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "debug").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "debug").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Infow(msg string, keysAndValues ...any) {
 	b.underlying.Infow(msg, keysAndValues...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "info").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "info").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Warnw(msg string, keysAndValues ...any) {
 	b.underlying.Warnw(msg, keysAndValues...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "warn").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "warn").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Errorw(msg string, keysAndValues ...any) {
 	b.underlying.Errorw(msg, keysAndValues...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "error").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "error").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Panicw(msg string, keysAndValues ...any) {
 	b.underlying.Panicw(msg, keysAndValues...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "panic").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "panic").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Fatalw(msg string, keysAndValues ...any) {
 	b.underlying.Fatalw(msg, keysAndValues...)
-	ctx, cancel := getBeholderCallContext()
-	defer cancel()
-	err := b.emitter.With(LogLevelKey, "fatal").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
-	if err != nil {
-		b.underlying.Errorw("error emitting log to Beholder", "error", err)
-	}
+	b.emitQueue.Enqueue(func(ctx context.Context) {
+		err := b.emitter.With(LogLevelKey, "fatal").WithMapLabels(getLabelMap(keysAndValues...)).Emit(ctx, msg)
+		if err != nil {
+			b.underlying.Errorw("error emitting log to Beholder", "error", err)
+		}
+	})
 }
 
 func (b *beholderLogger) Sync() error {
@@ -252,9 +253,4 @@ func getLabelMap(keysAndValues ...any) map[string]string {
 		labels[key] = value
 	}
 	return labels
-}
-
-func getBeholderCallContext() (context.Context, context.CancelFunc) {
-	// Beholder Emit() should not block for logs wrapped in a custom event but let's be safe
-	return context.WithTimeout(context.Background(), defaultBeholderEmitTimeoutMs*time.Millisecond)
 }

--- a/pkg/custmsg/logger_test.go
+++ b/pkg/custmsg/logger_test.go
@@ -3,6 +3,7 @@ package custmsg
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/matches"
@@ -10,7 +11,12 @@ import (
 
 func TestBeholderLogger(t *testing.T) {
 	emitter := newMockMessageEmitter(t)
-	lggr := NewBeholderLogger(logger.Test(t), emitter)
+	taskProc := &taskProcessor{
+		emitQueue: make(chan func(context.Context), 10),
+	}
+	loopDone := make(chan struct{})
+	go emitLoop(t, taskProc.emitQueue, loopDone)
+	lggr := NewBeholderLogger(logger.Test(t), emitter, taskProc)
 
 	emitter.EXPECT().With(LogLevelKey, "debug").Return(emitter).Once()
 	emitter.EXPECT().Emit(matches.AnyContext, "message").Return(nil).Once()
@@ -27,11 +33,18 @@ func TestBeholderLogger(t *testing.T) {
 
 	emitter.EXPECT().WithMapLabels(map[string]string{"keyY": "valueY"}).Return(emitter).Once()
 	_ = lggr.With("keyY", "valueY")
+	close(taskProc.emitQueue)
+	<-loopDone
 }
 
 func TestBeholderLogger_Blocking(t *testing.T) {
 	emitter := newMockMessageEmitter(t)
-	lggr := NewBeholderLogger(logger.Test(t), emitter)
+	taskProc := &taskProcessor{
+		emitQueue: make(chan func(context.Context), 10),
+	}
+	loopDone := make(chan struct{})
+	go emitLoop(t, taskProc.emitQueue, loopDone)
+	lggr := NewBeholderLogger(logger.Test(t), emitter, taskProc)
 
 	emitter.EXPECT().With(LogLevelKey, "debug").Return(emitter).Once()
 	// simulate a blocking call
@@ -41,4 +54,24 @@ func TestBeholderLogger_Blocking(t *testing.T) {
 	}).Once()
 	// should eventually cancel the context
 	lggr.Debug("message")
+	close(taskProc.emitQueue)
+	<-loopDone
+}
+
+type taskProcessor struct {
+	emitQueue chan func(context.Context)
+}
+
+func (tp *taskProcessor) Enqueue(fn func(context.Context)) {
+	tp.emitQueue <- fn
+}
+
+func emitLoop(t *testing.T, emitQueue chan func(context.Context), done chan struct{}) {
+	for fn := range emitQueue {
+		// block for 100ms to simulate a blocking call
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+		fn(ctx)
+	}
+	close(done)
 }


### PR DESCRIPTION
Push to a channel serviced by the caller (ideally in a separate goroutine)
