### PR TITLE
CCIP-6366 backport tracing disabled

### DIFF
--- a/pkg/loop/config.go
+++ b/pkg/loop/config.go
@@ -24,6 +24,7 @@ const (
 	envDatabaseLogSQL                       = "CL_DATABASE_LOG_SQL"
 	envDatabaseMaxOpenConns                 = "CL_DATABASE_MAX_OPEN_CONNS"
 	envDatabaseMaxIdleConns                 = "CL_DATABASE_MAX_IDLE_CONNS"
+	envDatabaseTracingEnabled               = "CL_DATABASE_TRACING_ENABLED"
 
 	envFeatureLogPoller = "CL_FEATURE_LOG_POLLER"
 
@@ -77,6 +78,7 @@ type EnvConfig struct {
 	DatabaseLogSQL                       bool
 	DatabaseMaxOpenConns                 int
 	DatabaseMaxIdleConns                 int
+	DatabaseTracingEnabled               bool
 
 	FeatureLogPoller bool
 
@@ -134,6 +136,7 @@ func (e *EnvConfig) AsCmdEnv() (env []string) {
 		add(envDatabaseLogSQL, strconv.FormatBool(e.DatabaseLogSQL))
 		add(envDatabaseMaxOpenConns, strconv.Itoa(e.DatabaseMaxOpenConns))
 		add(envDatabaseMaxIdleConns, strconv.Itoa(e.DatabaseMaxIdleConns))
+		add(envDatabaseTracingEnabled, strconv.FormatBool(e.DatabaseTracingEnabled))
 	}
 
 	add(envFeatureLogPoller, strconv.FormatBool(e.FeatureLogPoller))
@@ -228,6 +231,10 @@ func (e *EnvConfig) parse() error {
 			return err
 		}
 		e.DatabaseMaxIdleConns, err = getEnv(envDatabaseMaxIdleConns, strconv.Atoi)
+		if err != nil {
+			return err
+		}
+		e.DatabaseTracingEnabled, err = getBool(envDatabaseTracingEnabled)
 		if err != nil {
 			return err
 		}

--- a/pkg/loop/config_test.go
+++ b/pkg/loop/config_test.go
@@ -36,6 +36,7 @@ func TestEnvConfig_parse(t *testing.T) {
 				envDatabaseLogSQL:                       "true",
 				envDatabaseMaxOpenConns:                 "9999",
 				envDatabaseMaxIdleConns:                 "8080",
+				envDatabaseTracingEnabled:               "true",
 
 				envFeatureLogPoller: "true",
 
@@ -133,6 +134,7 @@ var envCfgFull = EnvConfig{
 	DatabaseLogSQL:                       true,
 	DatabaseMaxOpenConns:                 9999,
 	DatabaseMaxIdleConns:                 8080,
+	DatabaseTracingEnabled:               true,
 
 	FeatureLogPoller: true,
 
@@ -182,6 +184,7 @@ func TestEnvConfig_AsCmdEnv(t *testing.T) {
 	}
 
 	assert.Equal(t, "postgres://user:password@localhost:5432/db", got[envDatabaseURL])
+	assert.Equal(t, "true", got["CL_DATABASE_TRACING_ENABLED"])
 
 	assert.Equal(t, "1ms", got[envMercuryCacheLatestReportDeadline])
 	assert.Equal(t, "1µs", got[envMercuryCacheLatestReportTTL])

--- a/pkg/loop/server.go
+++ b/pkg/loop/server.go
@@ -166,6 +166,7 @@ func (s *Server) start() error {
 			LockTimeout:            s.EnvConfig.DatabaseLockTimeout,
 			MaxOpenConns:           s.EnvConfig.DatabaseMaxOpenConns,
 			MaxIdleConns:           s.EnvConfig.DatabaseMaxIdleConns,
+			EnableTracing:         	s.EnvConfig.DatabaseTracingEnabled,
 		}.New(ctx, dbURL, pg.DriverPostgres)
 		if err != nil {
 			return fmt.Errorf("error connecting to DataBase: %w", err)

--- a/pkg/sqlutil/pg/pg_test.go
+++ b/pkg/sqlutil/pg/pg_test.go
@@ -30,3 +30,17 @@ func Test_disallowReplica(t *testing.T) {
 	_, err = db.Exec("SET session_replication_role= 'not_valid_role'")
 	require.Error(t, err)
 }
+
+func TestDBConfig_WithTracing(t *testing.T) {
+	t.Parallel()
+	cfg := pg.DBConfig{}
+	require.False(t, cfg.EnableTracing)
+
+	cfgWithTrace := cfg.WithTracing(true)
+	require.True(t, cfgWithTrace.EnableTracing)
+	require.False(t, cfg.EnableTracing) // ensure original is not modified
+
+	cfgNoTrace := cfgWithTrace.WithTracing(false)
+	require.False(t, cfgNoTrace.EnableTracing)
+	require.True(t, cfgWithTrace.EnableTracing) // ensure original is not modified
+}


### PR DESCRIPTION
Backport https://github.com/smartcontractkit/chainlink-common/commit/0d28c6315689f22adace91f43c3f7333a0dd6c8f for `2.26.0-ccip`

Changes:
* DBConfig: add EnableTracing flag (default false)
* loop/server: wire up DBConfig.EnableTracing flag