### PR TITLE
Updates `HeaderProvider` interface to also return error

### DIFF
--- a/pkg/chipingress/auth.go
+++ b/pkg/chipingress/auth.go
@@ -11,7 +11,7 @@ var _ credentials.PerRPCCredentials = basicAuthCredentials{}
 var _ credentials.PerRPCCredentials = tokenAuthCredentials{}
 
 type HeaderProvider interface {
-	Headers(ctx context.Context) map[string]string
+	Headers(ctx context.Context) (map[string]string, error)
 }
 
 // Basic-Auth authentication for Chip Ingress
@@ -50,7 +50,7 @@ func (c tokenAuthCredentials) GetRequestMetadata(ctx context.Context, _ ...strin
 	if c.authTokenProvider == nil {
 		return nil, nil
 	}
-	return c.authTokenProvider.Headers(ctx), nil
+	return c.authTokenProvider.Headers(ctx)
 }
 
 func (c tokenAuthCredentials) RequireTransportSecurity() bool {

--- a/pkg/chipingress/auth_test.go
+++ b/pkg/chipingress/auth_test.go
@@ -53,8 +53,8 @@ type testHeaderProvider struct {
 	headers map[string]string
 }
 
-func (p *testHeaderProvider) Headers(ctx context.Context) map[string]string {
-	return p.headers
+func (p *testHeaderProvider) Headers(ctx context.Context) (map[string]string, error) {
+	return p.headers, nil
 }
 
 func TestTokenAuth(t *testing.T) {

--- a/pkg/chipingress/client.go
+++ b/pkg/chipingress/client.go
@@ -167,7 +167,13 @@ func newHeaderInterceptor(provider HeaderProvider) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		// Add dynamic headers from provider if available
 		if provider != nil {
-			for k, v := range provider.Headers(ctx) {
+
+			headers, err := provider.Headers(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get headers: %w", err)
+			}
+
+			for k, v := range headers {
 				ctx = metadata.AppendToOutgoingContext(ctx, k, v)
 			}
 		}

--- a/pkg/chipingress/client_test.go
+++ b/pkg/chipingress/client_test.go
@@ -584,8 +584,8 @@ type mockHeaderProvider struct {
 	headers map[string]string
 }
 
-func (m *mockHeaderProvider) Headers(ctx context.Context) map[string]string {
-	return m.headers
+func (m *mockHeaderProvider) Headers(ctx context.Context) (map[string]string, error) {
+	return m.headers, nil
 }
 
 func TestWithTLS(t *testing.T) {


### PR DESCRIPTION
needed for additional implementations
