### PR TITLE
Add Decrypt function to UnimplementedKeystore

### DIFF
--- a/pkg/types/core/keystore.go
+++ b/pkg/types/core/keystore.go
@@ -101,8 +101,6 @@ func (c *singleAccountSigner) Sign(ctx context.Context, account string, data []b
 	return nil, fmt.Errorf("account not found: %s", account)
 }
 
-var _ Keystore = &UnimplementedKeystore{}
-
 type UnimplementedKeystore struct{}
 
 func (u *UnimplementedKeystore) Accounts(ctx context.Context) (accounts []string, err error) {
@@ -111,4 +109,8 @@ func (u *UnimplementedKeystore) Accounts(ctx context.Context) (accounts []string
 
 func (u *UnimplementedKeystore) Sign(ctx context.Context, account string, data []byte) (signed []byte, err error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Sign not implemented")
+}
+
+func (u *UnimplementedKeystore) Decrypt(ctx context.Context, account string, ctxt []byte) (msg []byte, err error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Decrypt not implemented")
 }

--- a/pkg/types/core/keystore.go
+++ b/pkg/types/core/keystore.go
@@ -101,6 +101,8 @@ func (c *singleAccountSigner) Sign(ctx context.Context, account string, data []b
 	return nil, fmt.Errorf("account not found: %s", account)
 }
 
+var _ Keystore = &UnimplementedKeystore{}
+
 type UnimplementedKeystore struct{}
 
 func (u *UnimplementedKeystore) Accounts(ctx context.Context) (accounts []string, err error) {


### PR DESCRIPTION
## Summary

Adds a `Decrypt` method to `UnimplementedKeystore` in `pkg/types/core/keystore.go`, returning `codes.Unimplemented`.

## Why

A new keystore consumer (confidential compute) needs the `Decrypt` method on the interface. Adding the stub to `UnimplementedKeystore` lets mocks and test implementations that embed it continue to compile without implementing every method.
