### PR TITLE
DF-21518 Use a correct data ID in the sm aggregator

### DIFF
--- a/pkg/capabilities/consensus/ocr3/datafeeds/feeds_aggregator.go
+++ b/pkg/capabilities/consensus/ocr3/datafeeds/feeds_aggregator.go
@@ -38,6 +38,8 @@ const (
 	TimestampOutputFieldName    = EVMEncoderKey("Timestamp")
 	RemappedIDOutputFieldName   = EVMEncoderKey("RemappedID")
 	StreamIDOutputFieldName     = EVMEncoderKey("StreamID")
+	DataIDOutputFieldName       = EVMEncoderKey("DataID")
+	AnswerOutputFieldName       = EVMEncoderKey("Answer")
 
 	addrLen = 20
 )

--- a/pkg/capabilities/consensus/ocr3/datafeeds/securemint_aggregator.go
+++ b/pkg/capabilities/consensus/ocr3/datafeeds/securemint_aggregator.go
@@ -191,22 +191,22 @@ func (a *SecureMintAggregator) createOutcome(lggr logger.Logger, report *secureM
 
 	// Convert chain selector to bytes for data ID
 	// Secure Mint dataID: 0x04 + chain selector as bytes + right padded with 0s
-	var chainSelectorAsDataID [32]byte
+	var chainSelectorAsDataID [16]byte
 	chainSelectorAsDataID[0] = 0x04
 	binary.BigEndian.PutUint64(chainSelectorAsDataID[1:], uint64(a.config.TargetChainSelector))
 
-	smReportAsPrice, err := packSecureMintReportIntoUint224ForEVM(report.Mintable, report.Block)
+	smReportAsAnswer, err := packSecureMintReportIntoUint224ForEVM(report.Mintable, report.Block)
 	if err != nil {
-		return nil, fmt.Errorf("failed to pack secure mint report for into uint224: %w", err)
+		return nil, fmt.Errorf("failed to pack secure mint report for evm into uint224: %w", err)
 	}
-	lggr.Debugw("packed report into price", "smReportAsPrice", smReportAsPrice)
+	lggr.Debugw("packed report into answer", "smReportAsAnswer", smReportAsAnswer)
 
 	// This is what the DF Cache contract expects:
-	// abi: "(bytes32 FeedID, uint224 Price, uint32 Timestamp)[] Reports"
+	// abi: "(bytes16 dataId, uint32 timestamp, uint224 answer)[] Reports"
 	toWrap := []any{
 		map[EVMEncoderKey]any{
-			FeedIDOutputFieldName:    chainSelectorAsDataID,
-			PriceOutputFieldName:     smReportAsPrice,
+			DataIDOutputFieldName:    chainSelectorAsDataID,
+			AnswerOutputFieldName:    smReportAsAnswer,
 			TimestampOutputFieldName: int64(report.Block),
 		},
 	}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->
Nothing

### Supports
https://github.com/smartcontractkit/chainlink/pull/18870

### Notes

Updates the secure mint aggregator to properly write to the DF Cache.
In our test (see https://github.com/smartcontractkit/chainlink/pull/18870) we were using the KeystoneFeedsConsumer contract as consumer contract, while in reality we should use the DF Cache contract. This fixes that. 