### PR TITLE
[PRIV-128] Add DONForCapability to capability registry

### DIFF
--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -292,6 +292,11 @@ type ExecutableAndTriggerCapability interface {
 	ExecutableCapability
 }
 
+type DONWithNodes struct {
+	DON   DON
+	Nodes []Node
+}
+
 // DON represents a network of connected nodes.
 //
 // For an example of an empty DON check, see the following link:

--- a/pkg/loop/internal/core/services/capability/capabilities_registry.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_registry.go
@@ -78,6 +78,22 @@ func (cr *capabilitiesRegistryClient) NodeByPeerID(ctx context.Context, peerID p
 	return cr.nodeFromNodeReply(res), nil
 }
 
+func (cr *capabilitiesRegistryClient) DONForCapability(ctx context.Context, capabilityID string) (capabilities.DON, []capabilities.Node, error) {
+	res, err := cr.grpc.DONForCapability(ctx, &pb.DONForCapabilityRequest{CapabilityID: capabilityID})
+	if err != nil {
+		return capabilities.DON{}, nil, err
+	}
+
+	don := toDON(res.Don)
+
+	var nodes []capabilities.Node
+	for _, n := range res.Nodes {
+		nodes = append(nodes, cr.nodeFromNodeReply(n))
+	}
+
+	return don, nodes, nil
+}
+
 func (cr *capabilitiesRegistryClient) nodeFromNodeReply(nodeReply *pb.NodeReply) capabilities.Node {
 	var pid *p2ptypes.PeerID
 	if len(nodeReply.PeerID) > 0 {
@@ -363,6 +379,23 @@ func (c *capabilitiesRegistryServer) NodeByPeerID(ctx context.Context, nodeReque
 	}
 
 	return c.nodeReplyFromNode(node), nil
+}
+
+func (c *capabilitiesRegistryServer) DONForCapability(ctx context.Context, req *pb.DONForCapabilityRequest) (*pb.DONForCapabilityReply, error) {
+	don, nodes, err := c.impl.DONForCapability(ctx, req.CapabilityID)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodesPb []*pb.NodeReply
+	for _, n := range nodes {
+		nodesPb = append(nodesPb, c.nodeReplyFromNode(n))
+	}
+
+	return &pb.DONForCapabilityReply{
+		Don:   toPbDON(don),
+		Nodes: nodesPb,
+	}, nil
 }
 
 func (c *capabilitiesRegistryServer) nodeReplyFromNode(node capabilities.Node) *pb.NodeReply {

--- a/pkg/loop/internal/core/services/capability/capabilities_registry_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_registry_test.go
@@ -364,6 +364,7 @@ func testCapabilityInfo(t *testing.T, expectedInfo capabilities.CapabilityInfo, 
 	require.Equal(t, expectedInfo.Description, gotInfo.Description)
 	require.Equal(t, expectedInfo.Version(), gotInfo.Version())
 }
+
 func TestToDON(t *testing.T) {
 	don := &pb.DON{
 		Id:   0,
@@ -496,7 +497,7 @@ func TestCapabilitiesRegistry_ConfigForCapability_RemoteExecutableConfig(t *test
 	assert.Equal(t, 2*time.Minute, capConf.RemoteExecutableConfig.RegistrationExpiry)
 }
 
-func TestCapabilitiesRegistry_DONForCapability(t *testing.T) {
+func TestCapabilitiesRegistry_DONsForCapability(t *testing.T) {
 	stopCh := make(chan struct{})
 	logger := logger.Test(t)
 	reg := mocks.NewCapabilitiesRegistry(t)
@@ -552,12 +553,17 @@ func TestCapabilitiesRegistry_DONForCapability(t *testing.T) {
 			CapabilityDONs:      []capabilities.DON{},
 		},
 	}
-	reg.On("DONForCapability", mock.Anything, capID).Once().Return(expectedDON, expectedNodes, nil)
+	expectedDONs := []capabilities.DONWithNodes{
+		{
+			DON:   expectedDON,
+			Nodes: expectedNodes,
+		},
+	}
+	reg.On("DONsForCapability", mock.Anything, capID).Once().Return(expectedDONs, nil)
 
-	don, nodes, err := rc.DONForCapability(t.Context(), capID)
+	dons, err := rc.DONsForCapability(t.Context(), capID)
 	require.NoError(t, err)
-	assert.Equal(t, expectedDON, don)
-	assert.Equal(t, expectedNodes, nodes)
+	assert.Equal(t, expectedDONs, dons)
 }
 
 func ensureEqual(t *testing.T, expectedNode, actualNode capabilities.Node) {

--- a/pkg/loop/internal/pb/capabilities_registry.pb.go
+++ b/pkg/loop/internal/pb/capabilities_registry.pb.go
@@ -903,7 +903,7 @@ func (x *DONForCapabilityRequest) GetCapabilityID() string {
 	return ""
 }
 
-type DONForCapabilityReply struct {
+type DONWithNodes struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Don           *DON                   `protobuf:"bytes,1,opt,name=don,proto3" json:"don,omitempty"`
 	Nodes         []*NodeReply           `protobuf:"bytes,2,rep,name=nodes,proto3" json:"nodes,omitempty"`
@@ -911,9 +911,60 @@ type DONForCapabilityReply struct {
 	sizeCache     protoimpl.SizeCache
 }
 
+func (x *DONWithNodes) Reset() {
+	*x = DONWithNodes{}
+	mi := &file_capabilities_registry_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DONWithNodes) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DONWithNodes) ProtoMessage() {}
+
+func (x *DONWithNodes) ProtoReflect() protoreflect.Message {
+	mi := &file_capabilities_registry_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DONWithNodes.ProtoReflect.Descriptor instead.
+func (*DONWithNodes) Descriptor() ([]byte, []int) {
+	return file_capabilities_registry_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *DONWithNodes) GetDon() *DON {
+	if x != nil {
+		return x.Don
+	}
+	return nil
+}
+
+func (x *DONWithNodes) GetNodes() []*NodeReply {
+	if x != nil {
+		return x.Nodes
+	}
+	return nil
+}
+
+type DONForCapabilityReply struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Dons          []*DONWithNodes        `protobuf:"bytes,1,rep,name=dons,proto3" json:"dons,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
 func (x *DONForCapabilityReply) Reset() {
 	*x = DONForCapabilityReply{}
-	mi := &file_capabilities_registry_proto_msgTypes[16]
+	mi := &file_capabilities_registry_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -925,7 +976,7 @@ func (x *DONForCapabilityReply) String() string {
 func (*DONForCapabilityReply) ProtoMessage() {}
 
 func (x *DONForCapabilityReply) ProtoReflect() protoreflect.Message {
-	mi := &file_capabilities_registry_proto_msgTypes[16]
+	mi := &file_capabilities_registry_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -938,19 +989,12 @@ func (x *DONForCapabilityReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DONForCapabilityReply.ProtoReflect.Descriptor instead.
 func (*DONForCapabilityReply) Descriptor() ([]byte, []int) {
-	return file_capabilities_registry_proto_rawDescGZIP(), []int{16}
+	return file_capabilities_registry_proto_rawDescGZIP(), []int{17}
 }
 
-func (x *DONForCapabilityReply) GetDon() *DON {
+func (x *DONForCapabilityReply) GetDons() []*DONWithNodes {
 	if x != nil {
-		return x.Don
-	}
-	return nil
-}
-
-func (x *DONForCapabilityReply) GetNodes() []*NodeReply {
-	if x != nil {
-		return x.Nodes
+		return x.Dons
 	}
 	return nil
 }
@@ -1007,20 +1051,22 @@ const file_capabilities_registry_proto_rawDesc = "" +
 	"\x18ConfigForCapabilityReply\x12C\n" +
 	"\x11capability_config\x18\x01 \x01(\v2\x16.loop.CapabilityConfigR\x10capabilityConfig\"=\n" +
 	"\x17DONForCapabilityRequest\x12\"\n" +
-	"\fcapabilityID\x18\x01 \x01(\tR\fcapabilityID\"[\n" +
-	"\x15DONForCapabilityReply\x12\x1b\n" +
+	"\fcapabilityID\x18\x01 \x01(\tR\fcapabilityID\"R\n" +
+	"\fDONWithNodes\x12\x1b\n" +
 	"\x03don\x18\x01 \x01(\v2\t.loop.DONR\x03don\x12%\n" +
-	"\x05nodes\x18\x02 \x03(\v2\x0f.loop.NodeReplyR\x05nodes*\x89\x01\n" +
+	"\x05nodes\x18\x02 \x03(\v2\x0f.loop.NodeReplyR\x05nodes\"?\n" +
+	"\x15DONForCapabilityReply\x12&\n" +
+	"\x04dons\x18\x01 \x03(\v2\x12.loop.DONWithNodesR\x04dons*\x89\x01\n" +
 	"\x0eExecuteAPIType\x12\x1c\n" +
 	"\x18EXECUTE_API_TYPE_UNKNOWN\x10\x00\x12\x1c\n" +
 	"\x18EXECUTE_API_TYPE_TRIGGER\x10\x01\x12\x1c\n" +
 	"\x18EXECUTE_API_TYPE_EXECUTE\x10\x02\x12\x1d\n" +
-	"\x19EXECUTE_API_TYPE_COMBINED\x10\x032\x84\x05\n" +
+	"\x19EXECUTE_API_TYPE_COMBINED\x10\x032\x85\x05\n" +
 	"\x14CapabilitiesRegistry\x126\n" +
 	"\tLocalNode\x12\x16.google.protobuf.Empty\x1a\x0f.loop.NodeReply\"\x00\x124\n" +
 	"\fNodeByPeerID\x12\x11.loop.NodeRequest\x1a\x0f.loop.NodeReply\"\x00\x12Y\n" +
-	"\x13ConfigForCapability\x12 .loop.ConfigForCapabilityRequest\x1a\x1e.loop.ConfigForCapabilityReply\"\x00\x12P\n" +
-	"\x10DONForCapability\x12\x1d.loop.DONForCapabilityRequest\x1a\x1b.loop.DONForCapabilityReply\"\x00\x12)\n" +
+	"\x13ConfigForCapability\x12 .loop.ConfigForCapabilityRequest\x1a\x1e.loop.ConfigForCapabilityReply\"\x00\x12Q\n" +
+	"\x11DONsForCapability\x12\x1d.loop.DONForCapabilityRequest\x1a\x1b.loop.DONForCapabilityReply\"\x00\x12)\n" +
 	"\x03Get\x12\x10.loop.GetRequest\x1a\x0e.loop.GetReply\"\x00\x12>\n" +
 	"\n" +
 	"GetTrigger\x12\x17.loop.GetTriggerRequest\x1a\x15.loop.GetTriggerReply\"\x00\x12G\n" +
@@ -1042,7 +1088,7 @@ func file_capabilities_registry_proto_rawDescGZIP() []byte {
 }
 
 var file_capabilities_registry_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_capabilities_registry_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_capabilities_registry_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_capabilities_registry_proto_goTypes = []any{
 	(ExecuteAPIType)(0),                // 0: loop.ExecuteAPIType
 	(*DON)(nil),                        // 1: loop.DON
@@ -1061,43 +1107,45 @@ var file_capabilities_registry_proto_goTypes = []any{
 	(*ConfigForCapabilityRequest)(nil), // 14: loop.ConfigForCapabilityRequest
 	(*ConfigForCapabilityReply)(nil),   // 15: loop.ConfigForCapabilityReply
 	(*DONForCapabilityRequest)(nil),    // 16: loop.DONForCapabilityRequest
-	(*DONForCapabilityReply)(nil),      // 17: loop.DONForCapabilityReply
-	(*pb.CapabilityConfig)(nil),        // 18: loop.CapabilityConfig
-	(*emptypb.Empty)(nil),              // 19: google.protobuf.Empty
+	(*DONWithNodes)(nil),               // 17: loop.DONWithNodes
+	(*DONForCapabilityReply)(nil),      // 18: loop.DONForCapabilityReply
+	(*pb.CapabilityConfig)(nil),        // 19: loop.CapabilityConfig
+	(*emptypb.Empty)(nil),              // 20: google.protobuf.Empty
 }
 var file_capabilities_registry_proto_depIdxs = []int32{
 	1,  // 0: loop.NodeReply.workflowDON:type_name -> loop.DON
 	1,  // 1: loop.NodeReply.CapabilityDONs:type_name -> loop.DON
 	0,  // 2: loop.GetReply.type:type_name -> loop.ExecuteAPIType
 	0,  // 3: loop.AddRequest.type:type_name -> loop.ExecuteAPIType
-	18, // 4: loop.ConfigForCapabilityReply.capability_config:type_name -> loop.CapabilityConfig
-	1,  // 5: loop.DONForCapabilityReply.don:type_name -> loop.DON
-	3,  // 6: loop.DONForCapabilityReply.nodes:type_name -> loop.NodeReply
-	19, // 7: loop.CapabilitiesRegistry.LocalNode:input_type -> google.protobuf.Empty
-	2,  // 8: loop.CapabilitiesRegistry.NodeByPeerID:input_type -> loop.NodeRequest
-	14, // 9: loop.CapabilitiesRegistry.ConfigForCapability:input_type -> loop.ConfigForCapabilityRequest
-	16, // 10: loop.CapabilitiesRegistry.DONForCapability:input_type -> loop.DONForCapabilityRequest
-	4,  // 11: loop.CapabilitiesRegistry.Get:input_type -> loop.GetRequest
-	6,  // 12: loop.CapabilitiesRegistry.GetTrigger:input_type -> loop.GetTriggerRequest
-	8,  // 13: loop.CapabilitiesRegistry.GetExecutable:input_type -> loop.GetExecutableRequest
-	19, // 14: loop.CapabilitiesRegistry.List:input_type -> google.protobuf.Empty
-	12, // 15: loop.CapabilitiesRegistry.Add:input_type -> loop.AddRequest
-	13, // 16: loop.CapabilitiesRegistry.Remove:input_type -> loop.RemoveRequest
-	3,  // 17: loop.CapabilitiesRegistry.LocalNode:output_type -> loop.NodeReply
-	3,  // 18: loop.CapabilitiesRegistry.NodeByPeerID:output_type -> loop.NodeReply
-	15, // 19: loop.CapabilitiesRegistry.ConfigForCapability:output_type -> loop.ConfigForCapabilityReply
-	17, // 20: loop.CapabilitiesRegistry.DONForCapability:output_type -> loop.DONForCapabilityReply
-	5,  // 21: loop.CapabilitiesRegistry.Get:output_type -> loop.GetReply
-	7,  // 22: loop.CapabilitiesRegistry.GetTrigger:output_type -> loop.GetTriggerReply
-	9,  // 23: loop.CapabilitiesRegistry.GetExecutable:output_type -> loop.GetExecutableReply
-	10, // 24: loop.CapabilitiesRegistry.List:output_type -> loop.ListReply
-	19, // 25: loop.CapabilitiesRegistry.Add:output_type -> google.protobuf.Empty
-	19, // 26: loop.CapabilitiesRegistry.Remove:output_type -> google.protobuf.Empty
-	17, // [17:27] is the sub-list for method output_type
-	7,  // [7:17] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	19, // 4: loop.ConfigForCapabilityReply.capability_config:type_name -> loop.CapabilityConfig
+	1,  // 5: loop.DONWithNodes.don:type_name -> loop.DON
+	3,  // 6: loop.DONWithNodes.nodes:type_name -> loop.NodeReply
+	17, // 7: loop.DONForCapabilityReply.dons:type_name -> loop.DONWithNodes
+	20, // 8: loop.CapabilitiesRegistry.LocalNode:input_type -> google.protobuf.Empty
+	2,  // 9: loop.CapabilitiesRegistry.NodeByPeerID:input_type -> loop.NodeRequest
+	14, // 10: loop.CapabilitiesRegistry.ConfigForCapability:input_type -> loop.ConfigForCapabilityRequest
+	16, // 11: loop.CapabilitiesRegistry.DONsForCapability:input_type -> loop.DONForCapabilityRequest
+	4,  // 12: loop.CapabilitiesRegistry.Get:input_type -> loop.GetRequest
+	6,  // 13: loop.CapabilitiesRegistry.GetTrigger:input_type -> loop.GetTriggerRequest
+	8,  // 14: loop.CapabilitiesRegistry.GetExecutable:input_type -> loop.GetExecutableRequest
+	20, // 15: loop.CapabilitiesRegistry.List:input_type -> google.protobuf.Empty
+	12, // 16: loop.CapabilitiesRegistry.Add:input_type -> loop.AddRequest
+	13, // 17: loop.CapabilitiesRegistry.Remove:input_type -> loop.RemoveRequest
+	3,  // 18: loop.CapabilitiesRegistry.LocalNode:output_type -> loop.NodeReply
+	3,  // 19: loop.CapabilitiesRegistry.NodeByPeerID:output_type -> loop.NodeReply
+	15, // 20: loop.CapabilitiesRegistry.ConfigForCapability:output_type -> loop.ConfigForCapabilityReply
+	18, // 21: loop.CapabilitiesRegistry.DONsForCapability:output_type -> loop.DONForCapabilityReply
+	5,  // 22: loop.CapabilitiesRegistry.Get:output_type -> loop.GetReply
+	7,  // 23: loop.CapabilitiesRegistry.GetTrigger:output_type -> loop.GetTriggerReply
+	9,  // 24: loop.CapabilitiesRegistry.GetExecutable:output_type -> loop.GetExecutableReply
+	10, // 25: loop.CapabilitiesRegistry.List:output_type -> loop.ListReply
+	20, // 26: loop.CapabilitiesRegistry.Add:output_type -> google.protobuf.Empty
+	20, // 27: loop.CapabilitiesRegistry.Remove:output_type -> google.protobuf.Empty
+	18, // [18:28] is the sub-list for method output_type
+	8,  // [8:18] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_capabilities_registry_proto_init() }
@@ -1111,7 +1159,7 @@ func file_capabilities_registry_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_capabilities_registry_proto_rawDesc), len(file_capabilities_registry_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/loop/internal/pb/capabilities_registry.pb.go
+++ b/pkg/loop/internal/pb/capabilities_registry.pb.go
@@ -859,6 +859,102 @@ func (x *ConfigForCapabilityReply) GetCapabilityConfig() *pb.CapabilityConfig {
 	return nil
 }
 
+type DONForCapabilityRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CapabilityID  string                 `protobuf:"bytes,1,opt,name=capabilityID,proto3" json:"capabilityID,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DONForCapabilityRequest) Reset() {
+	*x = DONForCapabilityRequest{}
+	mi := &file_capabilities_registry_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DONForCapabilityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DONForCapabilityRequest) ProtoMessage() {}
+
+func (x *DONForCapabilityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_capabilities_registry_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DONForCapabilityRequest.ProtoReflect.Descriptor instead.
+func (*DONForCapabilityRequest) Descriptor() ([]byte, []int) {
+	return file_capabilities_registry_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *DONForCapabilityRequest) GetCapabilityID() string {
+	if x != nil {
+		return x.CapabilityID
+	}
+	return ""
+}
+
+type DONForCapabilityReply struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Don           *DON                   `protobuf:"bytes,1,opt,name=don,proto3" json:"don,omitempty"`
+	Nodes         []*NodeReply           `protobuf:"bytes,2,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DONForCapabilityReply) Reset() {
+	*x = DONForCapabilityReply{}
+	mi := &file_capabilities_registry_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DONForCapabilityReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DONForCapabilityReply) ProtoMessage() {}
+
+func (x *DONForCapabilityReply) ProtoReflect() protoreflect.Message {
+	mi := &file_capabilities_registry_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DONForCapabilityReply.ProtoReflect.Descriptor instead.
+func (*DONForCapabilityReply) Descriptor() ([]byte, []int) {
+	return file_capabilities_registry_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *DONForCapabilityReply) GetDon() *DON {
+	if x != nil {
+		return x.Don
+	}
+	return nil
+}
+
+func (x *DONForCapabilityReply) GetNodes() []*NodeReply {
+	if x != nil {
+		return x.Nodes
+	}
+	return nil
+}
+
 var File_capabilities_registry_proto protoreflect.FileDescriptor
 
 const file_capabilities_registry_proto_rawDesc = "" +
@@ -909,16 +1005,22 @@ const file_capabilities_registry_proto_rawDesc = "" +
 	"\fcapabilityID\x18\x01 \x01(\tR\fcapabilityID\x12\x14\n" +
 	"\x05donID\x18\x02 \x01(\rR\x05donID\"_\n" +
 	"\x18ConfigForCapabilityReply\x12C\n" +
-	"\x11capability_config\x18\x01 \x01(\v2\x16.loop.CapabilityConfigR\x10capabilityConfig*\x89\x01\n" +
+	"\x11capability_config\x18\x01 \x01(\v2\x16.loop.CapabilityConfigR\x10capabilityConfig\"=\n" +
+	"\x17DONForCapabilityRequest\x12\"\n" +
+	"\fcapabilityID\x18\x01 \x01(\tR\fcapabilityID\"[\n" +
+	"\x15DONForCapabilityReply\x12\x1b\n" +
+	"\x03don\x18\x01 \x01(\v2\t.loop.DONR\x03don\x12%\n" +
+	"\x05nodes\x18\x02 \x03(\v2\x0f.loop.NodeReplyR\x05nodes*\x89\x01\n" +
 	"\x0eExecuteAPIType\x12\x1c\n" +
 	"\x18EXECUTE_API_TYPE_UNKNOWN\x10\x00\x12\x1c\n" +
 	"\x18EXECUTE_API_TYPE_TRIGGER\x10\x01\x12\x1c\n" +
 	"\x18EXECUTE_API_TYPE_EXECUTE\x10\x02\x12\x1d\n" +
-	"\x19EXECUTE_API_TYPE_COMBINED\x10\x032\xb2\x04\n" +
+	"\x19EXECUTE_API_TYPE_COMBINED\x10\x032\x84\x05\n" +
 	"\x14CapabilitiesRegistry\x126\n" +
 	"\tLocalNode\x12\x16.google.protobuf.Empty\x1a\x0f.loop.NodeReply\"\x00\x124\n" +
 	"\fNodeByPeerID\x12\x11.loop.NodeRequest\x1a\x0f.loop.NodeReply\"\x00\x12Y\n" +
-	"\x13ConfigForCapability\x12 .loop.ConfigForCapabilityRequest\x1a\x1e.loop.ConfigForCapabilityReply\"\x00\x12)\n" +
+	"\x13ConfigForCapability\x12 .loop.ConfigForCapabilityRequest\x1a\x1e.loop.ConfigForCapabilityReply\"\x00\x12P\n" +
+	"\x10DONForCapability\x12\x1d.loop.DONForCapabilityRequest\x1a\x1b.loop.DONForCapabilityReply\"\x00\x12)\n" +
 	"\x03Get\x12\x10.loop.GetRequest\x1a\x0e.loop.GetReply\"\x00\x12>\n" +
 	"\n" +
 	"GetTrigger\x12\x17.loop.GetTriggerRequest\x1a\x15.loop.GetTriggerReply\"\x00\x12G\n" +
@@ -940,7 +1042,7 @@ func file_capabilities_registry_proto_rawDescGZIP() []byte {
 }
 
 var file_capabilities_registry_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_capabilities_registry_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_capabilities_registry_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_capabilities_registry_proto_goTypes = []any{
 	(ExecuteAPIType)(0),                // 0: loop.ExecuteAPIType
 	(*DON)(nil),                        // 1: loop.DON
@@ -958,38 +1060,44 @@ var file_capabilities_registry_proto_goTypes = []any{
 	(*RemoveRequest)(nil),              // 13: loop.RemoveRequest
 	(*ConfigForCapabilityRequest)(nil), // 14: loop.ConfigForCapabilityRequest
 	(*ConfigForCapabilityReply)(nil),   // 15: loop.ConfigForCapabilityReply
-	(*pb.CapabilityConfig)(nil),        // 16: loop.CapabilityConfig
-	(*emptypb.Empty)(nil),              // 17: google.protobuf.Empty
+	(*DONForCapabilityRequest)(nil),    // 16: loop.DONForCapabilityRequest
+	(*DONForCapabilityReply)(nil),      // 17: loop.DONForCapabilityReply
+	(*pb.CapabilityConfig)(nil),        // 18: loop.CapabilityConfig
+	(*emptypb.Empty)(nil),              // 19: google.protobuf.Empty
 }
 var file_capabilities_registry_proto_depIdxs = []int32{
 	1,  // 0: loop.NodeReply.workflowDON:type_name -> loop.DON
 	1,  // 1: loop.NodeReply.CapabilityDONs:type_name -> loop.DON
 	0,  // 2: loop.GetReply.type:type_name -> loop.ExecuteAPIType
 	0,  // 3: loop.AddRequest.type:type_name -> loop.ExecuteAPIType
-	16, // 4: loop.ConfigForCapabilityReply.capability_config:type_name -> loop.CapabilityConfig
-	17, // 5: loop.CapabilitiesRegistry.LocalNode:input_type -> google.protobuf.Empty
-	2,  // 6: loop.CapabilitiesRegistry.NodeByPeerID:input_type -> loop.NodeRequest
-	14, // 7: loop.CapabilitiesRegistry.ConfigForCapability:input_type -> loop.ConfigForCapabilityRequest
-	4,  // 8: loop.CapabilitiesRegistry.Get:input_type -> loop.GetRequest
-	6,  // 9: loop.CapabilitiesRegistry.GetTrigger:input_type -> loop.GetTriggerRequest
-	8,  // 10: loop.CapabilitiesRegistry.GetExecutable:input_type -> loop.GetExecutableRequest
-	17, // 11: loop.CapabilitiesRegistry.List:input_type -> google.protobuf.Empty
-	12, // 12: loop.CapabilitiesRegistry.Add:input_type -> loop.AddRequest
-	13, // 13: loop.CapabilitiesRegistry.Remove:input_type -> loop.RemoveRequest
-	3,  // 14: loop.CapabilitiesRegistry.LocalNode:output_type -> loop.NodeReply
-	3,  // 15: loop.CapabilitiesRegistry.NodeByPeerID:output_type -> loop.NodeReply
-	15, // 16: loop.CapabilitiesRegistry.ConfigForCapability:output_type -> loop.ConfigForCapabilityReply
-	5,  // 17: loop.CapabilitiesRegistry.Get:output_type -> loop.GetReply
-	7,  // 18: loop.CapabilitiesRegistry.GetTrigger:output_type -> loop.GetTriggerReply
-	9,  // 19: loop.CapabilitiesRegistry.GetExecutable:output_type -> loop.GetExecutableReply
-	10, // 20: loop.CapabilitiesRegistry.List:output_type -> loop.ListReply
-	17, // 21: loop.CapabilitiesRegistry.Add:output_type -> google.protobuf.Empty
-	17, // 22: loop.CapabilitiesRegistry.Remove:output_type -> google.protobuf.Empty
-	14, // [14:23] is the sub-list for method output_type
-	5,  // [5:14] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	18, // 4: loop.ConfigForCapabilityReply.capability_config:type_name -> loop.CapabilityConfig
+	1,  // 5: loop.DONForCapabilityReply.don:type_name -> loop.DON
+	3,  // 6: loop.DONForCapabilityReply.nodes:type_name -> loop.NodeReply
+	19, // 7: loop.CapabilitiesRegistry.LocalNode:input_type -> google.protobuf.Empty
+	2,  // 8: loop.CapabilitiesRegistry.NodeByPeerID:input_type -> loop.NodeRequest
+	14, // 9: loop.CapabilitiesRegistry.ConfigForCapability:input_type -> loop.ConfigForCapabilityRequest
+	16, // 10: loop.CapabilitiesRegistry.DONForCapability:input_type -> loop.DONForCapabilityRequest
+	4,  // 11: loop.CapabilitiesRegistry.Get:input_type -> loop.GetRequest
+	6,  // 12: loop.CapabilitiesRegistry.GetTrigger:input_type -> loop.GetTriggerRequest
+	8,  // 13: loop.CapabilitiesRegistry.GetExecutable:input_type -> loop.GetExecutableRequest
+	19, // 14: loop.CapabilitiesRegistry.List:input_type -> google.protobuf.Empty
+	12, // 15: loop.CapabilitiesRegistry.Add:input_type -> loop.AddRequest
+	13, // 16: loop.CapabilitiesRegistry.Remove:input_type -> loop.RemoveRequest
+	3,  // 17: loop.CapabilitiesRegistry.LocalNode:output_type -> loop.NodeReply
+	3,  // 18: loop.CapabilitiesRegistry.NodeByPeerID:output_type -> loop.NodeReply
+	15, // 19: loop.CapabilitiesRegistry.ConfigForCapability:output_type -> loop.ConfigForCapabilityReply
+	17, // 20: loop.CapabilitiesRegistry.DONForCapability:output_type -> loop.DONForCapabilityReply
+	5,  // 21: loop.CapabilitiesRegistry.Get:output_type -> loop.GetReply
+	7,  // 22: loop.CapabilitiesRegistry.GetTrigger:output_type -> loop.GetTriggerReply
+	9,  // 23: loop.CapabilitiesRegistry.GetExecutable:output_type -> loop.GetExecutableReply
+	10, // 24: loop.CapabilitiesRegistry.List:output_type -> loop.ListReply
+	19, // 25: loop.CapabilitiesRegistry.Add:output_type -> google.protobuf.Empty
+	19, // 26: loop.CapabilitiesRegistry.Remove:output_type -> google.protobuf.Empty
+	17, // [17:27] is the sub-list for method output_type
+	7,  // [7:17] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_capabilities_registry_proto_init() }
@@ -1003,7 +1111,7 @@ func file_capabilities_registry_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_capabilities_registry_proto_rawDesc), len(file_capabilities_registry_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   15,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/loop/internal/pb/capabilities_registry.proto
+++ b/pkg/loop/internal/pb/capabilities_registry.proto
@@ -11,6 +11,7 @@ service CapabilitiesRegistry {
   rpc LocalNode (google.protobuf.Empty) returns (NodeReply) {}
   rpc NodeByPeerID(NodeRequest) returns (NodeReply) {}
   rpc ConfigForCapability (ConfigForCapabilityRequest) returns (ConfigForCapabilityReply) {}
+  rpc DONForCapability (DONForCapabilityRequest) returns (DONForCapabilityReply) {}
   rpc Get (GetRequest) returns (GetReply) {}
   rpc GetTrigger (GetTriggerRequest) returns (GetTriggerReply) {}
   rpc GetExecutable (GetExecutableRequest) returns (GetExecutableReply) {}
@@ -111,4 +112,13 @@ message ConfigForCapabilityRequest {
 
 message ConfigForCapabilityReply {
   loop.CapabilityConfig capability_config = 1;
+}
+
+message DONForCapabilityRequest {
+  string capabilityID = 1;
+}
+
+message DONForCapabilityReply {
+  DON don = 1;
+  repeated NodeReply nodes = 2;
 }

--- a/pkg/loop/internal/pb/capabilities_registry.proto
+++ b/pkg/loop/internal/pb/capabilities_registry.proto
@@ -11,7 +11,7 @@ service CapabilitiesRegistry {
   rpc LocalNode (google.protobuf.Empty) returns (NodeReply) {}
   rpc NodeByPeerID(NodeRequest) returns (NodeReply) {}
   rpc ConfigForCapability (ConfigForCapabilityRequest) returns (ConfigForCapabilityReply) {}
-  rpc DONForCapability (DONForCapabilityRequest) returns (DONForCapabilityReply) {}
+  rpc DONsForCapability (DONForCapabilityRequest) returns (DONForCapabilityReply) {}
   rpc Get (GetRequest) returns (GetReply) {}
   rpc GetTrigger (GetTriggerRequest) returns (GetTriggerReply) {}
   rpc GetExecutable (GetExecutableRequest) returns (GetExecutableReply) {}
@@ -118,7 +118,11 @@ message DONForCapabilityRequest {
   string capabilityID = 1;
 }
 
-message DONForCapabilityReply {
+message DONWithNodes {
   DON don = 1;
   repeated NodeReply nodes = 2;
+}
+
+message DONForCapabilityReply {
+  repeated DONWithNodes dons = 1;
 }

--- a/pkg/loop/internal/pb/capabilities_registry_grpc.pb.go
+++ b/pkg/loop/internal/pb/capabilities_registry_grpc.pb.go
@@ -23,7 +23,7 @@ const (
 	CapabilitiesRegistry_LocalNode_FullMethodName           = "/loop.CapabilitiesRegistry/LocalNode"
 	CapabilitiesRegistry_NodeByPeerID_FullMethodName        = "/loop.CapabilitiesRegistry/NodeByPeerID"
 	CapabilitiesRegistry_ConfigForCapability_FullMethodName = "/loop.CapabilitiesRegistry/ConfigForCapability"
-	CapabilitiesRegistry_DONForCapability_FullMethodName    = "/loop.CapabilitiesRegistry/DONForCapability"
+	CapabilitiesRegistry_DONsForCapability_FullMethodName   = "/loop.CapabilitiesRegistry/DONsForCapability"
 	CapabilitiesRegistry_Get_FullMethodName                 = "/loop.CapabilitiesRegistry/Get"
 	CapabilitiesRegistry_GetTrigger_FullMethodName          = "/loop.CapabilitiesRegistry/GetTrigger"
 	CapabilitiesRegistry_GetExecutable_FullMethodName       = "/loop.CapabilitiesRegistry/GetExecutable"
@@ -39,7 +39,7 @@ type CapabilitiesRegistryClient interface {
 	LocalNode(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*NodeReply, error)
 	NodeByPeerID(ctx context.Context, in *NodeRequest, opts ...grpc.CallOption) (*NodeReply, error)
 	ConfigForCapability(ctx context.Context, in *ConfigForCapabilityRequest, opts ...grpc.CallOption) (*ConfigForCapabilityReply, error)
-	DONForCapability(ctx context.Context, in *DONForCapabilityRequest, opts ...grpc.CallOption) (*DONForCapabilityReply, error)
+	DONsForCapability(ctx context.Context, in *DONForCapabilityRequest, opts ...grpc.CallOption) (*DONForCapabilityReply, error)
 	Get(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (*GetReply, error)
 	GetTrigger(ctx context.Context, in *GetTriggerRequest, opts ...grpc.CallOption) (*GetTriggerReply, error)
 	GetExecutable(ctx context.Context, in *GetExecutableRequest, opts ...grpc.CallOption) (*GetExecutableReply, error)
@@ -86,10 +86,10 @@ func (c *capabilitiesRegistryClient) ConfigForCapability(ctx context.Context, in
 	return out, nil
 }
 
-func (c *capabilitiesRegistryClient) DONForCapability(ctx context.Context, in *DONForCapabilityRequest, opts ...grpc.CallOption) (*DONForCapabilityReply, error) {
+func (c *capabilitiesRegistryClient) DONsForCapability(ctx context.Context, in *DONForCapabilityRequest, opts ...grpc.CallOption) (*DONForCapabilityReply, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DONForCapabilityReply)
-	err := c.cc.Invoke(ctx, CapabilitiesRegistry_DONForCapability_FullMethodName, in, out, cOpts...)
+	err := c.cc.Invoke(ctx, CapabilitiesRegistry_DONsForCapability_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ type CapabilitiesRegistryServer interface {
 	LocalNode(context.Context, *emptypb.Empty) (*NodeReply, error)
 	NodeByPeerID(context.Context, *NodeRequest) (*NodeReply, error)
 	ConfigForCapability(context.Context, *ConfigForCapabilityRequest) (*ConfigForCapabilityReply, error)
-	DONForCapability(context.Context, *DONForCapabilityRequest) (*DONForCapabilityReply, error)
+	DONsForCapability(context.Context, *DONForCapabilityRequest) (*DONForCapabilityReply, error)
 	Get(context.Context, *GetRequest) (*GetReply, error)
 	GetTrigger(context.Context, *GetTriggerRequest) (*GetTriggerReply, error)
 	GetExecutable(context.Context, *GetExecutableRequest) (*GetExecutableReply, error)
@@ -189,8 +189,8 @@ func (UnimplementedCapabilitiesRegistryServer) NodeByPeerID(context.Context, *No
 func (UnimplementedCapabilitiesRegistryServer) ConfigForCapability(context.Context, *ConfigForCapabilityRequest) (*ConfigForCapabilityReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ConfigForCapability not implemented")
 }
-func (UnimplementedCapabilitiesRegistryServer) DONForCapability(context.Context, *DONForCapabilityRequest) (*DONForCapabilityReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method DONForCapability not implemented")
+func (UnimplementedCapabilitiesRegistryServer) DONsForCapability(context.Context, *DONForCapabilityRequest) (*DONForCapabilityReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DONsForCapability not implemented")
 }
 func (UnimplementedCapabilitiesRegistryServer) Get(context.Context, *GetRequest) (*GetReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Get not implemented")
@@ -285,20 +285,20 @@ func _CapabilitiesRegistry_ConfigForCapability_Handler(srv interface{}, ctx cont
 	return interceptor(ctx, in, info, handler)
 }
 
-func _CapabilitiesRegistry_DONForCapability_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _CapabilitiesRegistry_DONsForCapability_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(DONForCapabilityRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(CapabilitiesRegistryServer).DONForCapability(ctx, in)
+		return srv.(CapabilitiesRegistryServer).DONsForCapability(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: CapabilitiesRegistry_DONForCapability_FullMethodName,
+		FullMethod: CapabilitiesRegistry_DONsForCapability_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(CapabilitiesRegistryServer).DONForCapability(ctx, req.(*DONForCapabilityRequest))
+		return srv.(CapabilitiesRegistryServer).DONsForCapability(ctx, req.(*DONForCapabilityRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -431,8 +431,8 @@ var CapabilitiesRegistry_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _CapabilitiesRegistry_ConfigForCapability_Handler,
 		},
 		{
-			MethodName: "DONForCapability",
-			Handler:    _CapabilitiesRegistry_DONForCapability_Handler,
+			MethodName: "DONsForCapability",
+			Handler:    _CapabilitiesRegistry_DONsForCapability_Handler,
 		},
 		{
 			MethodName: "Get",

--- a/pkg/loop/internal/pb/capabilities_registry_grpc.pb.go
+++ b/pkg/loop/internal/pb/capabilities_registry_grpc.pb.go
@@ -23,6 +23,7 @@ const (
 	CapabilitiesRegistry_LocalNode_FullMethodName           = "/loop.CapabilitiesRegistry/LocalNode"
 	CapabilitiesRegistry_NodeByPeerID_FullMethodName        = "/loop.CapabilitiesRegistry/NodeByPeerID"
 	CapabilitiesRegistry_ConfigForCapability_FullMethodName = "/loop.CapabilitiesRegistry/ConfigForCapability"
+	CapabilitiesRegistry_DONForCapability_FullMethodName    = "/loop.CapabilitiesRegistry/DONForCapability"
 	CapabilitiesRegistry_Get_FullMethodName                 = "/loop.CapabilitiesRegistry/Get"
 	CapabilitiesRegistry_GetTrigger_FullMethodName          = "/loop.CapabilitiesRegistry/GetTrigger"
 	CapabilitiesRegistry_GetExecutable_FullMethodName       = "/loop.CapabilitiesRegistry/GetExecutable"
@@ -38,6 +39,7 @@ type CapabilitiesRegistryClient interface {
 	LocalNode(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*NodeReply, error)
 	NodeByPeerID(ctx context.Context, in *NodeRequest, opts ...grpc.CallOption) (*NodeReply, error)
 	ConfigForCapability(ctx context.Context, in *ConfigForCapabilityRequest, opts ...grpc.CallOption) (*ConfigForCapabilityReply, error)
+	DONForCapability(ctx context.Context, in *DONForCapabilityRequest, opts ...grpc.CallOption) (*DONForCapabilityReply, error)
 	Get(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (*GetReply, error)
 	GetTrigger(ctx context.Context, in *GetTriggerRequest, opts ...grpc.CallOption) (*GetTriggerReply, error)
 	GetExecutable(ctx context.Context, in *GetExecutableRequest, opts ...grpc.CallOption) (*GetExecutableReply, error)
@@ -78,6 +80,16 @@ func (c *capabilitiesRegistryClient) ConfigForCapability(ctx context.Context, in
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ConfigForCapabilityReply)
 	err := c.cc.Invoke(ctx, CapabilitiesRegistry_ConfigForCapability_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *capabilitiesRegistryClient) DONForCapability(ctx context.Context, in *DONForCapabilityRequest, opts ...grpc.CallOption) (*DONForCapabilityReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DONForCapabilityReply)
+	err := c.cc.Invoke(ctx, CapabilitiesRegistry_DONForCapability_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -151,6 +163,7 @@ type CapabilitiesRegistryServer interface {
 	LocalNode(context.Context, *emptypb.Empty) (*NodeReply, error)
 	NodeByPeerID(context.Context, *NodeRequest) (*NodeReply, error)
 	ConfigForCapability(context.Context, *ConfigForCapabilityRequest) (*ConfigForCapabilityReply, error)
+	DONForCapability(context.Context, *DONForCapabilityRequest) (*DONForCapabilityReply, error)
 	Get(context.Context, *GetRequest) (*GetReply, error)
 	GetTrigger(context.Context, *GetTriggerRequest) (*GetTriggerReply, error)
 	GetExecutable(context.Context, *GetExecutableRequest) (*GetExecutableReply, error)
@@ -175,6 +188,9 @@ func (UnimplementedCapabilitiesRegistryServer) NodeByPeerID(context.Context, *No
 }
 func (UnimplementedCapabilitiesRegistryServer) ConfigForCapability(context.Context, *ConfigForCapabilityRequest) (*ConfigForCapabilityReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ConfigForCapability not implemented")
+}
+func (UnimplementedCapabilitiesRegistryServer) DONForCapability(context.Context, *DONForCapabilityRequest) (*DONForCapabilityReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DONForCapability not implemented")
 }
 func (UnimplementedCapabilitiesRegistryServer) Get(context.Context, *GetRequest) (*GetReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Get not implemented")
@@ -265,6 +281,24 @@ func _CapabilitiesRegistry_ConfigForCapability_Handler(srv interface{}, ctx cont
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(CapabilitiesRegistryServer).ConfigForCapability(ctx, req.(*ConfigForCapabilityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CapabilitiesRegistry_DONForCapability_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DONForCapabilityRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CapabilitiesRegistryServer).DONForCapability(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CapabilitiesRegistry_DONForCapability_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CapabilitiesRegistryServer).DONForCapability(ctx, req.(*DONForCapabilityRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -395,6 +429,10 @@ var CapabilitiesRegistry_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ConfigForCapability",
 			Handler:    _CapabilitiesRegistry_ConfigForCapability_Handler,
+		},
+		{
+			MethodName: "DONForCapability",
+			Handler:    _CapabilitiesRegistry_DONForCapability_Handler,
 		},
 		{
 			MethodName: "Get",

--- a/pkg/types/core/capabilities_registry.go
+++ b/pkg/types/core/capabilities_registry.go
@@ -18,8 +18,8 @@ type CapabilitiesRegistryMetadata interface {
 	LocalNode(ctx context.Context) (capabilities.Node, error)
 	NodeByPeerID(ctx context.Context, peerID types.PeerID) (capabilities.Node, error)
 	ConfigForCapability(ctx context.Context, capabilityID string, donID uint32) (capabilities.CapabilityConfiguration, error)
+	DONForCapability(ctx context.Context, capabilityID string) (capabilities.DON, []capabilities.Node, error)
 }
-
 
 type CapabilitiesRegistryBase interface {
 	GetTrigger(ctx context.Context, ID string) (capabilities.TriggerCapability, error)
@@ -38,7 +38,7 @@ type UnimplementedCapabilitiesRegistry struct {
 	UnimplementedCapabilitiesRegistryBase
 }
 
-type UnimplementedCapabilitiesRegistryMetadata struct {}
+type UnimplementedCapabilitiesRegistryMetadata struct{}
 
 func (UnimplementedCapabilitiesRegistryMetadata) LocalNode(ctx context.Context) (capabilities.Node, error) {
 	return capabilities.Node{}, errors.New("LocalNode not implemented")
@@ -50,6 +50,10 @@ func (UnimplementedCapabilitiesRegistryMetadata) NodeByPeerID(ctx context.Contex
 
 func (UnimplementedCapabilitiesRegistryMetadata) ConfigForCapability(ctx context.Context, capabilityID string, donID uint32) (capabilities.CapabilityConfiguration, error) {
 	return capabilities.CapabilityConfiguration{}, errors.New("ConfigForCapability not implemented")
+}
+
+func (UnimplementedCapabilitiesRegistryMetadata) DONForCapability(ctx context.Context, capabilityID string) (capabilities.DON, []capabilities.Node, error) {
+	return capabilities.DON{}, nil, errors.New("DONForCapability not implemented")
 }
 
 type UnimplementedCapabilitiesRegistryBase struct {

--- a/pkg/types/core/capabilities_registry.go
+++ b/pkg/types/core/capabilities_registry.go
@@ -18,7 +18,7 @@ type CapabilitiesRegistryMetadata interface {
 	LocalNode(ctx context.Context) (capabilities.Node, error)
 	NodeByPeerID(ctx context.Context, peerID types.PeerID) (capabilities.Node, error)
 	ConfigForCapability(ctx context.Context, capabilityID string, donID uint32) (capabilities.CapabilityConfiguration, error)
-	DONForCapability(ctx context.Context, capabilityID string) (capabilities.DON, []capabilities.Node, error)
+	DONsForCapability(ctx context.Context, capabilityID string) ([]capabilities.DONWithNodes, error)
 }
 
 type CapabilitiesRegistryBase interface {
@@ -52,8 +52,8 @@ func (UnimplementedCapabilitiesRegistryMetadata) ConfigForCapability(ctx context
 	return capabilities.CapabilityConfiguration{}, errors.New("ConfigForCapability not implemented")
 }
 
-func (UnimplementedCapabilitiesRegistryMetadata) DONForCapability(ctx context.Context, capabilityID string) (capabilities.DON, []capabilities.Node, error) {
-	return capabilities.DON{}, nil, errors.New("DONForCapability not implemented")
+func (UnimplementedCapabilitiesRegistryMetadata) DONsForCapability(ctx context.Context, capabilityID string) ([]capabilities.DONWithNodes, error) {
+	return nil, errors.New("DONsForCapability not implemented")
 }
 
 type UnimplementedCapabilitiesRegistryBase struct {

--- a/pkg/types/core/mocks/capabilities_registry.go
+++ b/pkg/types/core/mocks/capabilities_registry.go
@@ -130,68 +130,61 @@ func (_c *CapabilitiesRegistry_ConfigForCapability_Call) RunAndReturn(run func(c
 	return _c
 }
 
-// DONForCapability provides a mock function with given fields: ctx, capabilityID
-func (_m *CapabilitiesRegistry) DONForCapability(ctx context.Context, capabilityID string) (capabilities.DON, []capabilities.Node, error) {
+// DONsForCapability provides a mock function with given fields: ctx, capabilityID
+func (_m *CapabilitiesRegistry) DONsForCapability(ctx context.Context, capabilityID string) ([]capabilities.DONWithNodes, error) {
 	ret := _m.Called(ctx, capabilityID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for DONForCapability")
+		panic("no return value specified for DONsForCapability")
 	}
 
-	var r0 capabilities.DON
-	var r1 []capabilities.Node
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (capabilities.DON, []capabilities.Node, error)); ok {
+	var r0 []capabilities.DONWithNodes
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]capabilities.DONWithNodes, error)); ok {
 		return rf(ctx, capabilityID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) capabilities.DON); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []capabilities.DONWithNodes); ok {
 		r0 = rf(ctx, capabilityID)
 	} else {
-		r0 = ret.Get(0).(capabilities.DON)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) []capabilities.Node); ok {
-		r1 = rf(ctx, capabilityID)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).([]capabilities.Node)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]capabilities.DONWithNodes)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string) error); ok {
-		r2 = rf(ctx, capabilityID)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, capabilityID)
 	} else {
-		r2 = ret.Error(2)
+		r1 = ret.Error(1)
 	}
 
-	return r0, r1, r2
+	return r0, r1
 }
 
-// CapabilitiesRegistry_DONForCapability_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DONForCapability'
-type CapabilitiesRegistry_DONForCapability_Call struct {
+// CapabilitiesRegistry_DONsForCapability_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DONsForCapability'
+type CapabilitiesRegistry_DONsForCapability_Call struct {
 	*mock.Call
 }
 
-// DONForCapability is a helper method to define mock.On call
+// DONsForCapability is a helper method to define mock.On call
 //   - ctx context.Context
 //   - capabilityID string
-func (_e *CapabilitiesRegistry_Expecter) DONForCapability(ctx interface{}, capabilityID interface{}) *CapabilitiesRegistry_DONForCapability_Call {
-	return &CapabilitiesRegistry_DONForCapability_Call{Call: _e.mock.On("DONForCapability", ctx, capabilityID)}
+func (_e *CapabilitiesRegistry_Expecter) DONsForCapability(ctx interface{}, capabilityID interface{}) *CapabilitiesRegistry_DONsForCapability_Call {
+	return &CapabilitiesRegistry_DONsForCapability_Call{Call: _e.mock.On("DONsForCapability", ctx, capabilityID)}
 }
 
-func (_c *CapabilitiesRegistry_DONForCapability_Call) Run(run func(ctx context.Context, capabilityID string)) *CapabilitiesRegistry_DONForCapability_Call {
+func (_c *CapabilitiesRegistry_DONsForCapability_Call) Run(run func(ctx context.Context, capabilityID string)) *CapabilitiesRegistry_DONsForCapability_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
 
-func (_c *CapabilitiesRegistry_DONForCapability_Call) Return(_a0 capabilities.DON, _a1 []capabilities.Node, _a2 error) *CapabilitiesRegistry_DONForCapability_Call {
-	_c.Call.Return(_a0, _a1, _a2)
+func (_c *CapabilitiesRegistry_DONsForCapability_Call) Return(_a0 []capabilities.DONWithNodes, _a1 error) *CapabilitiesRegistry_DONsForCapability_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *CapabilitiesRegistry_DONForCapability_Call) RunAndReturn(run func(context.Context, string) (capabilities.DON, []capabilities.Node, error)) *CapabilitiesRegistry_DONForCapability_Call {
+func (_c *CapabilitiesRegistry_DONsForCapability_Call) RunAndReturn(run func(context.Context, string) ([]capabilities.DONWithNodes, error)) *CapabilitiesRegistry_DONsForCapability_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/types/core/mocks/capabilities_registry.go
+++ b/pkg/types/core/mocks/capabilities_registry.go
@@ -130,6 +130,72 @@ func (_c *CapabilitiesRegistry_ConfigForCapability_Call) RunAndReturn(run func(c
 	return _c
 }
 
+// DONForCapability provides a mock function with given fields: ctx, capabilityID
+func (_m *CapabilitiesRegistry) DONForCapability(ctx context.Context, capabilityID string) (capabilities.DON, []capabilities.Node, error) {
+	ret := _m.Called(ctx, capabilityID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DONForCapability")
+	}
+
+	var r0 capabilities.DON
+	var r1 []capabilities.Node
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (capabilities.DON, []capabilities.Node, error)); ok {
+		return rf(ctx, capabilityID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) capabilities.DON); ok {
+		r0 = rf(ctx, capabilityID)
+	} else {
+		r0 = ret.Get(0).(capabilities.DON)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) []capabilities.Node); ok {
+		r1 = rf(ctx, capabilityID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]capabilities.Node)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, string) error); ok {
+		r2 = rf(ctx, capabilityID)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// CapabilitiesRegistry_DONForCapability_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DONForCapability'
+type CapabilitiesRegistry_DONForCapability_Call struct {
+	*mock.Call
+}
+
+// DONForCapability is a helper method to define mock.On call
+//   - ctx context.Context
+//   - capabilityID string
+func (_e *CapabilitiesRegistry_Expecter) DONForCapability(ctx interface{}, capabilityID interface{}) *CapabilitiesRegistry_DONForCapability_Call {
+	return &CapabilitiesRegistry_DONForCapability_Call{Call: _e.mock.On("DONForCapability", ctx, capabilityID)}
+}
+
+func (_c *CapabilitiesRegistry_DONForCapability_Call) Run(run func(ctx context.Context, capabilityID string)) *CapabilitiesRegistry_DONForCapability_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *CapabilitiesRegistry_DONForCapability_Call) Return(_a0 capabilities.DON, _a1 []capabilities.Node, _a2 error) *CapabilitiesRegistry_DONForCapability_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *CapabilitiesRegistry_DONForCapability_Call) RunAndReturn(run func(context.Context, string) (capabilities.DON, []capabilities.Node, error)) *CapabilitiesRegistry_DONForCapability_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Get provides a mock function with given fields: ctx, ID
 func (_m *CapabilitiesRegistry) Get(ctx context.Context, ID string) (capabilities.BaseCapability, error) {
 	ret := _m.Called(ctx, ID)


### PR DESCRIPTION
- Add a new method to the capability registry
- Implement client and server methods for it
- This change is backwards compatible since all core implementations of the interface already embed the unimplemented type.