### PR TITLE
augment OutboundHTTPResponse with helpful fields for metrics

### DIFF
--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -53,7 +53,8 @@
 			"RateLimit": "every30s:3",
 			"ResponseSizeLimit": "10kb",
 			"ConnectionTimeout": "10s",
-			"RequestSizeLimit": "100kb"
+			"RequestSizeLimit": "100kb",
+			"CacheAgeLimit": "10m0s"
 		},
 		"ChainWrite": {
 			"RateLimit": "every30s:3",

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -55,6 +55,7 @@ RateLimit = 'every30s:3'
 ResponseSizeLimit = '10kb'
 ConnectionTimeout = '10s'
 RequestSizeLimit = '100kb'
+CacheAgeLimit = '10m0s'
 
 [PerWorkflow.ChainWrite]
 RateLimit = 'every30s:3'

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -59,7 +59,6 @@ var Default = Schema{
 		ConsensusCallsLimit:           Int(2),
 		LogLineLimit:                  Size(config.KByte),
 		LogEventLimit:                 Int(1_000),
-
 		CRONTrigger: cronTrigger{
 			RateLimit: Rate(rate.Every(30*time.Second), 1),
 		},
@@ -81,6 +80,7 @@ var Default = Schema{
 			ResponseSizeLimit: Size(10 * config.KByte),
 			ConnectionTimeout: Duration(10 * time.Second),
 			RequestSizeLimit:  Size(100 * config.KByte),
+			CacheAgeLimit:     Duration(10 * time.Minute),
 		},
 		ChainWrite: chainWrite{
 			RateLimit:       Rate(rate.Every(30*time.Second), 3),
@@ -178,6 +178,7 @@ type httpAction struct {
 	ResponseSizeLimit Setting[config.Size]
 	ConnectionTimeout Setting[time.Duration]
 	RequestSizeLimit  Setting[config.Size]
+	CacheAgeLimit     Setting[time.Duration]
 }
 type chainWrite struct {
 	RateLimit       Setting[config.Rate]

--- a/pkg/types/gateway/action.go
+++ b/pkg/types/gateway/action.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"sort"
 	"strconv"
+	"time"
 )
 
 const (
@@ -65,8 +66,10 @@ func (req OutboundHTTPRequest) Hash() string {
 
 // OutboundHTTPResponse represents the response from gateway to workflow node.
 type OutboundHTTPResponse struct {
-	ErrorMessage string            `json:"errorMessage,omitempty"` // error message in case of execution errors. i.e. errors before or after attempting HTTP call to external client
-	StatusCode   int               `json:"statusCode,omitempty"`   // HTTP status code
-	Headers      map[string]string `json:"headers,omitempty"`      // HTTP headers
-	Body         []byte            `json:"body,omitempty"`         // HTTP response body
+	ErrorMessage            string            `json:"errorMessage,omitempty"`            // error message for all errors except HTTP errors returned by external endpoints
+	IsExternalEndpointError bool              `json:"isExternalEndpointError,omitempty"` // indicates whether the error is from a faulty external endpoint (e.g. timeout, response size) vs error introduced internally by gateway execution
+	StatusCode              int               `json:"statusCode,omitempty"`              // HTTP status code
+	Headers                 map[string]string `json:"headers,omitempty"`                 // HTTP headers
+	Body                    []byte            `json:"body,omitempty"`                    // HTTP response body
+	ExternalEndpointLatency time.Duration     `json:"externalEndpointLatency,omitempty"` // Latency of the external endpoint
 }


### PR DESCRIPTION
- augment OutboundHTTPResponse with `IsExternalEndpointError` and `ExternalEndpointLatency`
- add CacheAgeLimit to `cresettings`