### PR TITLE
Parse raw bytes instead of hex over capReg grpc wire for transmitter address

### DIFF
--- a/pkg/loop/internal/core/services/capability/capabilities_registry.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_registry.go
@@ -2,6 +2,7 @@ package capability
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -511,7 +512,12 @@ func (c *capabilitiesRegistryServer) ConfigForCapability(ctx context.Context, re
 			}
 			transmitters := make([][]byte, len(cfg.Transmitters))
 			for i, t := range cfg.Transmitters {
-				transmitters[i] = []byte(t)
+				decoded, hexErr := hex.DecodeString(string(t))
+				if hexErr == nil {
+					transmitters[i] = decoded
+				} else {
+					transmitters[i] = []byte(t)
+				}
 			}
 			ccp.Ocr3Configs[key] = &capabilitiespb.OCR3Config{
 				ConfigCount:           cfg.ConfigCount,

--- a/pkg/loop/internal/core/services/capability/capabilities_registry.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_registry.go
@@ -2,7 +2,6 @@ package capability
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -245,7 +244,7 @@ func decodeOcr3Config(pbCfg *capabilitiespb.OCR3Config) ocrtypes.ContractConfig 
 	}
 	transmitters := make([]ocrtypes.Account, len(pbCfg.Transmitters))
 	for i, t := range pbCfg.Transmitters {
-		transmitters[i] = ocrtypes.Account(hex.EncodeToString(t))
+		transmitters[i] = ocrtypes.Account(t)
 	}
 	return ocrtypes.ContractConfig{
 		ConfigCount:           pbCfg.ConfigCount,
@@ -512,10 +511,7 @@ func (c *capabilitiesRegistryServer) ConfigForCapability(ctx context.Context, re
 			}
 			transmitters := make([][]byte, len(cfg.Transmitters))
 			for i, t := range cfg.Transmitters {
-				transmitters[i], err = hex.DecodeString(string(t))
-				if err != nil {
-					return nil, fmt.Errorf("failed to decode transmitter: %w", err)
-				}
+				transmitters[i] = []byte(t)
 			}
 			ccp.Ocr3Configs[key] = &capabilitiespb.OCR3Config{
 				ConfigCount:           cfg.ConfigCount,


### PR DESCRIPTION
- Aptos capability loop plugin calls ConfigForCapability on capability registry server
- When converting the ocr3 config for the capability to proto, the server cannot [hexDecode](https://github.com/smartcontractkit/chainlink-common/blob/a931c3f2f1624245c75d465889588c399ecefcc3/pkg/loop/internal/core/services/capability/capabilities_registry.go#L515) the transmitter address
- Hence we get `"error":"failed to get capability config: rpc error: code = Unknown desc = failed to decode transmitter: encoding/hex: invalid byte: U+0093"`

This is the flow

Pushing on chain:
   - Push ocr3 config for any capability (does not matter aptos) [here](https://github.com/smartcontractkit/chainlink/blob/0ff1113f173aec2f7782ee2b47aad2e93f0a9c14/deployment/cre/capabilities_registry/v2/changeset/add_capabilities.go#L125)
     - calls [ComputeOCR3Config](https://github.com/smartcontractkit/chainlink/blob/0ff1113f173aec2f7782ee2b47aad2e93f0a9c14/deployment/cre/capabilities_registry/v2/changeset/configure_capabilities_registry.go#L284)
     - Which ends up creating `OCR2OracleConfig` with `Transmitters as []common.Address`
     - It then calls `OCR2OracleConfigToMap` to push this data to chain which stores transmitter address as [base64](https://github.com/smartcontractkit/chainlink/blob/0ff1113f173aec2f7782ee2b47aad2e93f0a9c14/deployment/cre/ocr3/registry_config.go#L146) string
     - protojson interprets base64 strings as raw bytes, on-chain proto stores the raw 20-byte EVM address
 

Reading on chain:
- LocalRegistry.Unmarshal does ocrtypes.Account(t) where t is those raw 20 bytes → the Account string contains raw binary. So when the gRPC server sees the Account, it contains raw binary bytes (like \xab\xcd\x93...). It naturally cannot hexDecode that