### PR TITLE
pkg/loop/loop/net: log improvements

### DIFF
--- a/pkg/loop/internal/net/broker.go
+++ b/pkg/loop/internal/net/broker.go
@@ -108,7 +108,7 @@ func (b *BrokerExt) Serve(name string, server *grpc.Server, deps ...Resource) (u
 	lis, err := b.Broker.Accept(id)
 	if err != nil {
 		b.CloseAll(deps...)
-		return 0, Resource{}, ErrConnAccept{Name: name, ID: id, Err: err}
+		return 0, Resource{}, ErrConnAccept{Broker: fmt.Sprintf("%p", b.Broker), Name: name, ID: id, Err: err}
 	}
 
 	var wg sync.WaitGroup

--- a/pkg/loop/internal/net/client.go
+++ b/pkg/loop/internal/net/client.go
@@ -64,7 +64,7 @@ func (c *clientConn) Invoke(ctx context.Context, method string, args interface{}
 				c.Logger.Warnw("clientConn: Invoke: terminal error", "method", method, "err", err)
 				return err
 			}
-			c.Logger.Warnw("clientConn: Invoke: terminal error, refreshing connection", "method", method, "err", err)
+			c.Logger.Errorw("clientConn: Invoke: terminal error, refreshing connection", "method", method, "err", err)
 			cc = c.refresh(ctx, cc)
 			continue
 		}
@@ -84,7 +84,7 @@ func (c *clientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, metho
 	for cc != nil {
 		s, err := cc.NewStream(ctx, desc, method, opts...)
 		if isErrTerminal(err) {
-			c.Logger.Warnw("clientConn: NewStream: terminal error, refreshing connection", "err", err)
+			c.Logger.Errorw("clientConn: NewStream: terminal error, refreshing connection", "err", err)
 			cc = c.refresh(ctx, cc)
 			continue
 		}

--- a/pkg/loop/internal/net/errors.go
+++ b/pkg/loop/internal/net/errors.go
@@ -9,13 +9,14 @@ import (
 )
 
 type ErrConnAccept struct {
-	ID   uint32
-	Name string
-	Err  error
+	Broker string
+	ID     uint32
+	Name   string
+	Err    error
 }
 
 func (e ErrConnAccept) Error() string {
-	return fmt.Sprintf("failed to accept %s server connection %d: %s", e.Name, e.ID, e.Err)
+	return fmt.Sprintf("broker %s failed to accept %s server connection %d: %s", e.Broker, e.Name, e.ID, e.Err)
 }
 
 func (e ErrConnAccept) Unwrap() error {


### PR DESCRIPTION
Include a broker identifier to distinguish between difference instances and elevate log level for terminal errors that trigger refresh.