### PR TITLE
Update relayer ccip provider interface to use dedicated args

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.24.2
+golang 1.24.5
 protoc 29.3
 protoc-gen-go-grpc 1.3.0
 golangci-lint 2.2.2

--- a/pkg/loop/internal/pb/relayer.pb.go
+++ b/pkg/loop/internal/pb/relayer.pb.go
@@ -360,7 +360,7 @@ func (x *RelayArgs) GetProviderType() string {
 	return ""
 }
 
-// RelayArgs represents [github.com/smartcontractkit/chainlink-common/pkg/types.PluginArgs].
+// PluginArgs represents [github.com/smartcontractkit/chainlink-common/pkg/types.PluginArgs].
 type PluginArgs struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TransmitterID string                 `protobuf:"bytes,1,opt,name=transmitterID,proto3" json:"transmitterID,omitempty"`
@@ -413,6 +413,66 @@ func (x *PluginArgs) GetPluginConfig() []byte {
 	return nil
 }
 
+type CCIPProviderArgs struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	ExternalJobID        []byte                 `protobuf:"bytes,1,opt,name=externalJobID,proto3" json:"externalJobID,omitempty"` // [32]byte
+	ContractReaderConfig []byte                 `protobuf:"bytes,2,opt,name=contractReaderConfig,proto3" json:"contractReaderConfig,omitempty"`
+	ChainWriterConfig    []byte                 `protobuf:"bytes,3,opt,name=chainWriterConfig,proto3" json:"chainWriterConfig,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *CCIPProviderArgs) Reset() {
+	*x = CCIPProviderArgs{}
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CCIPProviderArgs) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CCIPProviderArgs) ProtoMessage() {}
+
+func (x *CCIPProviderArgs) ProtoReflect() protoreflect.Message {
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CCIPProviderArgs.ProtoReflect.Descriptor instead.
+func (*CCIPProviderArgs) Descriptor() ([]byte, []int) {
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *CCIPProviderArgs) GetExternalJobID() []byte {
+	if x != nil {
+		return x.ExternalJobID
+	}
+	return nil
+}
+
+func (x *CCIPProviderArgs) GetContractReaderConfig() []byte {
+	if x != nil {
+		return x.ContractReaderConfig
+	}
+	return nil
+}
+
+func (x *CCIPProviderArgs) GetChainWriterConfig() []byte {
+	if x != nil {
+		return x.ChainWriterConfig
+	}
+	return nil
+}
+
 // NewContractWriterRequest has request parameters for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewContractWriter].
 type NewContractWriterRequest struct {
 	state                protoimpl.MessageState `protogen:"open.v1"`
@@ -423,7 +483,7 @@ type NewContractWriterRequest struct {
 
 func (x *NewContractWriterRequest) Reset() {
 	*x = NewContractWriterRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[7]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -435,7 +495,7 @@ func (x *NewContractWriterRequest) String() string {
 func (*NewContractWriterRequest) ProtoMessage() {}
 
 func (x *NewContractWriterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[7]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -448,7 +508,7 @@ func (x *NewContractWriterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewContractWriterRequest.ProtoReflect.Descriptor instead.
 func (*NewContractWriterRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{7}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *NewContractWriterRequest) GetContractWriterConfig() []byte {
@@ -468,7 +528,7 @@ type NewContractWriterReply struct {
 
 func (x *NewContractWriterReply) Reset() {
 	*x = NewContractWriterReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[8]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -480,7 +540,7 @@ func (x *NewContractWriterReply) String() string {
 func (*NewContractWriterReply) ProtoMessage() {}
 
 func (x *NewContractWriterReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[8]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -493,7 +553,7 @@ func (x *NewContractWriterReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewContractWriterReply.ProtoReflect.Descriptor instead.
 func (*NewContractWriterReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{8}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *NewContractWriterReply) GetContractWriterID() uint32 {
@@ -513,7 +573,7 @@ type NewContractReaderRequest struct {
 
 func (x *NewContractReaderRequest) Reset() {
 	*x = NewContractReaderRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[9]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -525,7 +585,7 @@ func (x *NewContractReaderRequest) String() string {
 func (*NewContractReaderRequest) ProtoMessage() {}
 
 func (x *NewContractReaderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[9]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -538,7 +598,7 @@ func (x *NewContractReaderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewContractReaderRequest.ProtoReflect.Descriptor instead.
 func (*NewContractReaderRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{9}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *NewContractReaderRequest) GetContractReaderConfig() []byte {
@@ -558,7 +618,7 @@ type NewContractReaderReply struct {
 
 func (x *NewContractReaderReply) Reset() {
 	*x = NewContractReaderReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[10]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -570,7 +630,7 @@ func (x *NewContractReaderReply) String() string {
 func (*NewContractReaderReply) ProtoMessage() {}
 
 func (x *NewContractReaderReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[10]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -583,7 +643,7 @@ func (x *NewContractReaderReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewContractReaderReply.ProtoReflect.Descriptor instead.
 func (*NewContractReaderReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{10}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *NewContractReaderReply) GetContractReaderID() uint32 {
@@ -604,7 +664,7 @@ type NewPluginProviderRequest struct {
 
 func (x *NewPluginProviderRequest) Reset() {
 	*x = NewPluginProviderRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[11]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -616,7 +676,7 @@ func (x *NewPluginProviderRequest) String() string {
 func (*NewPluginProviderRequest) ProtoMessage() {}
 
 func (x *NewPluginProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[11]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -629,7 +689,7 @@ func (x *NewPluginProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewPluginProviderRequest.ProtoReflect.Descriptor instead.
 func (*NewPluginProviderRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{11}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *NewPluginProviderRequest) GetRelayArgs() *RelayArgs {
@@ -656,7 +716,7 @@ type NewPluginProviderReply struct {
 
 func (x *NewPluginProviderReply) Reset() {
 	*x = NewPluginProviderReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[12]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -668,7 +728,7 @@ func (x *NewPluginProviderReply) String() string {
 func (*NewPluginProviderReply) ProtoMessage() {}
 
 func (x *NewPluginProviderReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[12]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -681,7 +741,7 @@ func (x *NewPluginProviderReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewPluginProviderReply.ProtoReflect.Descriptor instead.
 func (*NewPluginProviderReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{12}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *NewPluginProviderReply) GetPluginProviderID() uint32 {
@@ -701,7 +761,7 @@ type NewConfigProviderRequest struct {
 
 func (x *NewConfigProviderRequest) Reset() {
 	*x = NewConfigProviderRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[13]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -713,7 +773,7 @@ func (x *NewConfigProviderRequest) String() string {
 func (*NewConfigProviderRequest) ProtoMessage() {}
 
 func (x *NewConfigProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[13]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -726,7 +786,7 @@ func (x *NewConfigProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewConfigProviderRequest.ProtoReflect.Descriptor instead.
 func (*NewConfigProviderRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{13}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *NewConfigProviderRequest) GetRelayArgs() *RelayArgs {
@@ -746,7 +806,7 @@ type NewConfigProviderReply struct {
 
 func (x *NewConfigProviderReply) Reset() {
 	*x = NewConfigProviderReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[14]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -758,7 +818,7 @@ func (x *NewConfigProviderReply) String() string {
 func (*NewConfigProviderReply) ProtoMessage() {}
 
 func (x *NewConfigProviderReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[14]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -771,7 +831,7 @@ func (x *NewConfigProviderReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewConfigProviderReply.ProtoReflect.Descriptor instead.
 func (*NewConfigProviderReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{14}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *NewConfigProviderReply) GetConfigProviderID() uint32 {
@@ -783,15 +843,15 @@ func (x *NewConfigProviderReply) GetConfigProviderID() uint32 {
 
 // NewCCIPProviderRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewCCIPProvider].
 type NewCCIPProviderRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RelayArgs     *RelayArgs             `protobuf:"bytes,1,opt,name=relayArgs,proto3" json:"relayArgs,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	CcipProviderArgs *CCIPProviderArgs      `protobuf:"bytes,1,opt,name=ccipProviderArgs,proto3" json:"ccipProviderArgs,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *NewCCIPProviderRequest) Reset() {
 	*x = NewCCIPProviderRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[15]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -803,7 +863,7 @@ func (x *NewCCIPProviderRequest) String() string {
 func (*NewCCIPProviderRequest) ProtoMessage() {}
 
 func (x *NewCCIPProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[15]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -816,12 +876,12 @@ func (x *NewCCIPProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewCCIPProviderRequest.ProtoReflect.Descriptor instead.
 func (*NewCCIPProviderRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{15}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{16}
 }
 
-func (x *NewCCIPProviderRequest) GetRelayArgs() *RelayArgs {
+func (x *NewCCIPProviderRequest) GetCcipProviderArgs() *CCIPProviderArgs {
 	if x != nil {
-		return x.RelayArgs
+		return x.CcipProviderArgs
 	}
 	return nil
 }
@@ -836,7 +896,7 @@ type NewCCIPProviderReply struct {
 
 func (x *NewCCIPProviderReply) Reset() {
 	*x = NewCCIPProviderReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[16]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -848,7 +908,7 @@ func (x *NewCCIPProviderReply) String() string {
 func (*NewCCIPProviderReply) ProtoMessage() {}
 
 func (x *NewCCIPProviderReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[16]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -861,7 +921,7 @@ func (x *NewCCIPProviderReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewCCIPProviderReply.ProtoReflect.Descriptor instead.
 func (*NewCCIPProviderReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{16}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *NewCCIPProviderReply) GetCcipProviderID() uint32 {
@@ -879,7 +939,7 @@ type LatestHeadRequest struct {
 
 func (x *LatestHeadRequest) Reset() {
 	*x = LatestHeadRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[17]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -891,7 +951,7 @@ func (x *LatestHeadRequest) String() string {
 func (*LatestHeadRequest) ProtoMessage() {}
 
 func (x *LatestHeadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[17]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -904,7 +964,7 @@ func (x *LatestHeadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatestHeadRequest.ProtoReflect.Descriptor instead.
 func (*LatestHeadRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{17}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{18}
 }
 
 // LatestHeadReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.LatestHeadReply].
@@ -917,7 +977,7 @@ type LatestHeadReply struct {
 
 func (x *LatestHeadReply) Reset() {
 	*x = LatestHeadReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[18]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -929,7 +989,7 @@ func (x *LatestHeadReply) String() string {
 func (*LatestHeadReply) ProtoMessage() {}
 
 func (x *LatestHeadReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[18]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -942,7 +1002,7 @@ func (x *LatestHeadReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatestHeadReply.ProtoReflect.Descriptor instead.
 func (*LatestHeadReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{18}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *LatestHeadReply) GetHead() *Head {
@@ -960,7 +1020,7 @@ type GetChainStatusRequest struct {
 
 func (x *GetChainStatusRequest) Reset() {
 	*x = GetChainStatusRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[19]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -972,7 +1032,7 @@ func (x *GetChainStatusRequest) String() string {
 func (*GetChainStatusRequest) ProtoMessage() {}
 
 func (x *GetChainStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[19]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -985,7 +1045,7 @@ func (x *GetChainStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChainStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetChainStatusRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{19}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{20}
 }
 
 // ChainStatusReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.ChainStatus].
@@ -998,7 +1058,7 @@ type GetChainStatusReply struct {
 
 func (x *GetChainStatusReply) Reset() {
 	*x = GetChainStatusReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[20]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1010,7 +1070,7 @@ func (x *GetChainStatusReply) String() string {
 func (*GetChainStatusReply) ProtoMessage() {}
 
 func (x *GetChainStatusReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[20]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1023,7 +1083,7 @@ func (x *GetChainStatusReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChainStatusReply.ProtoReflect.Descriptor instead.
 func (*GetChainStatusReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{20}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetChainStatusReply) GetChain() *ChainStatus {
@@ -1041,7 +1101,7 @@ type GetChainInfoRequest struct {
 
 func (x *GetChainInfoRequest) Reset() {
 	*x = GetChainInfoRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[21]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1053,7 +1113,7 @@ func (x *GetChainInfoRequest) String() string {
 func (*GetChainInfoRequest) ProtoMessage() {}
 
 func (x *GetChainInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[21]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1066,7 +1126,7 @@ func (x *GetChainInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChainInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetChainInfoRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{21}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{22}
 }
 
 // GetChainInfoReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.GetChainInfo].
@@ -1079,7 +1139,7 @@ type GetChainInfoReply struct {
 
 func (x *GetChainInfoReply) Reset() {
 	*x = GetChainInfoReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[22]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1091,7 +1151,7 @@ func (x *GetChainInfoReply) String() string {
 func (*GetChainInfoReply) ProtoMessage() {}
 
 func (x *GetChainInfoReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[22]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1104,7 +1164,7 @@ func (x *GetChainInfoReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChainInfoReply.ProtoReflect.Descriptor instead.
 func (*GetChainInfoReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{22}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetChainInfoReply) GetChainInfo() *ChainInfo {
@@ -1126,7 +1186,7 @@ type ChainStatus struct {
 
 func (x *ChainStatus) Reset() {
 	*x = ChainStatus{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[23]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1138,7 +1198,7 @@ func (x *ChainStatus) String() string {
 func (*ChainStatus) ProtoMessage() {}
 
 func (x *ChainStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[23]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1151,7 +1211,7 @@ func (x *ChainStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChainStatus.ProtoReflect.Descriptor instead.
 func (*ChainStatus) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{23}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ChainStatus) GetId() string {
@@ -1188,7 +1248,7 @@ type ChainInfo struct {
 
 func (x *ChainInfo) Reset() {
 	*x = ChainInfo{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[24]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1200,7 +1260,7 @@ func (x *ChainInfo) String() string {
 func (*ChainInfo) ProtoMessage() {}
 
 func (x *ChainInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[24]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1213,7 +1273,7 @@ func (x *ChainInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChainInfo.ProtoReflect.Descriptor instead.
 func (*ChainInfo) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{24}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ChainInfo) GetFamilyName() string {
@@ -1255,7 +1315,7 @@ type ListNodeStatusesRequest struct {
 
 func (x *ListNodeStatusesRequest) Reset() {
 	*x = ListNodeStatusesRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[25]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1267,7 +1327,7 @@ func (x *ListNodeStatusesRequest) String() string {
 func (*ListNodeStatusesRequest) ProtoMessage() {}
 
 func (x *ListNodeStatusesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[25]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1280,7 +1340,7 @@ func (x *ListNodeStatusesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodeStatusesRequest.ProtoReflect.Descriptor instead.
 func (*ListNodeStatusesRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{25}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ListNodeStatusesRequest) GetPageSize() int32 {
@@ -1309,7 +1369,7 @@ type ListNodeStatusesReply struct {
 
 func (x *ListNodeStatusesReply) Reset() {
 	*x = ListNodeStatusesReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[26]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1321,7 +1381,7 @@ func (x *ListNodeStatusesReply) String() string {
 func (*ListNodeStatusesReply) ProtoMessage() {}
 
 func (x *ListNodeStatusesReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[26]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1334,7 +1394,7 @@ func (x *ListNodeStatusesReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodeStatusesReply.ProtoReflect.Descriptor instead.
 func (*ListNodeStatusesReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{26}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListNodeStatusesReply) GetNodes() []*NodeStatus {
@@ -1371,7 +1431,7 @@ type NodeStatus struct {
 
 func (x *NodeStatus) Reset() {
 	*x = NodeStatus{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[27]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1383,7 +1443,7 @@ func (x *NodeStatus) String() string {
 func (*NodeStatus) ProtoMessage() {}
 
 func (x *NodeStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[27]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1396,7 +1456,7 @@ func (x *NodeStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeStatus.ProtoReflect.Descriptor instead.
 func (*NodeStatus) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{27}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *NodeStatus) GetChainID() string {
@@ -1437,7 +1497,7 @@ type ReplayRequest struct {
 
 func (x *ReplayRequest) Reset() {
 	*x = ReplayRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[28]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1449,7 +1509,7 @@ func (x *ReplayRequest) String() string {
 func (*ReplayRequest) ProtoMessage() {}
 
 func (x *ReplayRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[28]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1462,7 +1522,7 @@ func (x *ReplayRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayRequest.ProtoReflect.Descriptor instead.
 func (*ReplayRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{28}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ReplayRequest) GetFromBlock() string {
@@ -1492,7 +1552,7 @@ type TransactionRequest struct {
 
 func (x *TransactionRequest) Reset() {
 	*x = TransactionRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[29]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1504,7 +1564,7 @@ func (x *TransactionRequest) String() string {
 func (*TransactionRequest) ProtoMessage() {}
 
 func (x *TransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[29]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1517,7 +1577,7 @@ func (x *TransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionRequest.ProtoReflect.Descriptor instead.
 func (*TransactionRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{29}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *TransactionRequest) GetFrom() string {
@@ -1565,7 +1625,7 @@ type ContractConfig struct {
 
 func (x *ContractConfig) Reset() {
 	*x = ContractConfig{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[30]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1577,7 +1637,7 @@ func (x *ContractConfig) String() string {
 func (*ContractConfig) ProtoMessage() {}
 
 func (x *ContractConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[30]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1590,7 +1650,7 @@ func (x *ContractConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContractConfig.ProtoReflect.Descriptor instead.
 func (*ContractConfig) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{30}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ContractConfig) GetConfigDigest() []byte {
@@ -1659,7 +1719,7 @@ type ConfigDigestRequest struct {
 
 func (x *ConfigDigestRequest) Reset() {
 	*x = ConfigDigestRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[31]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1671,7 +1731,7 @@ func (x *ConfigDigestRequest) String() string {
 func (*ConfigDigestRequest) ProtoMessage() {}
 
 func (x *ConfigDigestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[31]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1684,7 +1744,7 @@ func (x *ConfigDigestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigDigestRequest.ProtoReflect.Descriptor instead.
 func (*ConfigDigestRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{31}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ConfigDigestRequest) GetContractConfig() *ContractConfig {
@@ -1704,7 +1764,7 @@ type ConfigDigestReply struct {
 
 func (x *ConfigDigestReply) Reset() {
 	*x = ConfigDigestReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[32]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1716,7 +1776,7 @@ func (x *ConfigDigestReply) String() string {
 func (*ConfigDigestReply) ProtoMessage() {}
 
 func (x *ConfigDigestReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[32]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1729,7 +1789,7 @@ func (x *ConfigDigestReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigDigestReply.ProtoReflect.Descriptor instead.
 func (*ConfigDigestReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{32}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ConfigDigestReply) GetConfigDigest() []byte {
@@ -1747,7 +1807,7 @@ type ConfigDigestPrefixRequest struct {
 
 func (x *ConfigDigestPrefixRequest) Reset() {
 	*x = ConfigDigestPrefixRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[33]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1759,7 +1819,7 @@ func (x *ConfigDigestPrefixRequest) String() string {
 func (*ConfigDigestPrefixRequest) ProtoMessage() {}
 
 func (x *ConfigDigestPrefixRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[33]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1772,7 +1832,7 @@ func (x *ConfigDigestPrefixRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigDigestPrefixRequest.ProtoReflect.Descriptor instead.
 func (*ConfigDigestPrefixRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{33}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{34}
 }
 
 // ConfigDigestPrefixReply has return arguments for [github.com/smartcontractkit/libocr/offchainreporting2plus/types.OffchainConfigDigester.ConfigDigestPrefix].
@@ -1785,7 +1845,7 @@ type ConfigDigestPrefixReply struct {
 
 func (x *ConfigDigestPrefixReply) Reset() {
 	*x = ConfigDigestPrefixReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[34]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1797,7 +1857,7 @@ func (x *ConfigDigestPrefixReply) String() string {
 func (*ConfigDigestPrefixReply) ProtoMessage() {}
 
 func (x *ConfigDigestPrefixReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[34]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1810,7 +1870,7 @@ func (x *ConfigDigestPrefixReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigDigestPrefixReply.ProtoReflect.Descriptor instead.
 func (*ConfigDigestPrefixReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{34}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ConfigDigestPrefixReply) GetConfigDigestPrefix() uint32 {
@@ -1828,7 +1888,7 @@ type LatestConfigDetailsRequest struct {
 
 func (x *LatestConfigDetailsRequest) Reset() {
 	*x = LatestConfigDetailsRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[35]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1840,7 +1900,7 @@ func (x *LatestConfigDetailsRequest) String() string {
 func (*LatestConfigDetailsRequest) ProtoMessage() {}
 
 func (x *LatestConfigDetailsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[35]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1853,7 +1913,7 @@ func (x *LatestConfigDetailsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatestConfigDetailsRequest.ProtoReflect.Descriptor instead.
 func (*LatestConfigDetailsRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{35}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{36}
 }
 
 // LatestConfigDetailsReply has return arguments for [github.com/smartcontractkit/libocr/offchainreporting2plus/types.ContractConfigTracker.LatestConfigDetails].
@@ -1867,7 +1927,7 @@ type LatestConfigDetailsReply struct {
 
 func (x *LatestConfigDetailsReply) Reset() {
 	*x = LatestConfigDetailsReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[36]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1879,7 +1939,7 @@ func (x *LatestConfigDetailsReply) String() string {
 func (*LatestConfigDetailsReply) ProtoMessage() {}
 
 func (x *LatestConfigDetailsReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[36]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1892,7 +1952,7 @@ func (x *LatestConfigDetailsReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatestConfigDetailsReply.ProtoReflect.Descriptor instead.
 func (*LatestConfigDetailsReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{36}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *LatestConfigDetailsReply) GetChangedInBlock() uint64 {
@@ -1919,7 +1979,7 @@ type LatestConfigRequest struct {
 
 func (x *LatestConfigRequest) Reset() {
 	*x = LatestConfigRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[37]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1931,7 +1991,7 @@ func (x *LatestConfigRequest) String() string {
 func (*LatestConfigRequest) ProtoMessage() {}
 
 func (x *LatestConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[37]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1944,7 +2004,7 @@ func (x *LatestConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatestConfigRequest.ProtoReflect.Descriptor instead.
 func (*LatestConfigRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{37}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *LatestConfigRequest) GetChangedInBlock() uint64 {
@@ -1964,7 +2024,7 @@ type LatestConfigReply struct {
 
 func (x *LatestConfigReply) Reset() {
 	*x = LatestConfigReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[38]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1976,7 +2036,7 @@ func (x *LatestConfigReply) String() string {
 func (*LatestConfigReply) ProtoMessage() {}
 
 func (x *LatestConfigReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[38]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1989,7 +2049,7 @@ func (x *LatestConfigReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatestConfigReply.ProtoReflect.Descriptor instead.
 func (*LatestConfigReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{38}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *LatestConfigReply) GetContractConfig() *ContractConfig {
@@ -2007,7 +2067,7 @@ type LatestBlockHeightRequest struct {
 
 func (x *LatestBlockHeightRequest) Reset() {
 	*x = LatestBlockHeightRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[39]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2019,7 +2079,7 @@ func (x *LatestBlockHeightRequest) String() string {
 func (*LatestBlockHeightRequest) ProtoMessage() {}
 
 func (x *LatestBlockHeightRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[39]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2032,7 +2092,7 @@ func (x *LatestBlockHeightRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatestBlockHeightRequest.ProtoReflect.Descriptor instead.
 func (*LatestBlockHeightRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{39}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{40}
 }
 
 // LatestBlockHeightReply has return arguments for [github.com/smartcontractkit/libocr/offchainreporting2plus/types.ContractConfigTracker.LatestBlockHeightReply].
@@ -2045,7 +2105,7 @@ type LatestBlockHeightReply struct {
 
 func (x *LatestBlockHeightReply) Reset() {
 	*x = LatestBlockHeightReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[40]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2057,7 +2117,7 @@ func (x *LatestBlockHeightReply) String() string {
 func (*LatestBlockHeightReply) ProtoMessage() {}
 
 func (x *LatestBlockHeightReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[40]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2070,7 +2130,7 @@ func (x *LatestBlockHeightReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatestBlockHeightReply.ProtoReflect.Descriptor instead.
 func (*LatestBlockHeightReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{40}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *LatestBlockHeightReply) GetBlockHeight() uint64 {
@@ -2092,7 +2152,7 @@ type ReportTimestamp struct {
 
 func (x *ReportTimestamp) Reset() {
 	*x = ReportTimestamp{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[41]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2104,7 +2164,7 @@ func (x *ReportTimestamp) String() string {
 func (*ReportTimestamp) ProtoMessage() {}
 
 func (x *ReportTimestamp) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[41]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2117,7 +2177,7 @@ func (x *ReportTimestamp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportTimestamp.ProtoReflect.Descriptor instead.
 func (*ReportTimestamp) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{41}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ReportTimestamp) GetConfigDigest() []byte {
@@ -2152,7 +2212,7 @@ type ReportContext struct {
 
 func (x *ReportContext) Reset() {
 	*x = ReportContext{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[42]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2164,7 +2224,7 @@ func (x *ReportContext) String() string {
 func (*ReportContext) ProtoMessage() {}
 
 func (x *ReportContext) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[42]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2177,7 +2237,7 @@ func (x *ReportContext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportContext.ProtoReflect.Descriptor instead.
 func (*ReportContext) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{42}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ReportContext) GetReportTimestamp() *ReportTimestamp {
@@ -2205,7 +2265,7 @@ type AttributedOnchainSignature struct {
 
 func (x *AttributedOnchainSignature) Reset() {
 	*x = AttributedOnchainSignature{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[43]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2217,7 +2277,7 @@ func (x *AttributedOnchainSignature) String() string {
 func (*AttributedOnchainSignature) ProtoMessage() {}
 
 func (x *AttributedOnchainSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[43]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2230,7 +2290,7 @@ func (x *AttributedOnchainSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttributedOnchainSignature.ProtoReflect.Descriptor instead.
 func (*AttributedOnchainSignature) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{43}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *AttributedOnchainSignature) GetSignature() []byte {
@@ -2259,7 +2319,7 @@ type TransmitRequest struct {
 
 func (x *TransmitRequest) Reset() {
 	*x = TransmitRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[44]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2271,7 +2331,7 @@ func (x *TransmitRequest) String() string {
 func (*TransmitRequest) ProtoMessage() {}
 
 func (x *TransmitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[44]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2284,7 +2344,7 @@ func (x *TransmitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransmitRequest.ProtoReflect.Descriptor instead.
 func (*TransmitRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{44}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *TransmitRequest) GetReportContext() *ReportContext {
@@ -2316,7 +2376,7 @@ type TransmitReply struct {
 
 func (x *TransmitReply) Reset() {
 	*x = TransmitReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[45]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2328,7 +2388,7 @@ func (x *TransmitReply) String() string {
 func (*TransmitReply) ProtoMessage() {}
 
 func (x *TransmitReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[45]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2341,7 +2401,7 @@ func (x *TransmitReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransmitReply.ProtoReflect.Descriptor instead.
 func (*TransmitReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{45}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{46}
 }
 
 type LatestConfigDigestAndEpochRequest struct {
@@ -2352,7 +2412,7 @@ type LatestConfigDigestAndEpochRequest struct {
 
 func (x *LatestConfigDigestAndEpochRequest) Reset() {
 	*x = LatestConfigDigestAndEpochRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[46]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2364,7 +2424,7 @@ func (x *LatestConfigDigestAndEpochRequest) String() string {
 func (*LatestConfigDigestAndEpochRequest) ProtoMessage() {}
 
 func (x *LatestConfigDigestAndEpochRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[46]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2377,7 +2437,7 @@ func (x *LatestConfigDigestAndEpochRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use LatestConfigDigestAndEpochRequest.ProtoReflect.Descriptor instead.
 func (*LatestConfigDigestAndEpochRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{46}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{47}
 }
 
 // LatestConfigDigestAndEpochReply has return arguments for [github.com/smartcontractkit/libocr/offchainreporting2plus/types.ContractTransmitter.LatestConfigDigestAndEpoch].
@@ -2391,7 +2451,7 @@ type LatestConfigDigestAndEpochReply struct {
 
 func (x *LatestConfigDigestAndEpochReply) Reset() {
 	*x = LatestConfigDigestAndEpochReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[47]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2403,7 +2463,7 @@ func (x *LatestConfigDigestAndEpochReply) String() string {
 func (*LatestConfigDigestAndEpochReply) ProtoMessage() {}
 
 func (x *LatestConfigDigestAndEpochReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[47]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2416,7 +2476,7 @@ func (x *LatestConfigDigestAndEpochReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatestConfigDigestAndEpochReply.ProtoReflect.Descriptor instead.
 func (*LatestConfigDigestAndEpochReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{47}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *LatestConfigDigestAndEpochReply) GetConfigDigest() []byte {
@@ -2441,7 +2501,7 @@ type FromAccountRequest struct {
 
 func (x *FromAccountRequest) Reset() {
 	*x = FromAccountRequest{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[48]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2453,7 +2513,7 @@ func (x *FromAccountRequest) String() string {
 func (*FromAccountRequest) ProtoMessage() {}
 
 func (x *FromAccountRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[48]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2466,7 +2526,7 @@ func (x *FromAccountRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FromAccountRequest.ProtoReflect.Descriptor instead.
 func (*FromAccountRequest) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{48}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{49}
 }
 
 // FromAccountReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/types.Service.FromAccount].
@@ -2479,7 +2539,7 @@ type FromAccountReply struct {
 
 func (x *FromAccountReply) Reset() {
 	*x = FromAccountReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[49]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2491,7 +2551,7 @@ func (x *FromAccountReply) String() string {
 func (*FromAccountReply) ProtoMessage() {}
 
 func (x *FromAccountReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[49]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2504,7 +2564,7 @@ func (x *FromAccountReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FromAccountReply.ProtoReflect.Descriptor instead.
 func (*FromAccountReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{49}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *FromAccountReply) GetAccount() string {
@@ -2524,7 +2584,7 @@ type NameReply struct {
 
 func (x *NameReply) Reset() {
 	*x = NameReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[50]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2536,7 +2596,7 @@ func (x *NameReply) String() string {
 func (*NameReply) ProtoMessage() {}
 
 func (x *NameReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[50]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2549,7 +2609,7 @@ func (x *NameReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NameReply.ProtoReflect.Descriptor instead.
 func (*NameReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{50}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *NameReply) GetName() string {
@@ -2569,7 +2629,7 @@ type HealthReportReply struct {
 
 func (x *HealthReportReply) Reset() {
 	*x = HealthReportReply{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[51]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2581,7 +2641,7 @@ func (x *HealthReportReply) String() string {
 func (*HealthReportReply) ProtoMessage() {}
 
 func (x *HealthReportReply) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[51]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2594,7 +2654,7 @@ func (x *HealthReportReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthReportReply.ProtoReflect.Descriptor instead.
 func (*HealthReportReply) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{51}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *HealthReportReply) GetHealthReport() map[string]string {
@@ -2615,7 +2675,7 @@ type BigInt struct {
 
 func (x *BigInt) Reset() {
 	*x = BigInt{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[52]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2627,7 +2687,7 @@ func (x *BigInt) String() string {
 func (*BigInt) ProtoMessage() {}
 
 func (x *BigInt) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[52]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2640,7 +2700,7 @@ func (x *BigInt) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BigInt.ProtoReflect.Descriptor instead.
 func (*BigInt) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{52}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *BigInt) GetNegative() bool {
@@ -2667,7 +2727,7 @@ type StarknetSignature struct {
 
 func (x *StarknetSignature) Reset() {
 	*x = StarknetSignature{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[53]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2679,7 +2739,7 @@ func (x *StarknetSignature) String() string {
 func (*StarknetSignature) ProtoMessage() {}
 
 func (x *StarknetSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[53]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2692,7 +2752,7 @@ func (x *StarknetSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StarknetSignature.ProtoReflect.Descriptor instead.
 func (*StarknetSignature) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{53}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *StarknetSignature) GetX() *BigInt {
@@ -2718,7 +2778,7 @@ type StarknetMessageHash struct {
 
 func (x *StarknetMessageHash) Reset() {
 	*x = StarknetMessageHash{}
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[54]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2730,7 +2790,7 @@ func (x *StarknetMessageHash) String() string {
 func (*StarknetMessageHash) ProtoMessage() {}
 
 func (x *StarknetMessageHash) ProtoReflect() protoreflect.Message {
-	mi := &file_loop_internal_pb_relayer_proto_msgTypes[54]
+	mi := &file_loop_internal_pb_relayer_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2743,7 +2803,7 @@ func (x *StarknetMessageHash) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StarknetMessageHash.ProtoReflect.Descriptor instead.
 func (*StarknetMessageHash) Descriptor() ([]byte, []int) {
-	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{54}
+	return file_loop_internal_pb_relayer_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *StarknetMessageHash) GetHash() *BigInt {
@@ -2788,7 +2848,11 @@ const file_loop_internal_pb_relayer_proto_rawDesc = "" +
 	"\n" +
 	"PluginArgs\x12$\n" +
 	"\rtransmitterID\x18\x01 \x01(\tR\rtransmitterID\x12\"\n" +
-	"\fpluginConfig\x18\x02 \x01(\fR\fpluginConfig\"N\n" +
+	"\fpluginConfig\x18\x02 \x01(\fR\fpluginConfig\"\x9a\x01\n" +
+	"\x10CCIPProviderArgs\x12$\n" +
+	"\rexternalJobID\x18\x01 \x01(\fR\rexternalJobID\x122\n" +
+	"\x14contractReaderConfig\x18\x02 \x01(\fR\x14contractReaderConfig\x12,\n" +
+	"\x11chainWriterConfig\x18\x03 \x01(\fR\x11chainWriterConfig\"N\n" +
 	"\x18NewContractWriterRequest\x122\n" +
 	"\x14contractWriterConfig\x18\x01 \x01(\fR\x14contractWriterConfig\"D\n" +
 	"\x16NewContractWriterReply\x12*\n" +
@@ -2807,9 +2871,9 @@ const file_loop_internal_pb_relayer_proto_rawDesc = "" +
 	"\x18NewConfigProviderRequest\x12-\n" +
 	"\trelayArgs\x18\x01 \x01(\v2\x0f.loop.RelayArgsR\trelayArgs\"D\n" +
 	"\x16NewConfigProviderReply\x12*\n" +
-	"\x10configProviderID\x18\x01 \x01(\rR\x10configProviderID\"G\n" +
-	"\x16NewCCIPProviderRequest\x12-\n" +
-	"\trelayArgs\x18\x01 \x01(\v2\x0f.loop.RelayArgsR\trelayArgs\">\n" +
+	"\x10configProviderID\x18\x01 \x01(\rR\x10configProviderID\"\\\n" +
+	"\x16NewCCIPProviderRequest\x12B\n" +
+	"\x10ccipProviderArgs\x18\x01 \x01(\v2\x16.loop.CCIPProviderArgsR\x10ccipProviderArgs\">\n" +
 	"\x14NewCCIPProviderReply\x12&\n" +
 	"\x0eccipProviderID\x18\x01 \x01(\rR\x0eccipProviderID\"\x13\n" +
 	"\x11LatestHeadRequest\"1\n" +
@@ -2967,7 +3031,7 @@ func file_loop_internal_pb_relayer_proto_rawDescGZIP() []byte {
 	return file_loop_internal_pb_relayer_proto_rawDescData
 }
 
-var file_loop_internal_pb_relayer_proto_msgTypes = make([]protoimpl.MessageInfo, 56)
+var file_loop_internal_pb_relayer_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
 var file_loop_internal_pb_relayer_proto_goTypes = []any{
 	(*NewRelayerRequest)(nil),                 // 0: loop.NewRelayerRequest
 	(*NewRelayerReply)(nil),                   // 1: loop.NewRelayerReply
@@ -2976,131 +3040,132 @@ var file_loop_internal_pb_relayer_proto_goTypes = []any{
 	(*SignReply)(nil),                         // 4: loop.SignReply
 	(*RelayArgs)(nil),                         // 5: loop.RelayArgs
 	(*PluginArgs)(nil),                        // 6: loop.PluginArgs
-	(*NewContractWriterRequest)(nil),          // 7: loop.NewContractWriterRequest
-	(*NewContractWriterReply)(nil),            // 8: loop.NewContractWriterReply
-	(*NewContractReaderRequest)(nil),          // 9: loop.NewContractReaderRequest
-	(*NewContractReaderReply)(nil),            // 10: loop.NewContractReaderReply
-	(*NewPluginProviderRequest)(nil),          // 11: loop.NewPluginProviderRequest
-	(*NewPluginProviderReply)(nil),            // 12: loop.NewPluginProviderReply
-	(*NewConfigProviderRequest)(nil),          // 13: loop.NewConfigProviderRequest
-	(*NewConfigProviderReply)(nil),            // 14: loop.NewConfigProviderReply
-	(*NewCCIPProviderRequest)(nil),            // 15: loop.NewCCIPProviderRequest
-	(*NewCCIPProviderReply)(nil),              // 16: loop.NewCCIPProviderReply
-	(*LatestHeadRequest)(nil),                 // 17: loop.LatestHeadRequest
-	(*LatestHeadReply)(nil),                   // 18: loop.LatestHeadReply
-	(*GetChainStatusRequest)(nil),             // 19: loop.GetChainStatusRequest
-	(*GetChainStatusReply)(nil),               // 20: loop.GetChainStatusReply
-	(*GetChainInfoRequest)(nil),               // 21: loop.GetChainInfoRequest
-	(*GetChainInfoReply)(nil),                 // 22: loop.GetChainInfoReply
-	(*ChainStatus)(nil),                       // 23: loop.ChainStatus
-	(*ChainInfo)(nil),                         // 24: loop.ChainInfo
-	(*ListNodeStatusesRequest)(nil),           // 25: loop.ListNodeStatusesRequest
-	(*ListNodeStatusesReply)(nil),             // 26: loop.ListNodeStatusesReply
-	(*NodeStatus)(nil),                        // 27: loop.NodeStatus
-	(*ReplayRequest)(nil),                     // 28: loop.ReplayRequest
-	(*TransactionRequest)(nil),                // 29: loop.TransactionRequest
-	(*ContractConfig)(nil),                    // 30: loop.ContractConfig
-	(*ConfigDigestRequest)(nil),               // 31: loop.ConfigDigestRequest
-	(*ConfigDigestReply)(nil),                 // 32: loop.ConfigDigestReply
-	(*ConfigDigestPrefixRequest)(nil),         // 33: loop.ConfigDigestPrefixRequest
-	(*ConfigDigestPrefixReply)(nil),           // 34: loop.ConfigDigestPrefixReply
-	(*LatestConfigDetailsRequest)(nil),        // 35: loop.LatestConfigDetailsRequest
-	(*LatestConfigDetailsReply)(nil),          // 36: loop.LatestConfigDetailsReply
-	(*LatestConfigRequest)(nil),               // 37: loop.LatestConfigRequest
-	(*LatestConfigReply)(nil),                 // 38: loop.LatestConfigReply
-	(*LatestBlockHeightRequest)(nil),          // 39: loop.LatestBlockHeightRequest
-	(*LatestBlockHeightReply)(nil),            // 40: loop.LatestBlockHeightReply
-	(*ReportTimestamp)(nil),                   // 41: loop.ReportTimestamp
-	(*ReportContext)(nil),                     // 42: loop.ReportContext
-	(*AttributedOnchainSignature)(nil),        // 43: loop.AttributedOnchainSignature
-	(*TransmitRequest)(nil),                   // 44: loop.TransmitRequest
-	(*TransmitReply)(nil),                     // 45: loop.TransmitReply
-	(*LatestConfigDigestAndEpochRequest)(nil), // 46: loop.LatestConfigDigestAndEpochRequest
-	(*LatestConfigDigestAndEpochReply)(nil),   // 47: loop.LatestConfigDigestAndEpochReply
-	(*FromAccountRequest)(nil),                // 48: loop.FromAccountRequest
-	(*FromAccountReply)(nil),                  // 49: loop.FromAccountReply
-	(*NameReply)(nil),                         // 50: loop.NameReply
-	(*HealthReportReply)(nil),                 // 51: loop.HealthReportReply
-	(*BigInt)(nil),                            // 52: loop.BigInt
-	(*StarknetSignature)(nil),                 // 53: loop.StarknetSignature
-	(*StarknetMessageHash)(nil),               // 54: loop.StarknetMessageHash
-	nil,                                       // 55: loop.HealthReportReply.HealthReportEntry
-	(*Head)(nil),                              // 56: loop.Head
-	(*structpb.Struct)(nil),                   // 57: google.protobuf.Struct
-	(*emptypb.Empty)(nil),                     // 58: google.protobuf.Empty
+	(*CCIPProviderArgs)(nil),                  // 7: loop.CCIPProviderArgs
+	(*NewContractWriterRequest)(nil),          // 8: loop.NewContractWriterRequest
+	(*NewContractWriterReply)(nil),            // 9: loop.NewContractWriterReply
+	(*NewContractReaderRequest)(nil),          // 10: loop.NewContractReaderRequest
+	(*NewContractReaderReply)(nil),            // 11: loop.NewContractReaderReply
+	(*NewPluginProviderRequest)(nil),          // 12: loop.NewPluginProviderRequest
+	(*NewPluginProviderReply)(nil),            // 13: loop.NewPluginProviderReply
+	(*NewConfigProviderRequest)(nil),          // 14: loop.NewConfigProviderRequest
+	(*NewConfigProviderReply)(nil),            // 15: loop.NewConfigProviderReply
+	(*NewCCIPProviderRequest)(nil),            // 16: loop.NewCCIPProviderRequest
+	(*NewCCIPProviderReply)(nil),              // 17: loop.NewCCIPProviderReply
+	(*LatestHeadRequest)(nil),                 // 18: loop.LatestHeadRequest
+	(*LatestHeadReply)(nil),                   // 19: loop.LatestHeadReply
+	(*GetChainStatusRequest)(nil),             // 20: loop.GetChainStatusRequest
+	(*GetChainStatusReply)(nil),               // 21: loop.GetChainStatusReply
+	(*GetChainInfoRequest)(nil),               // 22: loop.GetChainInfoRequest
+	(*GetChainInfoReply)(nil),                 // 23: loop.GetChainInfoReply
+	(*ChainStatus)(nil),                       // 24: loop.ChainStatus
+	(*ChainInfo)(nil),                         // 25: loop.ChainInfo
+	(*ListNodeStatusesRequest)(nil),           // 26: loop.ListNodeStatusesRequest
+	(*ListNodeStatusesReply)(nil),             // 27: loop.ListNodeStatusesReply
+	(*NodeStatus)(nil),                        // 28: loop.NodeStatus
+	(*ReplayRequest)(nil),                     // 29: loop.ReplayRequest
+	(*TransactionRequest)(nil),                // 30: loop.TransactionRequest
+	(*ContractConfig)(nil),                    // 31: loop.ContractConfig
+	(*ConfigDigestRequest)(nil),               // 32: loop.ConfigDigestRequest
+	(*ConfigDigestReply)(nil),                 // 33: loop.ConfigDigestReply
+	(*ConfigDigestPrefixRequest)(nil),         // 34: loop.ConfigDigestPrefixRequest
+	(*ConfigDigestPrefixReply)(nil),           // 35: loop.ConfigDigestPrefixReply
+	(*LatestConfigDetailsRequest)(nil),        // 36: loop.LatestConfigDetailsRequest
+	(*LatestConfigDetailsReply)(nil),          // 37: loop.LatestConfigDetailsReply
+	(*LatestConfigRequest)(nil),               // 38: loop.LatestConfigRequest
+	(*LatestConfigReply)(nil),                 // 39: loop.LatestConfigReply
+	(*LatestBlockHeightRequest)(nil),          // 40: loop.LatestBlockHeightRequest
+	(*LatestBlockHeightReply)(nil),            // 41: loop.LatestBlockHeightReply
+	(*ReportTimestamp)(nil),                   // 42: loop.ReportTimestamp
+	(*ReportContext)(nil),                     // 43: loop.ReportContext
+	(*AttributedOnchainSignature)(nil),        // 44: loop.AttributedOnchainSignature
+	(*TransmitRequest)(nil),                   // 45: loop.TransmitRequest
+	(*TransmitReply)(nil),                     // 46: loop.TransmitReply
+	(*LatestConfigDigestAndEpochRequest)(nil), // 47: loop.LatestConfigDigestAndEpochRequest
+	(*LatestConfigDigestAndEpochReply)(nil),   // 48: loop.LatestConfigDigestAndEpochReply
+	(*FromAccountRequest)(nil),                // 49: loop.FromAccountRequest
+	(*FromAccountReply)(nil),                  // 50: loop.FromAccountReply
+	(*NameReply)(nil),                         // 51: loop.NameReply
+	(*HealthReportReply)(nil),                 // 52: loop.HealthReportReply
+	(*BigInt)(nil),                            // 53: loop.BigInt
+	(*StarknetSignature)(nil),                 // 54: loop.StarknetSignature
+	(*StarknetMessageHash)(nil),               // 55: loop.StarknetMessageHash
+	nil,                                       // 56: loop.HealthReportReply.HealthReportEntry
+	(*Head)(nil),                              // 57: loop.Head
+	(*structpb.Struct)(nil),                   // 58: google.protobuf.Struct
+	(*emptypb.Empty)(nil),                     // 59: google.protobuf.Empty
 }
 var file_loop_internal_pb_relayer_proto_depIdxs = []int32{
 	5,  // 0: loop.NewPluginProviderRequest.relayArgs:type_name -> loop.RelayArgs
 	6,  // 1: loop.NewPluginProviderRequest.pluginArgs:type_name -> loop.PluginArgs
 	5,  // 2: loop.NewConfigProviderRequest.relayArgs:type_name -> loop.RelayArgs
-	5,  // 3: loop.NewCCIPProviderRequest.relayArgs:type_name -> loop.RelayArgs
-	56, // 4: loop.LatestHeadReply.head:type_name -> loop.Head
-	23, // 5: loop.GetChainStatusReply.chain:type_name -> loop.ChainStatus
-	24, // 6: loop.GetChainInfoReply.chain_info:type_name -> loop.ChainInfo
-	27, // 7: loop.ListNodeStatusesReply.nodes:type_name -> loop.NodeStatus
-	57, // 8: loop.ReplayRequest.args:type_name -> google.protobuf.Struct
-	52, // 9: loop.TransactionRequest.amount:type_name -> loop.BigInt
-	30, // 10: loop.ConfigDigestRequest.contractConfig:type_name -> loop.ContractConfig
-	30, // 11: loop.LatestConfigReply.contractConfig:type_name -> loop.ContractConfig
-	41, // 12: loop.ReportContext.reportTimestamp:type_name -> loop.ReportTimestamp
-	42, // 13: loop.TransmitRequest.reportContext:type_name -> loop.ReportContext
-	43, // 14: loop.TransmitRequest.attributedOnchainSignatures:type_name -> loop.AttributedOnchainSignature
-	55, // 15: loop.HealthReportReply.healthReport:type_name -> loop.HealthReportReply.HealthReportEntry
-	52, // 16: loop.StarknetSignature.x:type_name -> loop.BigInt
-	52, // 17: loop.StarknetSignature.y:type_name -> loop.BigInt
-	52, // 18: loop.StarknetMessageHash.hash:type_name -> loop.BigInt
+	7,  // 3: loop.NewCCIPProviderRequest.ccipProviderArgs:type_name -> loop.CCIPProviderArgs
+	57, // 4: loop.LatestHeadReply.head:type_name -> loop.Head
+	24, // 5: loop.GetChainStatusReply.chain:type_name -> loop.ChainStatus
+	25, // 6: loop.GetChainInfoReply.chain_info:type_name -> loop.ChainInfo
+	28, // 7: loop.ListNodeStatusesReply.nodes:type_name -> loop.NodeStatus
+	58, // 8: loop.ReplayRequest.args:type_name -> google.protobuf.Struct
+	53, // 9: loop.TransactionRequest.amount:type_name -> loop.BigInt
+	31, // 10: loop.ConfigDigestRequest.contractConfig:type_name -> loop.ContractConfig
+	31, // 11: loop.LatestConfigReply.contractConfig:type_name -> loop.ContractConfig
+	42, // 12: loop.ReportContext.reportTimestamp:type_name -> loop.ReportTimestamp
+	43, // 13: loop.TransmitRequest.reportContext:type_name -> loop.ReportContext
+	44, // 14: loop.TransmitRequest.attributedOnchainSignatures:type_name -> loop.AttributedOnchainSignature
+	56, // 15: loop.HealthReportReply.healthReport:type_name -> loop.HealthReportReply.HealthReportEntry
+	53, // 16: loop.StarknetSignature.x:type_name -> loop.BigInt
+	53, // 17: loop.StarknetSignature.y:type_name -> loop.BigInt
+	53, // 18: loop.StarknetMessageHash.hash:type_name -> loop.BigInt
 	0,  // 19: loop.PluginRelayer.NewRelayer:input_type -> loop.NewRelayerRequest
-	58, // 20: loop.Keystore.Accounts:input_type -> google.protobuf.Empty
+	59, // 20: loop.Keystore.Accounts:input_type -> google.protobuf.Empty
 	3,  // 21: loop.Keystore.Sign:input_type -> loop.SignRequest
-	7,  // 22: loop.Relayer.NewContractWriter:input_type -> loop.NewContractWriterRequest
-	9,  // 23: loop.Relayer.NewContractReader:input_type -> loop.NewContractReaderRequest
-	13, // 24: loop.Relayer.NewConfigProvider:input_type -> loop.NewConfigProviderRequest
-	11, // 25: loop.Relayer.NewPluginProvider:input_type -> loop.NewPluginProviderRequest
-	15, // 26: loop.Relayer.NewCCIPProvider:input_type -> loop.NewCCIPProviderRequest
-	17, // 27: loop.Relayer.LatestHead:input_type -> loop.LatestHeadRequest
-	19, // 28: loop.Relayer.GetChainStatus:input_type -> loop.GetChainStatusRequest
-	21, // 29: loop.Relayer.GetChainInfo:input_type -> loop.GetChainInfoRequest
-	25, // 30: loop.Relayer.ListNodeStatuses:input_type -> loop.ListNodeStatusesRequest
-	29, // 31: loop.Relayer.Transact:input_type -> loop.TransactionRequest
-	28, // 32: loop.Relayer.Replay:input_type -> loop.ReplayRequest
-	31, // 33: loop.OffchainConfigDigester.ConfigDigest:input_type -> loop.ConfigDigestRequest
-	33, // 34: loop.OffchainConfigDigester.ConfigDigestPrefix:input_type -> loop.ConfigDigestPrefixRequest
-	35, // 35: loop.ContractConfigTracker.LatestConfigDetails:input_type -> loop.LatestConfigDetailsRequest
-	37, // 36: loop.ContractConfigTracker.LatestConfig:input_type -> loop.LatestConfigRequest
-	39, // 37: loop.ContractConfigTracker.LatestBlockHeight:input_type -> loop.LatestBlockHeightRequest
-	44, // 38: loop.ContractTransmitter.Transmit:input_type -> loop.TransmitRequest
-	46, // 39: loop.ContractTransmitter.LatestConfigDigestAndEpoch:input_type -> loop.LatestConfigDigestAndEpochRequest
-	48, // 40: loop.ContractTransmitter.FromAccount:input_type -> loop.FromAccountRequest
-	58, // 41: loop.Service.Name:input_type -> google.protobuf.Empty
-	58, // 42: loop.Service.Close:input_type -> google.protobuf.Empty
-	58, // 43: loop.Service.Ready:input_type -> google.protobuf.Empty
-	58, // 44: loop.Service.HealthReport:input_type -> google.protobuf.Empty
+	8,  // 22: loop.Relayer.NewContractWriter:input_type -> loop.NewContractWriterRequest
+	10, // 23: loop.Relayer.NewContractReader:input_type -> loop.NewContractReaderRequest
+	14, // 24: loop.Relayer.NewConfigProvider:input_type -> loop.NewConfigProviderRequest
+	12, // 25: loop.Relayer.NewPluginProvider:input_type -> loop.NewPluginProviderRequest
+	16, // 26: loop.Relayer.NewCCIPProvider:input_type -> loop.NewCCIPProviderRequest
+	18, // 27: loop.Relayer.LatestHead:input_type -> loop.LatestHeadRequest
+	20, // 28: loop.Relayer.GetChainStatus:input_type -> loop.GetChainStatusRequest
+	22, // 29: loop.Relayer.GetChainInfo:input_type -> loop.GetChainInfoRequest
+	26, // 30: loop.Relayer.ListNodeStatuses:input_type -> loop.ListNodeStatusesRequest
+	30, // 31: loop.Relayer.Transact:input_type -> loop.TransactionRequest
+	29, // 32: loop.Relayer.Replay:input_type -> loop.ReplayRequest
+	32, // 33: loop.OffchainConfigDigester.ConfigDigest:input_type -> loop.ConfigDigestRequest
+	34, // 34: loop.OffchainConfigDigester.ConfigDigestPrefix:input_type -> loop.ConfigDigestPrefixRequest
+	36, // 35: loop.ContractConfigTracker.LatestConfigDetails:input_type -> loop.LatestConfigDetailsRequest
+	38, // 36: loop.ContractConfigTracker.LatestConfig:input_type -> loop.LatestConfigRequest
+	40, // 37: loop.ContractConfigTracker.LatestBlockHeight:input_type -> loop.LatestBlockHeightRequest
+	45, // 38: loop.ContractTransmitter.Transmit:input_type -> loop.TransmitRequest
+	47, // 39: loop.ContractTransmitter.LatestConfigDigestAndEpoch:input_type -> loop.LatestConfigDigestAndEpochRequest
+	49, // 40: loop.ContractTransmitter.FromAccount:input_type -> loop.FromAccountRequest
+	59, // 41: loop.Service.Name:input_type -> google.protobuf.Empty
+	59, // 42: loop.Service.Close:input_type -> google.protobuf.Empty
+	59, // 43: loop.Service.Ready:input_type -> google.protobuf.Empty
+	59, // 44: loop.Service.HealthReport:input_type -> google.protobuf.Empty
 	1,  // 45: loop.PluginRelayer.NewRelayer:output_type -> loop.NewRelayerReply
 	2,  // 46: loop.Keystore.Accounts:output_type -> loop.AccountsReply
 	4,  // 47: loop.Keystore.Sign:output_type -> loop.SignReply
-	8,  // 48: loop.Relayer.NewContractWriter:output_type -> loop.NewContractWriterReply
-	10, // 49: loop.Relayer.NewContractReader:output_type -> loop.NewContractReaderReply
-	14, // 50: loop.Relayer.NewConfigProvider:output_type -> loop.NewConfigProviderReply
-	12, // 51: loop.Relayer.NewPluginProvider:output_type -> loop.NewPluginProviderReply
-	16, // 52: loop.Relayer.NewCCIPProvider:output_type -> loop.NewCCIPProviderReply
-	18, // 53: loop.Relayer.LatestHead:output_type -> loop.LatestHeadReply
-	20, // 54: loop.Relayer.GetChainStatus:output_type -> loop.GetChainStatusReply
-	22, // 55: loop.Relayer.GetChainInfo:output_type -> loop.GetChainInfoReply
-	26, // 56: loop.Relayer.ListNodeStatuses:output_type -> loop.ListNodeStatusesReply
-	58, // 57: loop.Relayer.Transact:output_type -> google.protobuf.Empty
-	58, // 58: loop.Relayer.Replay:output_type -> google.protobuf.Empty
-	32, // 59: loop.OffchainConfigDigester.ConfigDigest:output_type -> loop.ConfigDigestReply
-	34, // 60: loop.OffchainConfigDigester.ConfigDigestPrefix:output_type -> loop.ConfigDigestPrefixReply
-	36, // 61: loop.ContractConfigTracker.LatestConfigDetails:output_type -> loop.LatestConfigDetailsReply
-	38, // 62: loop.ContractConfigTracker.LatestConfig:output_type -> loop.LatestConfigReply
-	40, // 63: loop.ContractConfigTracker.LatestBlockHeight:output_type -> loop.LatestBlockHeightReply
-	45, // 64: loop.ContractTransmitter.Transmit:output_type -> loop.TransmitReply
-	47, // 65: loop.ContractTransmitter.LatestConfigDigestAndEpoch:output_type -> loop.LatestConfigDigestAndEpochReply
-	49, // 66: loop.ContractTransmitter.FromAccount:output_type -> loop.FromAccountReply
-	50, // 67: loop.Service.Name:output_type -> loop.NameReply
-	58, // 68: loop.Service.Close:output_type -> google.protobuf.Empty
-	58, // 69: loop.Service.Ready:output_type -> google.protobuf.Empty
-	51, // 70: loop.Service.HealthReport:output_type -> loop.HealthReportReply
+	9,  // 48: loop.Relayer.NewContractWriter:output_type -> loop.NewContractWriterReply
+	11, // 49: loop.Relayer.NewContractReader:output_type -> loop.NewContractReaderReply
+	15, // 50: loop.Relayer.NewConfigProvider:output_type -> loop.NewConfigProviderReply
+	13, // 51: loop.Relayer.NewPluginProvider:output_type -> loop.NewPluginProviderReply
+	17, // 52: loop.Relayer.NewCCIPProvider:output_type -> loop.NewCCIPProviderReply
+	19, // 53: loop.Relayer.LatestHead:output_type -> loop.LatestHeadReply
+	21, // 54: loop.Relayer.GetChainStatus:output_type -> loop.GetChainStatusReply
+	23, // 55: loop.Relayer.GetChainInfo:output_type -> loop.GetChainInfoReply
+	27, // 56: loop.Relayer.ListNodeStatuses:output_type -> loop.ListNodeStatusesReply
+	59, // 57: loop.Relayer.Transact:output_type -> google.protobuf.Empty
+	59, // 58: loop.Relayer.Replay:output_type -> google.protobuf.Empty
+	33, // 59: loop.OffchainConfigDigester.ConfigDigest:output_type -> loop.ConfigDigestReply
+	35, // 60: loop.OffchainConfigDigester.ConfigDigestPrefix:output_type -> loop.ConfigDigestPrefixReply
+	37, // 61: loop.ContractConfigTracker.LatestConfigDetails:output_type -> loop.LatestConfigDetailsReply
+	39, // 62: loop.ContractConfigTracker.LatestConfig:output_type -> loop.LatestConfigReply
+	41, // 63: loop.ContractConfigTracker.LatestBlockHeight:output_type -> loop.LatestBlockHeightReply
+	46, // 64: loop.ContractTransmitter.Transmit:output_type -> loop.TransmitReply
+	48, // 65: loop.ContractTransmitter.LatestConfigDigestAndEpoch:output_type -> loop.LatestConfigDigestAndEpochReply
+	50, // 66: loop.ContractTransmitter.FromAccount:output_type -> loop.FromAccountReply
+	51, // 67: loop.Service.Name:output_type -> loop.NameReply
+	59, // 68: loop.Service.Close:output_type -> google.protobuf.Empty
+	59, // 69: loop.Service.Ready:output_type -> google.protobuf.Empty
+	52, // 70: loop.Service.HealthReport:output_type -> loop.HealthReportReply
 	45, // [45:71] is the sub-list for method output_type
 	19, // [19:45] is the sub-list for method input_type
 	19, // [19:19] is the sub-list for extension type_name
@@ -3120,7 +3185,7 @@ func file_loop_internal_pb_relayer_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_loop_internal_pb_relayer_proto_rawDesc), len(file_loop_internal_pb_relayer_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   56,
+			NumMessages:   57,
 			NumExtensions: 0,
 			NumServices:   7,
 		},

--- a/pkg/loop/internal/pb/relayer.proto
+++ b/pkg/loop/internal/pb/relayer.proto
@@ -68,10 +68,16 @@ message RelayArgs {
   string providerType = 6;
 }
 
-// RelayArgs represents [github.com/smartcontractkit/chainlink-common/pkg/types.PluginArgs].
+// PluginArgs represents [github.com/smartcontractkit/chainlink-common/pkg/types.PluginArgs].
 message PluginArgs {
   string transmitterID = 1;
   bytes pluginConfig = 2;
+}
+
+message CCIPProviderArgs {
+  bytes externalJobID = 1; // [32]byte
+  bytes contractReaderConfig = 2;
+  bytes chainWriterConfig = 3;
 }
 
 // NewContractWriterRequest has request parameters for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewContractWriter].
@@ -117,7 +123,7 @@ message NewConfigProviderReply {
 
 // NewCCIPProviderRequest has arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewCCIPProvider].
 message NewCCIPProviderRequest {
-  RelayArgs relayArgs = 1;
+  CCIPProviderArgs ccipProviderArgs = 1;
 }
 
 // NewCCIPProviderReply has return arguments for [github.com/smartcontractkit/chainlink-common/pkg/loop.Relayer.NewCCIPProvider].

--- a/pkg/loop/internal/relayer/relayer.go
+++ b/pkg/loop/internal/relayer/relayer.go
@@ -288,16 +288,13 @@ func (r *relayerClient) NewLLOProvider(ctx context.Context, rargs types.RelayArg
 	return nil, fmt.Errorf("llo provider not supported: %w", errors.ErrUnsupported)
 }
 
-func (r *relayerClient) NewCCIPProvider(ctx context.Context, rargs types.RelayArgs) (types.CCIPProvider, error) {
+func (r *relayerClient) NewCCIPProvider(ctx context.Context, rargs types.CCIPProviderArgs) (types.CCIPProvider, error) {
 	cc := r.NewClientConn("CCIPProvider", func(ctx context.Context) (uint32, net.Resources, error) {
 		reply, err := r.relayer.NewCCIPProvider(ctx, &pb.NewCCIPProviderRequest{
-			RelayArgs: &pb.RelayArgs{
+			CcipProviderArgs: &pb.CCIPProviderArgs{
 				ExternalJobID: rargs.ExternalJobID[:],
-				JobID:         rargs.JobID,
-				ContractID:    rargs.ContractID,
-				New:           rargs.New,
-				RelayConfig:   rargs.RelayConfig,
-				ProviderType:  rargs.ProviderType,
+				ContractReaderConfig: rargs.ContractReaderConfig,
+				ChainWriterConfig: rargs.ChainWriterConfig,
 			},
 		})
 		if err != nil {
@@ -717,22 +714,19 @@ func (r *relayerServer) newCommitProvider(ctx context.Context, relayArgs types.R
 }
 
 func (r *relayerServer) NewCCIPProvider(ctx context.Context, request *pb.NewCCIPProviderRequest) (*pb.NewCCIPProviderReply, error) {
-	rargs := request.RelayArgs
+	rargs := request.CcipProviderArgs
 
 	exJobID, err := uuid.FromBytes(rargs.ExternalJobID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid uuid bytes for ExternalJobID: %w", err)
 	}
-	relayArgs := types.RelayArgs{
+	ccipProviderArgs := types.CCIPProviderArgs{
 		ExternalJobID: exJobID,
-		JobID:         rargs.JobID,
-		ContractID:    rargs.ContractID,
-		New:           rargs.New,
-		RelayConfig:   rargs.RelayConfig,
-		ProviderType:  rargs.ProviderType,
+		ContractReaderConfig: rargs.ContractReaderConfig,
+		ChainWriterConfig: rargs.ChainWriterConfig,
 	}
 
-	provider, err := r.impl.NewCCIPProvider(ctx, relayArgs)
+	provider, err := r.impl.NewCCIPProvider(ctx, ccipProviderArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/loop/internal/types/types.go
+++ b/pkg/loop/internal/types/types.go
@@ -58,7 +58,7 @@ type Relayer interface {
 	NewConfigProvider(context.Context, types.RelayArgs) (types.ConfigProvider, error)
 	NewPluginProvider(context.Context, types.RelayArgs, types.PluginArgs) (types.PluginProvider, error)
 	NewLLOProvider(context.Context, types.RelayArgs, types.PluginArgs) (types.LLOProvider, error)
-	NewCCIPProvider(context.Context, types.RelayArgs) (types.CCIPProvider, error)
+	NewCCIPProvider(context.Context, types.CCIPProviderArgs) (types.CCIPProvider, error)
 }
 
 // Keystore This interface contains all the keystore GRPC functionality, keystore.Keystore is meant to be exposed to consumers and the keystore.Management interface in exposed only to the core node

--- a/pkg/loop/mocks/relayer.go
+++ b/pkg/loop/mocks/relayer.go
@@ -461,7 +461,7 @@ func (_c *Relayer_Name_Call) RunAndReturn(run func() string) *Relayer_Name_Call 
 }
 
 // NewCCIPProvider provides a mock function with given fields: _a0, _a1
-func (_m *Relayer) NewCCIPProvider(_a0 context.Context, _a1 types.RelayArgs) (types.CCIPProvider, error) {
+func (_m *Relayer) NewCCIPProvider(_a0 context.Context, _a1 types.CCIPProviderArgs) (types.CCIPProvider, error) {
 	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
@@ -470,10 +470,10 @@ func (_m *Relayer) NewCCIPProvider(_a0 context.Context, _a1 types.RelayArgs) (ty
 
 	var r0 types.CCIPProvider
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.RelayArgs) (types.CCIPProvider, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.CCIPProviderArgs) (types.CCIPProvider, error)); ok {
 		return rf(_a0, _a1)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, types.RelayArgs) types.CCIPProvider); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.CCIPProviderArgs) types.CCIPProvider); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
@@ -481,7 +481,7 @@ func (_m *Relayer) NewCCIPProvider(_a0 context.Context, _a1 types.RelayArgs) (ty
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, types.RelayArgs) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, types.CCIPProviderArgs) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
@@ -497,14 +497,14 @@ type Relayer_NewCCIPProvider_Call struct {
 
 // NewCCIPProvider is a helper method to define mock.On call
 //   - _a0 context.Context
-//   - _a1 types.RelayArgs
+//   - _a1 types.CCIPProviderArgs
 func (_e *Relayer_Expecter) NewCCIPProvider(_a0 interface{}, _a1 interface{}) *Relayer_NewCCIPProvider_Call {
 	return &Relayer_NewCCIPProvider_Call{Call: _e.mock.On("NewCCIPProvider", _a0, _a1)}
 }
 
-func (_c *Relayer_NewCCIPProvider_Call) Run(run func(_a0 context.Context, _a1 types.RelayArgs)) *Relayer_NewCCIPProvider_Call {
+func (_c *Relayer_NewCCIPProvider_Call) Run(run func(_a0 context.Context, _a1 types.CCIPProviderArgs)) *Relayer_NewCCIPProvider_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(types.RelayArgs))
+		run(args[0].(context.Context), args[1].(types.CCIPProviderArgs))
 	})
 	return _c
 }
@@ -514,7 +514,7 @@ func (_c *Relayer_NewCCIPProvider_Call) Return(_a0 types.CCIPProvider, _a1 error
 	return _c
 }
 
-func (_c *Relayer_NewCCIPProvider_Call) RunAndReturn(run func(context.Context, types.RelayArgs) (types.CCIPProvider, error)) *Relayer_NewCCIPProvider_Call {
+func (_c *Relayer_NewCCIPProvider_Call) RunAndReturn(run func(context.Context, types.CCIPProviderArgs) (types.CCIPProvider, error)) *Relayer_NewCCIPProvider_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/loop/relayer_service.go
+++ b/pkg/loop/relayer_service.go
@@ -85,7 +85,7 @@ func (r *RelayerService) NewLLOProvider(ctx context.Context, rargs types.RelayAr
 	return r.Service.NewLLOProvider(ctx, rargs, pargs)
 }
 
-func (r *RelayerService) NewCCIPProvider(ctx context.Context, rargs types.RelayArgs) (types.CCIPProvider, error) {
+func (r *RelayerService) NewCCIPProvider(ctx context.Context, rargs types.CCIPProviderArgs) (types.CCIPProvider, error) {
 	if err := r.WaitCtx(ctx); err != nil {
 		return nil, err
 	}

--- a/pkg/types/provider_ccip.go
+++ b/pkg/types/provider_ccip.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
@@ -52,4 +53,12 @@ type CCIPProvider interface {
 	ChainAccessor() ccipocr3.ChainAccessor
 	ContractTransmitter() ocr3types.ContractTransmitter[[]byte]
 	Codec() ccipocr3.Codec
+}
+
+// CCIPProviderArgs are the args required to create a CCIP Provider through a Relayer.
+// The are common to all relayer implementations.
+type CCIPProviderArgs struct {
+	ExternalJobID        uuid.UUID 
+	ContractReaderConfig []byte
+	ChainWriterConfig    []byte
 }

--- a/pkg/types/relayer.go
+++ b/pkg/types/relayer.go
@@ -255,7 +255,7 @@ type Relayer interface {
 
 	NewOCR3CapabilityProvider(ctx context.Context, rargs RelayArgs, pargs PluginArgs) (OCR3CapabilityProvider, error)
 
-	NewCCIPProvider(ctx context.Context, rargs RelayArgs) (CCIPProvider, error)
+	NewCCIPProvider(ctx context.Context, rargs CCIPProviderArgs) (CCIPProvider, error)
 }
 
 var _ Relayer = &UnimplementedRelayer{}
@@ -366,6 +366,6 @@ func (u *UnimplementedRelayer) NewOCR3CapabilityProvider(ctx context.Context, ra
 	return nil, status.Errorf(codes.Unimplemented, "method NewOCR3CapabilityProvider not implemented")
 }
 
-func (u *UnimplementedRelayer) NewCCIPProvider(ctx context.Context, rargs RelayArgs) (CCIPProvider, error) {
+func (u *UnimplementedRelayer) NewCCIPProvider(ctx context.Context, rargs CCIPProviderArgs) (CCIPProvider, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method NewCCIPProvider not implemented")
 }


### PR DESCRIPTION
Added dedicated args specifically for the NewCCIPProvider method in the Relayer to support initializing the default provider in the Relayer. The generic relayer args was not providing the contract reader and chain reader config to initialize both for the default chain accessor.