### PR TITLE
codeowners: add privacy team to /pkg/teeattestation/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,3 +23,4 @@
 /pkg/values/ @smartcontractkit/keystone @smartcontractkit/capabilities-team
 /pkg/workflows/ @smartcontractkit/keystone
 /pkg/storage/ @smartcontractkit/dev-services
+/pkg/teeattestation/ @smartcontractkit/privacy @smartcontractkit/foundations


### PR DESCRIPTION
## Summary

- Adds `/pkg/teeattestation/ @smartcontractkit/privacy @smartcontractkit/foundations` so the privacy team co-owns the TEE attestation package alongside foundations.
- The TEE attestation logic was extracted from `confidential-compute` (deleting `enclave-client/attestation-validator/` in https://github.com/smartcontractkit/confidential-compute/pull/279) and now lives here. The privacy team owns the upstream code and needs codeowner status to review changes to attestation logic going forward.