### PR TITLE
Add DKG plugin type

### DIFF
--- a/pkg/types/plugin.go
+++ b/pkg/types/plugin.go
@@ -16,6 +16,7 @@ const (
 	GenericPlugin  OCR2PluginType = "plugin"
 	OCR3Capability OCR2PluginType = "ocr3-capability"
 	VaultPlugin    OCR2PluginType = "vault-plugin"
+	DKGPlugin      OCR2PluginType = "dkg-plugin"
 	DonTimePlugin  OCR2PluginType = "dontime"
 	SecureMint     OCR2PluginType = "securemint"
 


### PR DESCRIPTION
## Summary

Registers a new `DKGPlugin` OCR2 plugin type (`"dkg-plugin"`) in `pkg/types/plugin.go`.

## Why

Adds the plugin-type constant needed for the DKG plugin so it can be distinguished from other OCR2 plugin types in registration and dispatch paths.
