### PR TITLE
Revert "Clean up dropped resources in relayer construction (#1927)"

### DIFF
--- a/pkg/loop/internal/relayer/relayer.go
+++ b/pkg/loop/internal/relayer/relayer.go
@@ -61,7 +61,7 @@ func (p *PluginRelayerClient) NewRelayer(ctx context.Context, config string, key
 			pb.RegisterKeystoreServer(s, ks.NewServer(keystore))
 		})
 		if err != nil {
-			return 0, deps, fmt.Errorf("Failed to create relayer client: failed to serve keystore: %w", err)
+			return 0, nil, fmt.Errorf("Failed to create relayer client: failed to serve keystore: %w", err)
 		}
 		deps.Add(ksRes)
 
@@ -70,7 +70,7 @@ func (p *PluginRelayerClient) NewRelayer(ctx context.Context, config string, key
 			pb.RegisterKeystoreServer(s, ks.NewServer(csaKeystore))
 		})
 		if err != nil {
-			return 0, deps, fmt.Errorf("Failed to create relayer client: failed to serve CSA keystore: %w", err)
+			return 0, nil, fmt.Errorf("Failed to create relayer client: failed to serve CSA keystore: %w", err)
 		}
 		deps.Add(ksCSARes)
 
@@ -78,7 +78,7 @@ func (p *PluginRelayerClient) NewRelayer(ctx context.Context, config string, key
 			pb.RegisterCapabilitiesRegistryServer(s, capability.NewCapabilitiesRegistryServer(p.BrokerExt, capabilityRegistry))
 		})
 		if err != nil {
-			return 0, deps, fmt.Errorf("failed to serve new capability registry: %w", err)
+			return 0, nil, fmt.Errorf("failed to serve new capability registry: %w", err)
 		}
 		deps.Add(capabilityRegistryResource)
 
@@ -89,9 +89,9 @@ func (p *PluginRelayerClient) NewRelayer(ctx context.Context, config string, key
 			CapabilityRegistryID: capabilityRegistryID,
 		})
 		if err != nil {
-			return 0, deps, fmt.Errorf("Failed to create relayer client: failed request: %w", err)
+			return 0, nil, fmt.Errorf("Failed to create relayer client: failed request: %w", err)
 		}
-		return reply.RelayerID, deps, nil
+		return reply.RelayerID, nil, nil
 	})
 	return newRelayerClient(p.BrokerExt, cc), nil
 }
@@ -127,7 +127,7 @@ func (p *pluginRelayerServer) NewRelayer(ctx context.Context, request *pb.NewRel
 		p.CloseAll(ksRes)
 		return nil, net.ErrConnDial{Name: "CSAKeystore", ID: request.KeystoreCSAID, Err: err}
 	}
-	ksCSARes := net.Resource{Closer: ksCSAConn, Name: "CSAKeystore"}
+	ksCSARes := net.Resource{Closer: ksConn, Name: "CSAKeystore"}
 
 	capRegistryConn, err := p.Dial(request.CapabilityRegistryID)
 	if err != nil {
@@ -324,7 +324,7 @@ func (r *relayerClient) NewCCIPProvider(ctx context.Context, cargs types.CCIPPro
 				ccipocr3pb.RegisterExtraDataCodecBundleServer(s, ccipocr3loop.NewExtraDataCodecBundleServer(cargs.ExtraDataCodecBundle))
 			})
 			if err != nil {
-				return 0, deps, fmt.Errorf("failed to serve ExtraDataCodecBundle: %w", err)
+				return 0, nil, fmt.Errorf("failed to serve ExtraDataCodecBundle: %w", err)
 			}
 			deps.Add(edcRes)
 			extraDataCodecBundleID = edcID
@@ -344,7 +344,7 @@ func (r *relayerClient) NewCCIPProvider(ctx context.Context, cargs types.CCIPPro
 			},
 		})
 		if err != nil {
-			return 0, deps, err
+			return 0, nil, err
 		}
 		return reply.CcipProviderID, deps, nil
 	})


### PR DESCRIPTION
This reverts commit c8e0d77df4210cea915ed317ad835cf7fec8bd54.

This commit was reverted in `2.41.3-rc1` due to the keystore dropped socket connection
We need to make sure core `develop` branch stays in sync with the currently released CCIP version