### PR TITLE
Add OrgId to confidential relay and workflow execution types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.89
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260326111235-8c09d1a4491f
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260409211238-5b99921cbc7c
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260205130626-db2a2aab956b
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10/go.mod h1:oiDa54M0FwxevWwyAX773lwdWvFYYlYHHQV1LQ5HpWY=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4 h1:GCzrxDWn3b7jFfEA+WiYRi8CKoegsayiDoJBCjYkneE=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4/go.mod h1:HHGeDUpAsPa0pmOx7wrByCitjQ0mbUxf0R9v+g67uCA=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260326111235-8c09d1a4491f h1:8p3vE987AHM3Of1JvnNJXNE/AtWtfNvJhk3TeeAG3Qw=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260326111235-8c09d1a4491f/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260409211238-5b99921cbc7c h1:7V+V3R//Z/g1kiz/to9MGT4KmcSTcbv2YSsRDD0RN5A=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260409211238-5b99921cbc7c/go.mod h1:Jqt53s27Tr0jDl8mdBXg1xhu6F8Fci8JOuq43tgHOM8=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
 github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260205130626-db2a2aab956b h1:36knUpKHHAZ86K4FGWXtx8i/EQftGdk2bqCoEu/Cha8=

--- a/pkg/capabilities/v2/actions/confidentialrelay/types.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/types.go
@@ -16,12 +16,13 @@ type SecretIdentifier struct {
 
 // SecretsRequestParams is the JSON-RPC params for "confidential.secrets.get".
 type SecretsRequestParams struct {
-	WorkflowID          string             `json:"workflow_id"`
-	Owner               string             `json:"owner"`                         // Ethereum address (hex, 0x-prefixed)
-	ExecutionID         string             `json:"execution_id"`                  // 32 bytes, hex-encoded
-	Secrets             []SecretIdentifier `json:"secrets"`
-	EnclavePublicKey    string             `json:"enclave_public_key"`
-	Attestation         string             `json:"attestation,omitempty"`
+	WorkflowID       string             `json:"workflow_id"`
+	Owner            string             `json:"owner"`              // Ethereum address (hex, 0x-prefixed)
+	ExecutionID      string             `json:"execution_id"`       // 32 bytes, hex-encoded
+	OrgID            string             `json:"org_id,omitempty"`   // Organization identifier for org-based secret ownership
+	Secrets          []SecretIdentifier `json:"secrets"`
+	EnclavePublicKey string             `json:"enclave_public_key"`
+	Attestation      string             `json:"attestation,omitempty"`
 }
 
 // SecretEntry is a single secret in the relay DON's response.

--- a/pkg/capabilities/v2/actions/confidentialworkflow/client.pb.go
+++ b/pkg/capabilities/v2/actions/confidentialworkflow/client.pb.go
@@ -93,7 +93,10 @@ type WorkflowExecution struct {
 	Owner string `protobuf:"bytes,5,opt,name=owner,proto3" json:"owner,omitempty"`
 	// execution_id is the unique execution identifier (64 hex chars, 32 bytes).
 	// Used by the enclave for runtime secret fetching from VaultDON.
-	ExecutionId   string `protobuf:"bytes,6,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	ExecutionId string `protobuf:"bytes,6,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	// org_id is the organization identifier for the workflow owner.
+	// Used by the enclave when fetching secrets from VaultDON with org-based ownership.
+	OrgId         string `protobuf:"bytes,7,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -166,6 +169,13 @@ func (x *WorkflowExecution) GetOwner() string {
 func (x *WorkflowExecution) GetExecutionId() string {
 	if x != nil {
 		return x.ExecutionId
+	}
+	return ""
+}
+
+func (x *WorkflowExecution) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
 	}
 	return ""
 }
@@ -279,7 +289,7 @@ const file_capabilities_compute_confidentialworkflow_v1alpha_client_proto_rawDes
 	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
 	"\tnamespace\x18\x02 \x01(\tH\x00R\tnamespace\x88\x01\x01B\f\n" +
 	"\n" +
-	"_namespace\"\xd6\x01\n" +
+	"_namespace\"\xed\x01\n" +
 	"\x11WorkflowExecution\x12\x1f\n" +
 	"\vworkflow_id\x18\x01 \x01(\tR\n" +
 	"workflowId\x12\x1d\n" +
@@ -289,7 +299,8 @@ const file_capabilities_compute_confidentialworkflow_v1alpha_client_proto_rawDes
 	"binaryHash\x12'\n" +
 	"\x0fexecute_request\x18\x04 \x01(\fR\x0eexecuteRequest\x12\x14\n" +
 	"\x05owner\x18\x05 \x01(\tR\x05owner\x12!\n" +
-	"\fexecution_id\x18\x06 \x01(\tR\vexecutionId\"\xf2\x01\n" +
+	"\fexecution_id\x18\x06 \x01(\tR\vexecutionId\x12\x15\n" +
+	"\x06org_id\x18\a \x01(\tR\x05orgId\"\xf2\x01\n" +
 	"\x1bConfidentialWorkflowRequest\x12o\n" +
 	"\x11vault_don_secrets\x18\x01 \x03(\v2C.capabilities.compute.confidentialworkflow.v1alpha.SecretIdentifierR\x0fvaultDonSecrets\x12b\n" +
 	"\texecution\x18\x02 \x01(\v2D.capabilities.compute.confidentialworkflow.v1alpha.WorkflowExecutionR\texecution\"I\n" +


### PR DESCRIPTION
## Summary
- Bumps chainlink-protos to `cre-sdk/v1alpha.20` (adds `org_id` field to `WorkflowExecution` proto)
- Regenerates `confidentialworkflow` codegen (`client.pb.go`)
- Adds `OrgID` to `confidentialrelay.SecretsRequestParams`

The enclave needs org identity to forward to VaultDON when fetching secrets via the confidential relay path, matching the existing org-based ownership pattern in executor.go.

Waterfall: chainlink-protos#338 (merged) -> this -> chainlink (cw-4) + CC (PR 279)