### PR TITLE
[CRE-1787] descriptive error message when wasm instance runs out of memory

### DIFF
--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"math"
 	"math/rand"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -568,6 +569,18 @@ func runWasm[I, O proto.Message](
 	wasi.InheritStdout()
 	defer wasi.Close()
 
+	// Capture WASM stderr to detect "fatal error: out of memory". The Go runtime writes
+	// this literal string to stderr before exit(2), regardless of debug symbols.
+	var stderrCapturePath string
+	if f, tempErr := os.CreateTemp("", "wasm-stderr-*"); tempErr == nil {
+		stderrCapturePath = f.Name()
+		f.Close()
+		defer os.Remove(stderrCapturePath)
+		if setErr := wasi.SetStderrFile(stderrCapturePath); setErr != nil {
+			stderrCapturePath = ""
+		}
+	}
+
 	wasi.SetArgv([]string{"wasi", reqstr})
 
 	store.SetWasi(wasi)
@@ -649,6 +662,17 @@ func runWasm[I, O proto.Message](
 		return o, fmt.Errorf("invariant violation: host errored during sendResponse")
 	}
 
+	// Exit status 2 is produced by the Go WASM runtime on any fatal error (runtime.throw or
+	// runtime.fatalpanic), including unrecovered panics and out-of-memory.
+	// The Go runtime writes its diagnostic to WASM stderr, which we capture to tell them apart.
+	if containsCode(err, 2) {
+		memLimitMBs, limErr := m.cfg.MemoryLimiter.Limit(ctx)
+		if limErr == nil && isOOMStderr(stderrCapturePath) {
+			return o, fmt.Errorf("WASM module ran out of memory (limit is %d MB): %w", memLimitMBs/config.MByte, err)
+		}
+		return o, fmt.Errorf("WASM module crashed with a Go runtime fatal error: %w", err)
+	}
+
 	// If an error has occurred and the deadline has been reached or exceeded, return a deadline exceeded error.
 	// Note - there is no other reliable signal on the error that can be used to infer it is due to epoch deadline
 	// being reached, so if an error is returned after the deadline it is assumed it is due to that and return
@@ -666,6 +690,21 @@ func containsCode(err error, code int) bool {
 		return false
 	}
 	return strings.Contains(err.Error(), fmt.Sprintf("exit status %d", code))
+}
+
+// isOOMStderr reports whether the Go runtime fatal error message captured from WASM stderr
+// indicates an out-of-memory failure. The Go runtime always writes "fatal error: out of memory"
+// to stderr before calling exit(2). This string is a literal in the Go runtime and does not
+// depend on whether the binary was built with or without debug symbols.
+func isOOMStderr(path string) bool {
+	if path == "" {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return false
+	}
+	return bytes.Contains(data, []byte("out of memory"))
 }
 
 // createSendResponseFn injects the dependency required by a WASM guest to

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -571,6 +571,10 @@ func runWasm[I, O proto.Message](
 
 	// Capture WASM stderr to detect "fatal error: out of memory". The Go runtime writes
 	// this literal string to stderr before exit(2), regardless of debug symbols.
+	// A workflow can write to stderr in a loop and grow this file beyond WASMMemoryLimit;
+	// the file is deleted by defer os.Remove as soon as runWasm returns (bounded by Timeout).
+	// We only read the tail of the file because the Go runtime fatal message is always
+	// written last, right before exit(2).
 	var stderrCapturePath string
 	if f, tempErr := os.CreateTemp("", "wasm-stderr-*"); tempErr == nil {
 		stderrCapturePath = f.Name()
@@ -696,11 +700,28 @@ func containsCode(err error, code int) bool {
 // indicates an out-of-memory failure. The Go runtime always writes "fatal error: out of memory"
 // to stderr before calling exit(2). This string is a literal in the Go runtime and does not
 // depend on whether the binary was built with or without debug symbols.
+//
+// "fatal error: out of memory" is the first output the Go runtime writes; a goroutine dump
+// follows. We therefore read from the beginning of the file. A workflow that writes > 1 MB
+// to stderr before OOM will fall back to the generic "fatal error" message, which is still
+// accurate but less specific.
+//
+// Note: the write side is not bounded by this function. A workflow writing to stderr in a loop
+// can grow the file during execution. The file is deleted by defer os.Remove when runWasm
+// returns, so disk exposure is bounded by the execution timeout.
+const stderrReadLimit = 1 * 1024 * 1024 // 1 MB
+
 func isOOMStderr(path string) bool {
 	if path == "" {
 		return false
 	}
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, stderrReadLimit))
 	if err != nil || len(data) == 0 {
 		return false
 	}

--- a/pkg/workflows/wasm/host/wasm_test.go
+++ b/pkg/workflows/wasm/host/wasm_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	wasmpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/pb"
+	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	valuespb "github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
 )
 
@@ -909,20 +910,51 @@ func TestModule_Errors(t *testing.T) {
 }
 
 func TestModule_Sandbox_Memory(t *testing.T) {
-	ctx := t.Context()
+	t.Parallel()
+
 	binary := createTestBinary(oomBinaryCmd, oomBinaryLocation, true, t)
 
-	m, err := NewModule(ctx, &ModuleConfig{IsUncompressed: true, Logger: logger.Test(t)}, binary)
-	require.NoError(t, err)
+	t.Run("Run (legacy DAG) path returns descriptive OOM error", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		m, err := NewModule(ctx, &ModuleConfig{IsUncompressed: true, Logger: logger.Test(t)}, binary)
+		require.NoError(t, err)
 
-	m.Start()
+		m.Start()
+		defer m.Close()
 
-	req := &wasmpb.Request{
-		Id:      uuid.New().String(),
-		Message: &wasmpb.Request_SpecRequest{},
-	}
-	_, err = m.Run(ctx, req)
-	assert.ErrorContains(t, err, "exit status 2")
+		req := &wasmpb.Request{
+			Id:      uuid.New().String(),
+			Message: &wasmpb.Request_SpecRequest{},
+		}
+		_, err = m.Run(ctx, req)
+		assert.ErrorContains(t, err, "WASM module ran out of memory")
+		assert.ErrorContains(t, err, "exit status 2")
+	})
+
+	t.Run("Execute (v2) path returns descriptive OOM error", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		m, err := NewModule(ctx, &ModuleConfig{IsUncompressed: true, Logger: logger.Test(t)}, binary)
+		require.NoError(t, err)
+
+		// OOM binary has no CRE SDK v2 import; set v2ImportName directly so Execute does not
+		// reject it as a legacy DAG module before attempting to run.
+		m.v2ImportName = "test"
+		m.Start()
+		defer m.Close()
+
+		mockHelper := NewMockExecutionHelper(t)
+		mockHelper.EXPECT().GetWorkflowExecutionID().Return("test-exec-id")
+		mockHelper.EXPECT().GetNodeTime().Return(time.Now()).Maybe()
+
+		req := &sdkpb.ExecuteRequest{
+			Request: &sdkpb.ExecuteRequest_Trigger{},
+		}
+		_, err = m.Execute(ctx, req, mockHelper)
+		assert.ErrorContains(t, err, "WASM module ran out of memory")
+		assert.ErrorContains(t, err, "exit status 2")
+	})
 }
 
 func TestModule_CompressedBinarySize(t *testing.T) {


### PR DESCRIPTION
#### Description

While load-testing the consensus capability with a workflow that triggered ~7000 consensus calls, WASM instances were dying with exit status 2 but the wasmtime backtrace was completely opaque:
```
error while executing at wasm backtrace:
    0: 0xc4bc9 - <unknown>!<wasm function 1009>
    1: 0xcc27e - <unknown>!<wasm function 1062>
    ...
Caused by:
    Exited with i32 exit status 2
```

Production binaries are built with -ldflags="-w -s", stripping all DWARF debug symbols. Without them, wasmtime cannot resolve function names and the backtrace is useless. The only way to diagnose this was to redeploy with debug symbols (-ldflags="-w=false"), at which point the backtrace revealed the WASM instance was exhausting its 100 MB linear memory limit.

#### Fix
The Go runtime always writes a human-readable message to stderr before calling `exit(2)`, regardless of whether debug symbols are present. For OOM, that message is always:

`fatal error: out of memory`

This is a string literal compiled into the runtime itself (runtime/panic.go) — not a symbol name or DWARF annotation — and is present in fully stripped production binaries.

We redirect WASM fd 2 to a temp file via `wasi.SetStderrFile()` before the module runs, then read it only if `exit(2)` is caught. This lets us distinguish OOM from other fatal crashes and surface a descriptive error.

The temp file is created once per execution and cleaned up immediately after. It is only read on the fatal exit path — there is zero overhead on normal (successful) executions.

[CRE-1787](https://smartcontract-it.atlassian.net/browse/CRE-1787)


### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->


[CRE-1787]: https://smartcontract-it.atlassian.net/browse/CRE-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ