### PR TITLE
DF-21546 Configure secure mint aggregator with data id

### DIFF
--- a/pkg/capabilities/consensus/ocr3/datafeeds/securemint_aggregator.go
+++ b/pkg/capabilities/consensus/ocr3/datafeeds/securemint_aggregator.go
@@ -126,7 +126,7 @@ func (f *evmReportFormatter) packReport(lggr logger.Logger, report *secureMintRe
 		map[EVMEncoderKey]any{
 			DataIDOutputFieldName:    f.dataID,
 			AnswerOutputFieldName:    smReportAsAnswer,
-			TimestampOutputFieldName: uint32(report.Block), // TODO: check if this change from int64 to uint32 is correct
+			TimestampOutputFieldName: uint32(report.Block),
 		},
 	}
 

--- a/pkg/capabilities/consensus/ocr3/datafeeds/securemint_aggregator.go
+++ b/pkg/capabilities/consensus/ocr3/datafeeds/securemint_aggregator.go
@@ -442,10 +442,18 @@ func parseSecureMintConfig(config values.Map) (SecureMintAggregatorConfig, error
 		return SecureMintAggregatorConfig{}, fmt.Errorf("dataID must be 16 bytes, got %d", len(decodedDataID))
 	}
 
+	if len(rawCfg.Solana.AccountContext) > 0 {
+		for _, acc := range rawCfg.Solana.AccountContext {
+			if acc.PublicKey == [32]byte{} {
+				return SecureMintAggregatorConfig{}, errors.New("solana account context public key must not be all zeros")
+			}
+		}
+	}
+
 	parsedConfig := SecureMintAggregatorConfig{
 		TargetChainSelector: chainSelector(sel),
 		DataID:              [16]byte(decodedDataID),
-		Solana:              rawCfg.Solana, // TODO(gg): validate?
+		Solana:              rawCfg.Solana,
 	}
 
 	return parsedConfig, nil


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

So far, the data id that's used for writing the secure mint report to the DF Cache contract was constructed from the chain selector. However, to enable multiple secure mint reports on the same chain, we should use a more configurable data id. 
That's why in this PR the data id is set on the aggregator config in the workflow. 




### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->

https://github.com/smartcontractkit/chainlink/pull/19106
