### PR TITLE
loop/net: defer old relayer resource teardown until refresh succeeds

### DIFF
--- a/pkg/loop/internal/net/client.go
+++ b/pkg/loop/internal/net/client.go
@@ -122,17 +122,16 @@ func (c *clientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, metho
 // refresh replaces c.cc with a new (different from orig) *grpc.ClientConn, and returns it as well.
 // It will block until a new connection is successfully dialed, or return nil if the context expires.
 func (c *clientConn) refresh(ctx context.Context, orig *grpc.ClientConn) (*grpc.ClientConn, error) {
+	var oldCC *grpc.ClientConn
+	var oldDeps Resources
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.cc != orig {
 		return c.cc, nil
 	}
-	if c.cc != nil {
-		if err := c.cc.Close(); err != nil {
-			c.Logger.Errorw("Client close failed", "err", err)
-		}
-		c.CloseAll(c.deps...)
-	}
+	oldCC = c.cc
+	oldDeps = c.deps
 
 	try := func() error {
 		if d, ok := ctx.Deadline(); ok {
@@ -144,17 +143,28 @@ func (c *clientConn) refresh(ctx context.Context, orig *grpc.ClientConn) (*grpc.
 			c.CloseAll(deps...)
 			return err
 		}
-		c.deps = deps
 
 		lggr := logger.With(c.Logger, "id", id)
 		lggr.Debug("Client dial")
-		c.cc, err = c.Dial(id)
+		cc, err := c.Dial(id)
 		if err != nil {
 			if ctx.Err() != nil {
 				lggr.Errorw("Client dial failed", "err", ErrConnDial{Name: c.name, ID: id, Err: err})
 			}
-			c.CloseAll(c.deps...)
+			c.CloseAll(deps...)
 			return err
+		}
+
+		c.deps = deps
+		c.cc = cc
+
+		if oldCC != nil {
+			if err := oldCC.Close(); err != nil {
+				c.Logger.Errorw("Client close failed", "err", err)
+			}
+			c.CloseAll(oldDeps...)
+			oldCC = nil
+			oldDeps = nil
 		}
 		return nil
 	}

--- a/pkg/loop/internal/net/client.go
+++ b/pkg/loop/internal/net/client.go
@@ -130,6 +130,9 @@ func (c *clientConn) refresh(ctx context.Context, orig *grpc.ClientConn) (*grpc.
 	if c.cc != orig {
 		return c.cc, nil
 	}
+	// Hold on to the currently published generation until the replacement has been fully
+	// created and dialed. This avoids tearing down live broker-backed sockets on a failed
+	// refresh attempt.
 	oldCC = c.cc
 	oldDeps = c.deps
 
@@ -159,6 +162,8 @@ func (c *clientConn) refresh(ctx context.Context, orig *grpc.ClientConn) (*grpc.
 		c.cc = cc
 
 		if oldCC != nil {
+			// Only retire the previous generation after the successor is published, so callers
+			// never observe a failed cutover with the old sockets already gone.
 			if err := oldCC.Close(); err != nil {
 				c.Logger.Errorw("Client close failed", "err", err)
 			}

--- a/pkg/loop/internal/net/client_test.go
+++ b/pkg/loop/internal/net/client_test.go
@@ -58,6 +58,7 @@ func TestWrappedErrorError(t *testing.T) {
 func TestClientConnRefresh_PreservesPublishedDepsUntilReplacementSucceeds(t *testing.T) {
 	t.Parallel()
 
+	// Start with one published generation and make refresh fail once before succeeding.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	oldConn := newBufconnClientConn(t)
@@ -72,9 +73,11 @@ func TestClientConnRefresh_PreservesPublishedDepsUntilReplacementSucceeds(t *tes
 		BrokerExt: &BrokerExt{Broker: testBroker{dial: func(id uint32, _ ...grpc.DialOption) (*grpc.ClientConn, error) {
 			switch id {
 			case 1:
+				// A failed replacement attempt must not have already torn down the published deps.
 				assert.Equal(t, int32(0), oldDepClosed.Load(), "published deps must remain live while a replacement attempt fails")
 				return nil, errors.New("boom")
 			case 2:
+				// The next attempt publishes the replacement generation.
 				return newConn, nil
 			default:
 				return nil, fmt.Errorf("unexpected dial id %d", id)
@@ -91,11 +94,13 @@ func TestClientConnRefresh_PreservesPublishedDepsUntilReplacementSucceeds(t *tes
 	client.newClient = func(context.Context) (uint32, Resources, error) {
 		switch dialAttempts.Add(1) {
 		case 1:
+			// First attempt allocates deps that should be cleaned up immediately on failure.
 			return 1, Resources{{
 				Closer: fnCloser(func() { failedAttemptDepClosed.Add(1) }),
 				Name:   "failed-attempt",
 			}}, nil
 		case 2:
+			// Second attempt allocates the deps that should remain published after cutover.
 			return 2, Resources{{
 				Closer: fnCloser(func() { newDepClosed.Add(1) }),
 				Name:   "new",

--- a/pkg/loop/internal/net/client_test.go
+++ b/pkg/loop/internal/net/client_test.go
@@ -1,14 +1,36 @@
 package net
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	stdnet "net"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
+
+type testBroker struct {
+	dial func(id uint32, opts ...grpc.DialOption) (*grpc.ClientConn, error)
+}
+
+func (b testBroker) Accept(uint32) (stdnet.Listener, error) {
+	return nil, errors.New("unused in test")
+}
+
+func (b testBroker) DialWithOptions(id uint32, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return b.dial(id, opts...)
+}
+
+func (b testBroker) NextId() uint32 { return 1 }
 
 func TestWrappedErrorError(t *testing.T) {
 	t.Parallel()
@@ -31,4 +53,92 @@ func TestWrappedErrorError(t *testing.T) {
 		wrapped := WrapRPCErr(fmt.Errorf("%w: %w", types.ErrInvalidType, errors.New("some other error")))
 		assert.True(t, errors.Is(wrapped, types.ErrInvalidType))
 	})
+}
+
+func TestClientConnRefresh_PreservesPublishedDepsUntilReplacementSucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	oldConn := newBufconnClientConn(t)
+	newConn := newBufconnClientConn(t)
+
+	var oldDepClosed atomic.Int32
+	var failedAttemptDepClosed atomic.Int32
+	var newDepClosed atomic.Int32
+	var dialAttempts atomic.Uint32
+
+	client := &clientConn{
+		BrokerExt: &BrokerExt{Broker: testBroker{dial: func(id uint32, _ ...grpc.DialOption) (*grpc.ClientConn, error) {
+			switch id {
+			case 1:
+				assert.Equal(t, int32(0), oldDepClosed.Load(), "published deps must remain live while a replacement attempt fails")
+				return nil, errors.New("boom")
+			case 2:
+				return newConn, nil
+			default:
+				return nil, fmt.Errorf("unexpected dial id %d", id)
+			}
+		}}, BrokerConfig: BrokerConfig{Logger: logger.Test(t)}},
+		name: "Relayer",
+		cc:   oldConn,
+		deps: Resources{{
+			Closer: fnCloser(func() { oldDepClosed.Add(1) }),
+			Name:   "old",
+		}},
+	}
+
+	client.newClient = func(context.Context) (uint32, Resources, error) {
+		switch dialAttempts.Add(1) {
+		case 1:
+			return 1, Resources{{
+				Closer: fnCloser(func() { failedAttemptDepClosed.Add(1) }),
+				Name:   "failed-attempt",
+			}}, nil
+		case 2:
+			return 2, Resources{{
+				Closer: fnCloser(func() { newDepClosed.Add(1) }),
+				Name:   "new",
+			}}, nil
+		default:
+			return 0, nil, errors.New("unexpected extra refresh attempt")
+		}
+	}
+
+	cc, err := client.refresh(ctx, oldConn)
+	require.NoError(t, err)
+	require.NotNil(t, cc)
+	assert.Equal(t, int32(1), failedAttemptDepClosed.Load(), "failed attempt deps should be cleaned up immediately")
+	assert.Equal(t, int32(1), oldDepClosed.Load(), "old deps should be closed only after the replacement is published")
+	assert.Equal(t, int32(0), newDepClosed.Load(), "replacement deps must remain live after cutover")
+	assert.Len(t, client.deps, 1)
+	assert.Equal(t, "new", client.deps[0].Name)
+	assert.Same(t, newConn, cc)
+	assert.Same(t, newConn, client.cc)
+	assert.Equal(t, uint32(2), dialAttempts.Load())
+}
+
+func newBufconnClientConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+
+	lis := bufconn.Listen(1024)
+	server := grpc.NewServer()
+	go func() {
+		_ = server.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	conn, err := grpc.DialContext(context.Background(), "bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (stdnet.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+	return conn
 }


### PR DESCRIPTION
## Summary

Fix relayer client refresh so a failed replacement attempt does not tear down the currently published broker-backed resources too early.

The issue was in `client.go:124`: `clientConn.refresh()` closed the active connection and its tracked deps before a replacement client had been successfully created and dialed. For relayer construction, those deps can include live broker-served resources such as keystore-related listeners. If the replacement attempt failed, the old generation was already torn down, which could leave callers with dead /tmp/plugin... sockets.

## Changes

- Updated `client.go:124` so refresh now:
    - keeps the current `cc` and `deps` alive while attempting the replacement
    - cleans up only failed-attempt deps immediately
    - publishes the new connection first
    - closes the previous generation only after successful cutover
- Added a focused regression in `client_test.go:58` that proves:
    - old published deps remain live across a failed refresh attempt
    - failed-attempt deps are cleaned up
    - old deps are closed only after the replacement is published