### PR TITLE
fix: eliminate data race in SleeperTask context lifecycle

### DIFF
--- a/pkg/utils/sleeper_task.go
+++ b/pkg/utils/sleeper_task.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
@@ -110,8 +111,7 @@ func (s *SleeperTask) WorkDone() <-chan struct{} {
 func (s *SleeperTask) workerLoop() {
 	defer close(s.chDone)
 
-	ctx, cancel := s.chStop.NewCtx()
-	defer cancel()
+	ctx := &stopChanCtx{ch: s.chStop}
 
 	for {
 		select {
@@ -121,6 +121,25 @@ func (s *SleeperTask) workerLoop() {
 		case <-s.chStop:
 			return
 		}
+	}
+}
+
+// stopChanCtx implements [context.Context] backed directly by a stop channel.
+// Unlike [services.StopChan.NewCtx], this does not spawn a goroutine to call
+// cancel(), avoiding a data race between context cancellation and concurrent
+// reflect-based reads (e.g. testify mock argument formatting).
+type stopChanCtx struct{ ch <-chan struct{} }
+
+func (c *stopChanCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *stopChanCtx) Done() <-chan struct{}        { return c.ch }
+func (c *stopChanCtx) Value(any) any                { return nil }
+
+func (c *stopChanCtx) Err() error {
+	select {
+	case <-c.ch:
+		return context.Canceled
+	default:
+		return nil
 	}
 }
 

--- a/pkg/utils/sleeper_task_test.go
+++ b/pkg/utils/sleeper_task_test.go
@@ -1,6 +1,9 @@
 package utils_test
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -70,6 +73,43 @@ func TestSleeperTask_WakeupPerformsWork(t *testing.T) {
 	}
 
 	require.NoError(t, sleeper.Stop())
+}
+
+// reflectWorker simulates the race scenario: Work() spawns goroutines that
+// read the context via fmt.Sprintf (like testify's mock.callString), while
+// Stop() concurrently triggers context cancellation.
+type reflectWorker struct {
+	wg sync.WaitGroup
+}
+
+func (w *reflectWorker) Name() string { return "ReflectWorker" }
+
+func (w *reflectWorker) Work(ctx context.Context) {
+	w.wg.Add(10)
+	for range 10 {
+		go func() {
+			defer w.wg.Done()
+			// Simulate testify's callString: fmt.Sprintf("%#v", ctx) reads context
+			// internals via reflect. With the old NewCtx()/CtxCancel pattern, cancel()
+			// fired concurrently, writing to context internals → DATA RACE.
+			_ = fmt.Sprintf("%#v", ctx)
+		}()
+	}
+	w.wg.Wait()
+}
+
+func TestSleeperTask_NoConcurrentContextRace(t *testing.T) {
+	t.Parallel()
+
+	// Run many iterations to increase chance of triggering a race.
+	for range 50 {
+		w := &reflectWorker{}
+		sleeper := utils.NewSleeperTaskCtx(w)
+		sleeper.WakeUp()
+		// Stop concurrently with Work — this closes chStop, which previously
+		// fired cancel() via a CtxCancel goroutine, racing with reflect reads.
+		require.NoError(t, sleeper.Stop())
+	}
 }
 
 type controllableWorker struct {


### PR DESCRIPTION
## Summary

Defense-in-depth against testify/mock's unsynchronized reflect reads of context arguments. Replaces `SleeperTask`'s context implementation with a read-only `stopChanCtx` that has no mutable internal state.

## Background

testify's mock library has a fundamentally broken code path: when a mock method is called without a matching expectation, `callString()` formats all arguments via `fmt.Sprintf("%#v", args...)`, which walks them with `reflect`. This is completely unsynchronized — any concurrent mutation of an argument (like `context.cancel()` writing to `cancelCtx` internals) causes a data race. An upstream fix was attempted but rejected.

## What This Changes

`SleeperTask.workerLoop()` previously created its context via `StopChan.NewCtx()`, which internally calls `context.WithCancel()` + spawns a detached goroutine that calls `cancel()` when the stop channel closes. That `cancel()` writes to `cancelCtx` internal fields (`sync/atomic.AddInt32`, mutex state, etc.) — racing with any concurrent `fmt.Sprintf("%#v", ctx)` from testify's error path.

The new `stopChanCtx` is a read-only `context.Context` implementation backed directly by the stop channel:

- `Done()` returns the stop channel — closing it signals cancellation
- `Err()` checks if the channel is closed
- No `cancel()` function, no detached goroutine, no mutable internal state
- Child contexts (`context.WithCancel`, `context.WithTimeout`) propagate correctly via Go's standard `Done()` mechanism

Since there's nothing to mutate, testify can `fmt.Sprintf("%#v")` this context all day without racing.

## Test Evidence

`TestSleeperTask_NoConcurrentContextRace` reproduces the exact scenario: `Work()` goroutines read the context via `fmt.Sprintf` while `Stop()` concurrently closes the stop channel.

**Old code** (NewCtx/CtxCancel): `WARNING: DATA RACE` — `reflect.typedmemmove` vs `sync/atomic.AddInt32`
**New code** (stopChanCtx): 10 runs × all tests, zero races

## Related

- Root cause fix (shutdown ordering): https://github.com/smartcontractkit/chainlink-evm/pull/425
- Belt-and-suspenders (mock expectations): https://github.com/smartcontractkit/chainlink/pull/22042
- Failing CI: https://github.com/smartcontractkit/chainlink/actions/runs/24509952973/job/71638172320
