### PR TITLE
feat(types): add GasPrice to TxMeta [PLEX-2887]

### DIFF
--- a/pkg/types/contract_writer.go
+++ b/pkg/types/contract_writer.go
@@ -42,6 +42,10 @@ type TxMeta struct {
 	// setting a gas limit for the transaction.  If it is set and the ContractWriter implementation does not support setting
 	// this value per transaction it will return ErrSettingTransactionGasLimitNotSupported
 	GasLimit *big.Int
+	// An optional gas unit price for the transaction. If not set the ContractWriter implementation will be responsible for
+	// determining the gas price (e.g. via simulation, fee estimator, or node-level config). When set, the implementation
+	// should honor the caller-provided value instead of overriding it with its own estimate.
+	GasPrice *big.Int
 }
 
 // TransactionStatus are the status we expect every TXM to support and that can be returned by StatusForUUID.


### PR DESCRIPTION
## Summary
- Adds `GasPrice *big.Int` to `TxMeta` so callers can supply a per-transaction gas unit price that the underlying ContractWriter implementation should honor instead of overriding via its own estimate.

## Why
Audit finding [PLEX-2887](https://smartcontract-it.atlassian.net/browse/PLEX-2887): Aptos request callers populate `GasConfig.GasUnitPrice` (e.g. capabilities `forwarder_client.go`, system tests with operator-configured gas price), but the value is silently dropped because there is no `TxMeta` field to carry it. This adds the field; the chainlink-aptos PR consumes it.

The pattern mirrors Solana's per-tx `ComputeConfig.ComputeMaxPrice` already plumbed via `SubmitTransactionRequest`. EVM does not expose a per-tx caller override (operator-only via TOML), so EVM is unaffected.

## Test plan
- [x] \`go vet ./pkg/types/...\` clean
- [x] \`go test ./pkg/types/\` passes
- [ ] Consumed by chainlink-aptos PR (linked below)

Stacked: chainlink-aptos consumer PR follows.

[PLEX-2887]: https://smartcontract-it.atlassian.net/browse/PLEX-2887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ