### PR TITLE
Adds `context` to `HeaderProvider.Headers(ctx)`

### DIFF
--- a/pkg/chipingress/auth.go
+++ b/pkg/chipingress/auth.go
@@ -10,6 +10,10 @@ import (
 var _ credentials.PerRPCCredentials = basicAuthCredentials{}
 var _ credentials.PerRPCCredentials = tokenAuthCredentials{}
 
+type HeaderProvider interface {
+	Headers(ctx context.Context) map[string]string
+}
+
 // Basic-Auth authentication for Chip Ingress
 type basicAuthCredentials struct {
 	authHeader map[string]string
@@ -42,11 +46,11 @@ type tokenAuthCredentials struct {
 }
 
 // implement PerRPCCredentials interface
-func (c tokenAuthCredentials) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+func (c tokenAuthCredentials) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
 	if c.authTokenProvider == nil {
 		return nil, nil
 	}
-	return c.authTokenProvider.GetHeaders(), nil
+	return c.authTokenProvider.Headers(ctx), nil
 }
 
 func (c tokenAuthCredentials) RequireTransportSecurity() bool {

--- a/pkg/chipingress/auth_test.go
+++ b/pkg/chipingress/auth_test.go
@@ -49,13 +49,11 @@ func TestBasicAuth(t *testing.T) {
 	})
 }
 
-var authHeaderKey = "X-Auth-Token"
-
 type testHeaderProvider struct {
 	headers map[string]string
 }
 
-func (p *testHeaderProvider) GetHeaders() map[string]string {
+func (p *testHeaderProvider) Headers(ctx context.Context) map[string]string {
 	return p.headers
 }
 

--- a/pkg/chipingress/client_test.go
+++ b/pkg/chipingress/client_test.go
@@ -584,7 +584,7 @@ type mockHeaderProvider struct {
 	headers map[string]string
 }
 
-func (m *mockHeaderProvider) GetHeaders() map[string]string {
+func (m *mockHeaderProvider) Headers(ctx context.Context) map[string]string {
 	return m.headers
 }
 


### PR DESCRIPTION
- Required step to implement rotating header provider that uses `Keystore.Sign`
- rename `GetHeaders` -> `Headers` less stuttering
