### PR TITLE
Doc: fix utils.WithJitter Deprecation notice

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -11,7 +11,10 @@ import (
 )
 
 // WithJitter adds +/- 10% to a duration.
-// Deprecated: use timeutil.WithJitter
+//
+// Deprecated: Use [timeutil.JitterPct(0.1).Apply(d)] instead.
+//
+//go:fix inline
 func WithJitter(d time.Duration) time.Duration { return timeutil.JitterPct(0.1).Apply(d) }
 
 // ContextFromChan creates a context that finishes when the provided channel

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,7 +12,7 @@ import (
 
 // WithJitter adds +/- 10% to a duration.
 //
-// Deprecated: Use [timeutil.JitterPct(0.1).Apply(d)] instead.
+// Deprecated: Use [timeutil.JitterPct] instead; for example, `timeutil.JitterPct(0.1).Apply(d)`.
 //
 //go:fix inline
 func WithJitter(d time.Duration) time.Duration { return timeutil.JitterPct(0.1).Apply(d) }


### PR DESCRIPTION
🥜 Update [utils.WithJitter](https://github.com/smartcontractkit/chainlink-common/blob/efb84d8ef0731cb18629ed65e64651a1d95a4166/pkg/utils/utils.go#L18)'s deprecation notice so that linter picks up it is deprecated, with quick autofix for replacing it with `timeutil.JitterPct`. See https://go.dev/wiki/Deprecated .

In a snippet like this:

```go
utils.WithJitter(duration)
```

go:fix replaces it with

```go
timeutil.JitterPct(0.1).Apply(duration)
```