### PR TITLE
add signed confidential relay response types

### DIFF
--- a/pkg/capabilities/v2/actions/confidentialrelay/types.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/types.go
@@ -1,11 +1,24 @@
 package confidentialrelay
 
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"hash"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/teeattestation"
+	"github.com/smartcontractkit/libocr/ragep2p/peeridhelper"
+)
+
 const (
 	MethodSecretsGet     = "confidential.secrets.get"
 	MethodCapabilityExec = "confidential.capability.execute"
 
 	DomainSecretsGet     = "ConfidentialSecretsGet"
 	DomainCapabilityExec = "ConfidentialCapabilityExecute"
+
+	// RelayResponseSignaturePrefix domain-separates signatures over relay
+	// response hashes from other ed25519 payloads in the system.
+	RelayResponseSignaturePrefix = "CONFIDENTIAL_RELAY_PAYLOAD_"
 )
 
 // SecretIdentifier identifies a secret by key and namespace.
@@ -17,9 +30,9 @@ type SecretIdentifier struct {
 // SecretsRequestParams is the JSON-RPC params for "confidential.secrets.get".
 type SecretsRequestParams struct {
 	WorkflowID       string             `json:"workflow_id"`
-	Owner            string             `json:"owner"`              // Ethereum address (hex, 0x-prefixed)
-	ExecutionID      string             `json:"execution_id"`       // 32 bytes, hex-encoded
-	OrgID            string             `json:"org_id,omitempty"`   // Organization identifier for org-based secret ownership
+	Owner            string             `json:"owner"`            // Ethereum address (hex, 0x-prefixed)
+	ExecutionID      string             `json:"execution_id"`     // 32 bytes, hex-encoded
+	OrgID            string             `json:"org_id,omitempty"` // Organization identifier for org-based secret ownership
 	Secrets          []SecretIdentifier `json:"secrets"`
 	EnclavePublicKey string             `json:"enclave_public_key"`
 	Attestation      string             `json:"attestation,omitempty"`
@@ -39,6 +52,31 @@ type SecretsResponseResult struct {
 	Secrets []SecretEntry `json:"secrets"`
 }
 
+// Hash computes the canonical hash of the cleaned request params and logical
+// relay response body. Attestation is intentionally excluded.
+func (r *SecretsResponseResult) Hash(params SecretsRequestParams) [32]byte {
+	h := sha256.New()
+	h.Write([]byte(teeattestation.DomainSeparator))
+	h.Write([]byte("\nSecretsResponseResult\n"))
+
+	writeSecretsRequestParams(h, params)
+
+	writeLengthPrefix(h, len(r.Secrets))
+	for _, secret := range r.Secrets {
+		writeSecretIdentifier(h, secret.ID)
+		writeString(h, secret.Ciphertext)
+
+		writeLengthPrefix(h, len(secret.EncryptedShares))
+		for _, share := range secret.EncryptedShares {
+			writeString(h, share)
+		}
+	}
+
+	var result [32]byte
+	h.Sum(result[:0])
+	return result
+}
+
 // CapabilityRequestParams is the JSON-RPC params for "confidential.capability.execute".
 type CapabilityRequestParams struct {
 	WorkflowID   string `json:"workflow_id"`
@@ -54,4 +92,90 @@ type CapabilityRequestParams struct {
 type CapabilityResponseResult struct {
 	Payload string `json:"payload,omitempty"`
 	Error   string `json:"error,omitempty"`
+}
+
+// Hash computes the canonical hash of the cleaned request params and logical
+// relay response body. Attestation is intentionally excluded.
+func (r *CapabilityResponseResult) Hash(params CapabilityRequestParams) [32]byte {
+	h := sha256.New()
+	h.Write([]byte(teeattestation.DomainSeparator))
+	h.Write([]byte("\nCapabilityResponseResult\n"))
+
+	writeCapabilityRequestParams(h, params)
+	writeString(h, r.Payload)
+	writeString(h, r.Error)
+
+	var result [32]byte
+	h.Sum(result[:0])
+	return result
+}
+
+// RelayResponseSignature is a single relay-DON node signature over a relay
+// response hash.
+type RelayResponseSignature struct {
+	Signer    []byte `json:"signer"`
+	Signature []byte `json:"signature"`
+}
+
+// SignedSecretsResponseResult wraps a logical secrets response with the relay
+// signatures that attest to it.
+type SignedSecretsResponseResult struct {
+	Result     SecretsResponseResult    `json:"result"`
+	Signatures []RelayResponseSignature `json:"signatures"`
+}
+
+// SignedCapabilityResponseResult wraps a logical capability response with the
+// relay signatures that attest to it.
+type SignedCapabilityResponseResult struct {
+	Result     CapabilityResponseResult `json:"result"`
+	Signatures []RelayResponseSignature `json:"signatures"`
+}
+
+// RelayResponseSignaturePayload prepares a relay response hash for signing with
+// the standard peerid domain-separated payload format.
+func RelayResponseSignaturePayload(responseHash [32]byte) []byte {
+	return peeridhelper.MakePeerIDSignatureDomainSeparatedPayload(RelayResponseSignaturePrefix, responseHash[:])
+}
+
+func writeSecretsRequestParams(h hash.Hash, params SecretsRequestParams) {
+	writeString(h, params.WorkflowID)
+	writeString(h, params.Owner)
+	writeString(h, params.ExecutionID)
+	writeString(h, params.OrgID)
+
+	writeLengthPrefix(h, len(params.Secrets))
+	for _, secret := range params.Secrets {
+		writeSecretIdentifier(h, secret)
+	}
+
+	writeString(h, params.EnclavePublicKey)
+}
+
+func writeCapabilityRequestParams(h hash.Hash, params CapabilityRequestParams) {
+	writeString(h, params.WorkflowID)
+	writeString(h, params.Owner)
+	writeString(h, params.ExecutionID)
+	writeString(h, params.ReferenceID)
+	writeString(h, params.CapabilityID)
+	writeString(h, params.Payload)
+}
+
+func writeSecretIdentifier(h hash.Hash, id SecretIdentifier) {
+	writeString(h, id.Key)
+	writeString(h, id.Namespace)
+}
+
+func writeString(h hash.Hash, s string) {
+	writeBytes(h, []byte(s))
+}
+
+func writeBytes(h hash.Hash, b []byte) {
+	writeLengthPrefix(h, len(b))
+	h.Write(b)
+}
+
+func writeLengthPrefix(h hash.Hash, length int) {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(length))
+	h.Write(buf[:])
 }

--- a/pkg/capabilities/v2/actions/confidentialrelay/types_test.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/types_test.go
@@ -1,0 +1,86 @@
+package confidentialrelay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/libocr/ragep2p/peeridhelper"
+)
+
+func TestSecretsResponseResultHash_IgnoresAttestationAndBindsRequestAndResponse(t *testing.T) {
+	params := SecretsRequestParams{
+		WorkflowID:       "wf-1",
+		Owner:            "0x1234",
+		ExecutionID:      "exec-1",
+		OrgID:            "org-1",
+		EnclavePublicKey: "pubkey-1",
+		Attestation:      "att-a",
+		Secrets: []SecretIdentifier{
+			{Key: "alpha", Namespace: "ns-a"},
+			{Key: "beta", Namespace: "ns-b"},
+		},
+	}
+	result := SecretsResponseResult{
+		Secrets: []SecretEntry{
+			{
+				ID:         SecretIdentifier{Key: "alpha", Namespace: "ns-a"},
+				Ciphertext: "cipher-a",
+				EncryptedShares: []string{
+					"share-a1",
+					"share-a2",
+				},
+			},
+		},
+	}
+
+	sameButDifferentAttestation := params
+	sameButDifferentAttestation.Attestation = "att-b"
+
+	require.Equal(t, result.Hash(params), result.Hash(sameButDifferentAttestation))
+
+	differentRequest := params
+	differentRequest.Owner = "0x9999"
+	require.NotEqual(t, result.Hash(params), result.Hash(differentRequest))
+
+	differentResponse := result
+	differentResponse.Secrets = append([]SecretEntry(nil), result.Secrets...)
+	differentResponse.Secrets[0].EncryptedShares = append([]string(nil), result.Secrets[0].EncryptedShares...)
+	differentResponse.Secrets[0].EncryptedShares[1] = "share-a3"
+	require.NotEqual(t, result.Hash(params), differentResponse.Hash(params))
+}
+
+func TestCapabilityResponseResultHash_IgnoresAttestationAndBindsRequestAndResponse(t *testing.T) {
+	params := CapabilityRequestParams{
+		WorkflowID:   "wf-1",
+		Owner:        "0x1234",
+		ExecutionID:  "exec-1",
+		ReferenceID:  "42",
+		CapabilityID: "write_ethereum-testnet-sepolia@1.0.0",
+		Payload:      "request-payload",
+		Attestation:  "att-a",
+	}
+	result := CapabilityResponseResult{
+		Payload: "response-payload",
+	}
+
+	sameButDifferentAttestation := params
+	sameButDifferentAttestation.Attestation = "att-b"
+	require.Equal(t, result.Hash(params), result.Hash(sameButDifferentAttestation))
+
+	differentRequest := params
+	differentRequest.ReferenceID = "43"
+	require.NotEqual(t, result.Hash(params), result.Hash(differentRequest))
+
+	differentResponse := result
+	differentResponse.Error = "boom"
+	require.NotEqual(t, result.Hash(params), differentResponse.Hash(params))
+}
+
+func TestRelayResponseSignaturePayload_UsesExpectedPrefix(t *testing.T) {
+	hash := [32]byte{1, 2, 3, 4}
+
+	expected := peeridhelper.MakePeerIDSignatureDomainSeparatedPayload(RelayResponseSignaturePrefix, hash[:])
+	require.Equal(t, expected, RelayResponseSignaturePayload(hash))
+	require.NotEqual(t, hash[:], RelayResponseSignaturePayload(hash))
+}


### PR DESCRIPTION
## What changed
This PR adds the shared step-1 protocol surface for relay response signatures in `confidentialrelay`.

It introduces:
- signed wrapper types for secrets and capability relay responses
- a shared relay response signature prefix and helper for domain-separated signing payloads
- canonical hash helpers on the logical response types that bind cleaned request params plus the logical response body
- focused tests covering request binding, response binding, attestation exclusion, and the signature payload helper

## Why
This is the first step in hardening the reverse confidential-relay path. The later `chainlink` and `confidential-compute` changes need a shared contract for:
- what exactly gets signed by relay DON nodes
- how that payload is hashed
- how the signed response is represented on the wire

The hash intentionally excludes request attestation so the relay response signature covers the logical request and logical response, not the transport attestation blob.

## Impact
This is a shared-types and hashing-only change. It does not yet change runtime behavior in `chainlink` or `confidential-compute`.

## Validation
- `go test ./pkg/capabilities/v2/actions/confidentialrelay`
