### PR TITLE
Add a standard test for secrets failing in node mode

### DIFF
--- a/pkg/workflows/wasm/host/standard_tests/secrets_fail_in_node_mode/main_wasip1.go
+++ b/pkg/workflows/wasm/host/standard_tests/secrets_fail_in_node_mode/main_wasip1.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host/internal/rawsdk"
+	"github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+)
+
+func main() {
+	// The real SDKs do something to capture the runtime.
+	// This is to mimic the mode switch calls they would make
+	rawsdk.SwitchModes(int32(sdk.Mode_MODE_NODE))
+
+	consensus := &sdk.SimpleConsensusInputs{
+		Observation: &sdk.SimpleConsensusInputs_Error{Error: "cannot use Runtime inside RunInNodeMode"},
+		Descriptors: &sdk.ConsensusDescriptor{Descriptor_: &sdk.ConsensusDescriptor_Aggregation{Aggregation: sdk.AggregationType_AGGREGATION_TYPE_IDENTICAL}},
+	}
+
+	err := rawsdk.DoRequestErr("consensus@1.0.0-alpha", "Simple", sdk.Mode_MODE_DON, consensus)
+	rawsdk.SwitchModes(int32(sdk.Mode_MODE_DON))
+	rawsdk.SendError(err)
+}


### PR DESCRIPTION
[PR 1/2](https://github.com/smartcontractkit/chainlink-common/pull/1517) update the standard tests
[PR 2/2](https://github.com/smartcontractkit/cre-sdk-go/pull/58) update the go SDK to disallow secret access on the runtime in node mode. 