### PR TITLE
pkg/services: wrap context to prevent mockery race

### DIFF
--- a/pkg/services/stop.go
+++ b/pkg/services/stop.go
@@ -48,16 +48,3 @@ func (s StopRChan) Ctx(ctx context.Context) (context.Context, context.CancelFunc
 func (s StopRChan) CtxWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return s.CtxCancel(context.WithTimeout(context.Background(), timeout))
 }
-
-// CtxCancel cancels a [context.Context] when StopChan is closed.
-// Returns ctx and cancel unmodified, for convenience.
-func (s StopRChan) CtxCancel(ctx context.Context, cancel context.CancelFunc) (context.Context, context.CancelFunc) {
-	go func() {
-		select {
-		case <-s:
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
-	return ctx, cancel
-}

--- a/pkg/services/stop_!race.go
+++ b/pkg/services/stop_!race.go
@@ -1,0 +1,18 @@
+//go:build !race
+
+package services
+
+import "context"
+
+// CtxCancel cancels a [context.Context] when StopChan is closed.
+// Returns ctx and cancel unmodified, for convenience.
+func (s StopRChan) CtxCancel(ctx context.Context, cancel context.CancelFunc) (context.Context, context.CancelFunc) {
+	go func() {
+		select {
+		case <-s:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}

--- a/pkg/services/stop_race.go
+++ b/pkg/services/stop_race.go
@@ -1,0 +1,41 @@
+//go:build race
+
+package services
+
+import (
+	"context"
+	"time"
+)
+
+// CtxCancel cancels a [context.Context] when StopChan is closed.
+// Returns ctx and cancel unmodified, for convenience.
+func (s StopRChan) CtxCancel(ctx context.Context, cancel context.CancelFunc) (context.Context, context.CancelFunc) {
+	go func() {
+		select {
+		case <-s:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return &syncCtx{
+		deadline: ctx.Deadline,
+		done:     ctx.Done,
+		value:    ctx.Value,
+		err:      ctx.Err,
+	}, cancel
+}
+
+var _ context.Context = &syncCtx{}
+
+// syncCtx is a context.Context implementation that is safe to format via %#v, which mockery uses.
+type syncCtx struct {
+	deadline func() (time.Time, bool)
+	done     func() <-chan struct{}
+	value    func(any) any
+	err      func() error
+}
+
+func (s *syncCtx) Deadline() (time.Time, bool) { return s.deadline() }
+func (s *syncCtx) Done() <-chan struct{}       { return s.done() }
+func (s *syncCtx) Value(k any) any             { return s.value(k) }
+func (c *syncCtx) Err() error                  { return c.err() }


### PR DESCRIPTION
This is a reinterpretation of the fix proposed in https://github.com/smartcontractkit/chainlink-common/pull/1984, in lieu of https://github.com/stretchr/testify/pull/1689 or similar.

When the `-race` detector is active, we wrap contexts derived from `services.StopChan` so they don't flag the detector when printed by mockery via `%#v`.