### PR TITLE
pkg/loop: wait from chain family

### DIFF
--- a/pkg/loop/internal/goplugin/plugin_service.go
+++ b/pkg/loop/internal/goplugin/plugin_service.go
@@ -257,7 +257,17 @@ func (s *PluginService[P, S]) WaitCtx(ctx context.Context) error {
 	case <-s.serviceCh:
 		return nil
 	case <-s.stopCh:
-		return fmt.Errorf("service was stoped while waiting: %w", context.Canceled)
+		return fmt.Errorf("service was stopped while waiting: %w", context.Canceled)
+	}
+}
+
+// Wait waits for the service to start up until it receives the stop signal.
+func (s *PluginService[P, S]) Wait() error {
+	select {
+	case <-s.serviceCh:
+		return nil
+	case <-s.stopCh:
+		return fmt.Errorf("service was stopped while waiting: %w", context.Canceled)
 	}
 }
 

--- a/pkg/loop/relayer_service.go
+++ b/pkg/loop/relayer_service.go
@@ -43,10 +43,16 @@ func NewRelayerService(lggr logger.Logger, grpcOpts GRPCOpts, cmd func() *exec.C
 }
 
 func (r *RelayerService) EVM() (types.EVMService, error) {
+	if err := r.Wait(); err != nil {
+		return nil, err
+	}
 	return r.Service.EVM()
 }
 
 func (r *RelayerService) TON() (types.TONService, error) {
+	if err := r.Wait(); err != nil {
+		return nil, err
+	}
 	return r.Service.TON()
 }
 
@@ -107,6 +113,9 @@ func (r *RelayerService) GetChainStatus(ctx context.Context) (types.ChainStatus,
 }
 
 func (r *RelayerService) GetChainInfo(ctx context.Context) (types.ChainInfo, error) {
+	if err := r.WaitCtx(ctx); err != nil {
+		return types.ChainInfo{}, err
+	}
 	return r.Service.GetChainInfo(ctx)
 }
 


### PR DESCRIPTION
The `Service` field is initialized async so access must be gated by a call to `Wait`.