### PR TITLE
remove auth rate limit check and payload size from CRESettings

### DIFF
--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -2,9 +2,6 @@
 	"WorkflowLimit": "200",
 	"WorkflowRegistrationQueueLimit": "20",
 	"WorkflowExecutionConcurrencyLimit": "50",
-	"HTTPTrigger": {
-		"AuthRateLimit": "100rps:-1"
-	},
 	"PerOrg": {
 		"WorkflowDeploymentRateLimit": "every1m0s:1",
 		"ZeroBalancePruningTimeout": "24h0m0s"
@@ -38,9 +35,6 @@
 		},
 		"HTTPTrigger": {
 			"RateLimit": "every30s:3",
-			"AuthRateLimit": "1rps:-1",
-			"IncomingPayloadSizeLimit": "10kb",
-			"OutgoingPayloadSizeLimit": "-1b"
 		},
 		"LogTrigger": {
 			"RateLimit": "every10s:-1",
@@ -53,7 +47,8 @@
 			"RateLimit": "every30s:3",
 			"ResponseSizeLimit": "10kb",
 			"ConnectionTimeout": "10s",
-			"RequestSizeLimit": "100kb"
+			"RequestSizeLimit": "100kb",
+			"CacheAgeLimit": "10m0s"
 		},
 		"ChainWrite": {
 			"RateLimit": "every30s:3",

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -2,9 +2,6 @@ WorkflowLimit = '200'
 WorkflowRegistrationQueueLimit = '20'
 WorkflowExecutionConcurrencyLimit = '50'
 
-[HTTPTrigger]
-AuthRateLimit = '100rps:-1'
-
 [PerOrg]
 WorkflowDeploymentRateLimit = 'every1m0s:1'
 ZeroBalancePruningTimeout = '24h0m0s'
@@ -39,9 +36,6 @@ RateLimit = 'every30s:1'
 
 [PerWorkflow.HTTPTrigger]
 RateLimit = 'every30s:3'
-AuthRateLimit = '1rps:-1'
-IncomingPayloadSizeLimit = '10kb'
-OutgoingPayloadSizeLimit = '-1b'
 
 [PerWorkflow.LogTrigger]
 RateLimit = 'every10s:-1'
@@ -55,6 +49,7 @@ RateLimit = 'every30s:3'
 ResponseSizeLimit = '10kb'
 ConnectionTimeout = '10s'
 RequestSizeLimit = '100kb'
+CacheAgeLimit = '10m0s'
 
 [PerWorkflow.ChainWrite]
 RateLimit = 'every30s:3'

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -27,10 +27,6 @@ var Default = Schema{
 	WorkflowRegistrationQueueLimit:    Int(20),
 	WorkflowExecutionConcurrencyLimit: Int(50),
 
-	HTTPTrigger: httpTriggerGlobal{
-		AuthRateLimit: Rate(100, -1), //TODO
-	},
-
 	PerOrg: Orgs{
 		WorkflowDeploymentRateLimit: Rate(rate.Every(time.Minute), 1),
 		ZeroBalancePruningTimeout:   Duration(24 * time.Hour),
@@ -64,10 +60,7 @@ var Default = Schema{
 			RateLimit: Rate(rate.Every(30*time.Second), 1),
 		},
 		HTTPTrigger: httpTrigger{
-			RateLimit:                Rate(rate.Every(30*time.Second), 3),
-			AuthRateLimit:            Rate(1, -1), //TODO
-			IncomingPayloadSizeLimit: Size(10 * config.KByte),
-			OutgoingPayloadSizeLimit: Size(-1), //TODO
+			RateLimit: Rate(rate.Every(30*time.Second), 3),
 		},
 		LogTrigger: logTrigger{
 			RateLimit:                Rate(rate.Every(10*time.Second), -1), //TODO
@@ -81,6 +74,7 @@ var Default = Schema{
 			ResponseSizeLimit: Size(10 * config.KByte),
 			ConnectionTimeout: Duration(10 * time.Second),
 			RequestSizeLimit:  Size(100 * config.KByte),
+			CacheAgeLimit:     Duration(10 * time.Minute),
 		},
 		ChainWrite: chainWrite{
 			RateLimit:       Rate(rate.Every(30*time.Second), 3),
@@ -102,8 +96,6 @@ type Schema struct {
 	WorkflowLimit                     Setting[int] `unit:"{workflow}"`
 	WorkflowRegistrationQueueLimit    Setting[int] `unit:"{workflow}"`
 	WorkflowExecutionConcurrencyLimit Setting[int] `unit:"{workflow}"`
-
-	HTTPTrigger httpTriggerGlobal
 
 	PerOrg      Orgs      `scope:"org"`
 	PerOwner    Owners    `scope:"owner"`
@@ -157,14 +149,8 @@ type Workflows struct {
 type cronTrigger struct {
 	RateLimit Setting[config.Rate]
 }
-type httpTriggerGlobal struct {
-	AuthRateLimit Setting[config.Rate]
-}
 type httpTrigger struct {
-	RateLimit                Setting[config.Rate]
-	AuthRateLimit            Setting[config.Rate]
-	IncomingPayloadSizeLimit Setting[config.Size]
-	OutgoingPayloadSizeLimit Setting[config.Size]
+	RateLimit Setting[config.Rate]
 }
 type logTrigger struct {
 	RateLimit                Setting[config.Rate]
@@ -178,6 +164,7 @@ type httpAction struct {
 	ResponseSizeLimit Setting[config.Size]
 	ConnectionTimeout Setting[time.Duration]
 	RequestSizeLimit  Setting[config.Size]
+	CacheAgeLimit     Setting[time.Duration]
 }
 type chainWrite struct {
 	RateLimit       Setting[config.Rate]


### PR DESCRIPTION
- remove auth rate limit check and payload size from CRESettings. These checks are applied globally (including non-cre components) for the gateway via TOML config
- add cacheAge default for HTTP action