### PR TITLE
switching metering units over to billing proto

### DIFF
--- a/pkg/metering/units.go
+++ b/pkg/metering/units.go
@@ -4,13 +4,18 @@ import (
 	"fmt"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
+	billing "github.com/smartcontractkit/chainlink-protos/billing/go"
 )
 
 var (
-	PayloadUnit = unit{Name: "payload", Unit: "bytes"}
+	PayloadUnit = unit{
+		Name: billing.ResourceType_RESOURCE_TYPE_NETWORK.String(),
+		Unit: billing.MeasurementUnit_MEASUREMENT_UNIT_BYTES.String()}
 
-	// ComputeUnit is an example.
-	ComputeUnit = unit{Name: "compute", Unit: "ms"}
+
+	ComputeUnit = unit{
+		Name: billing.ResourceType_RESOURCE_TYPE_COMPUTE.String(),
+		Unit: billing.MeasurementUnit_MEASUREMENT_UNIT_MILLISECONDS.String()}
 )
 
 // unit provides exported Name and unit fields for


### PR DESCRIPTION
The billing service expects unit names from the chainlink-protos repo. Instead of maintaining a switch statement like currently in https://github.com/smartcontractkit/chainlink/pull/18821/files#diff-b99512a623b961f122d18085f397b1ac84b2de9b7578012a2697fe5fe8879038R365, this change sets the right values upstream. 

The consensus capability + engine will have to pull this change in. 