### PR TITLE
add store flag to cache settings struct

### DIFF
--- a/pkg/types/gateway/action.go
+++ b/pkg/types/gateway/action.go
@@ -65,10 +65,6 @@ func (req OutboundHTTPRequest) Hash() string {
 	}
 
 	s.Write([]byte(strconv.FormatUint(uint64(req.MaxResponseBytes), 10)))
-	s.Write(sep)
-	s.Write([]byte(strconv.FormatInt(int64(req.CacheSettings.MaxAgeMs), 10)))
-	s.Write(sep)
-	s.Write([]byte(strconv.FormatBool(req.CacheSettings.Store)))
 
 	return hex.EncodeToString(s.Sum(nil))
 }

--- a/pkg/types/gateway/action.go
+++ b/pkg/types/gateway/action.go
@@ -15,8 +15,10 @@ const (
 
 // CacheSettings defines cache control options for outbound HTTP requests.
 type CacheSettings struct {
-	ReadFromCache bool  `json:"readFromCache,omitempty"` // If true, attempt to read a cached response for the request
-	MaxAgeMs      int32 `json:"maxAgeMs,omitempty"`      // Maximum age of a cached response in milliseconds.
+	MaxAgeMs int32 `json:"maxAgeMs,omitempty"` // Maximum age of a cached response in milliseconds.
+	Store    bool  `json:"store,omitempty"`    // If true, cache the response.
+	// Deprecated: positive MaxAgeMs implies ReadFromCache is true
+	ReadFromCache bool `json:"readFromCache,omitempty"` // If true, attempt to read a cached response for the request
 }
 
 // OutboundHTTPRequest represents an HTTP request to be sent from workflow node to the gateway.


### PR DESCRIPTION
- deperecate `ReadFromCache` flag and introduce `cache` flag to mirror latest changes in chainlink-protos ([code](https://github.com/smartcontractkit/chainlink-protos/blob/main/cre/capabilities/networking/http/v1alpha/client.proto))
- extend hashing to include workflow owner and cache settings