### PR TITLE
Add notice for using StandardCapabilityAccount

### DIFF
--- a/pkg/types/core/keystore.go
+++ b/pkg/types/core/keystore.go
@@ -78,6 +78,9 @@ func (s *Ed25519Signer) Sign(r io.Reader, digest []byte, opts crypto.SignerOpts)
 	return s.signFn(ctx, s.account, digest)
 }
 
+// Notice: when developing a capability that uses the StandardCapabilityAccount signer,
+// prefix your signing data with a unique string using the `MakePeerIDSignatureDomainSeparatedPayload` helper function.
+// Link: https://github.com/smartcontractkit/libocr/blob/88bb5d99bf3f9f215a8926e8af972de0cdd3802e/ragep2p/peeridhelper/domain_separation.go#L25
 var P2PAccountKey = "P2P_SIGNER"
 var StandardCapabilityAccount = "STANDARD_CAPABILITY_ACCOUNT"
 


### PR DESCRIPTION
## Summary

Adds a notice above the `StandardCapabilityAccount` constant in `pkg/types/core/keystore.go` directing capability authors to domain-separate their signing payloads using `MakePeerIDSignatureDomainSeparatedPayload`.

## Why

Capabilities using the `StandardCapabilityAccount` signer must prefix their signing data with a unique domain-separation string, otherwise signatures from different capabilities could be replayed against each other. The comment points authors at the libocr helper that does this correctly.
