### PR TITLE
pkg/loop/internal: cleanup resources; fail TestRelayerService if goroutines leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/grafana/pyroscope-go v1.2.8
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/hashicorp/go-hclog v1.6.3
-	github.com/hashicorp/go-plugin v1.7.0
+	github.com/hashicorp/go-plugin v1.8.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jackc/pgx/v5 v5.9.2
@@ -69,6 +69,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.49.0
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 h1:BpJ2o0OR5FV7vrkDYf
 github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026/go.mod h1:5Scbynm8dF1XAPwIwkGPqzkM/shndPm79Jd1003hTjE=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
-github.com/hashicorp/go-plugin v1.7.0 h1:YghfQH/0QmPNc/AZMTFE3ac8fipZyZECHdDPshfk+mA=
-github.com/hashicorp/go-plugin v1.7.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn0NMcihqOqb8=
+github.com/hashicorp/go-plugin v1.8.0 h1:ie8S6RRY8RvB2usYZv+AAZ/wBvx2AU5p5QeP5j/FORs=
+github.com/hashicorp/go-plugin v1.8.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn0NMcihqOqb8=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=

--- a/pkg/loop/internal/core/services/oraclefactory/client.go
+++ b/pkg/loop/internal/core/services/oraclefactory/client.go
@@ -28,7 +28,7 @@ type client struct {
 	serviceClient *goplugin.ServiceClient
 }
 
-func NewClient(log logger.Logger, b *net.BrokerExt, conn grpc.ClientConnInterface) *client {
+func NewClient(log logger.Logger, b *net.BrokerExt, conn net.ClientConnInterface) *client {
 	b = b.WithName("OracleFactoryClient")
 	return &client{
 		log:           log,

--- a/pkg/loop/internal/core/services/reportingplugin/ocr2/reporting.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr2/reporting.go
@@ -22,7 +22,7 @@ type ReportingPluginFactoryClient struct {
 	grpc pb.ReportingPluginFactoryClient
 }
 
-func NewReportingPluginFactoryClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *ReportingPluginFactoryClient {
+func NewReportingPluginFactoryClient(b *net.BrokerExt, cc net.ClientConnInterface) *ReportingPluginFactoryClient {
 	b = b.WithName("ReportingPluginProviderClient")
 	return &ReportingPluginFactoryClient{
 		BrokerExt:     b,

--- a/pkg/loop/internal/core/services/reportingplugin/ocr2/reporting_plugin_service.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr2/reporting_plugin_service.go
@@ -60,7 +60,7 @@ func (m *ReportingPluginServiceClient) NewReportingPluginFactory(
 			pb.RegisterPipelineRunnerServiceServer(s, pipeline.NewRunnerServer(pipelineRunner))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(pipelineRunnerRes)
 
@@ -68,7 +68,7 @@ func (m *ReportingPluginServiceClient) NewReportingPluginFactory(
 			pb.RegisterTelemetryServer(s, telemetry.NewTelemetryServer(telemetryService))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(telemetryRes)
 
@@ -76,7 +76,7 @@ func (m *ReportingPluginServiceClient) NewReportingPluginFactory(
 			pb.RegisterErrorLogServer(s, errorlog.NewServer(errorLog))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(errorLogRes)
 
@@ -85,14 +85,14 @@ func (m *ReportingPluginServiceClient) NewReportingPluginFactory(
 		})
 
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to serve new key value store: %w", err)
+			return 0, deps, fmt.Errorf("failed to serve new key value store: %w", err)
 		}
 
 		deps.Add(keyValueStoreRes)
 
 		relayerSetServer, relayerSetServerRes := relayerset.NewRelayerSetServer(m.Logger, relayerSet, m.BrokerExt)
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to create new relayer set: %w", err)
+			return 0, deps, fmt.Errorf("failed to create new relayer set: %w", err)
 		}
 
 		relayerSetID, relayerSetRes, err := m.ServeNew("RelayerSet", func(s *grpc.Server) {
@@ -100,7 +100,7 @@ func (m *ReportingPluginServiceClient) NewReportingPluginFactory(
 		})
 
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to serve new relayer set: %w", err)
+			return 0, deps, fmt.Errorf("failed to serve new relayer set: %w", err)
 		}
 
 		deps.Add(relayerSetRes)
@@ -122,9 +122,9 @@ func (m *ReportingPluginServiceClient) NewReportingPluginFactory(
 			RelayerSetID:     relayerSetID,
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
-		return reply.ID, nil, nil
+		return reply.ID, deps, nil
 	})
 	return NewReportingPluginFactoryClient(m.BrokerExt, cc), nil
 }

--- a/pkg/loop/internal/core/services/reportingplugin/ocr3/reporting.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr3/reporting.go
@@ -2,6 +2,8 @@ package ocr3
 
 import (
 	"context"
+	"errors"
+	"io"
 	"math"
 	"time"
 
@@ -24,7 +26,7 @@ type reportingPluginFactoryClient struct {
 	grpc ocr3.ReportingPluginFactoryClient
 }
 
-func NewReportingPluginFactoryClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *reportingPluginFactoryClient {
+func NewReportingPluginFactoryClient(b *net.BrokerExt, cc net.ClientConnInterface) *reportingPluginFactoryClient {
 	b = b.WithName("OCR3ReportingPluginProviderClient")
 	return &reportingPluginFactoryClient{b, goplugin.NewServiceClient(b, cc), ocr3.NewReportingPluginFactoryClient(cc)}
 }
@@ -126,6 +128,7 @@ var _ ocr3types.ReportingPlugin[[]byte] = (*reportingPluginClient)(nil)
 
 type reportingPluginClient struct {
 	*net.BrokerExt
+	cc   io.Closer // backing client connection
 	grpc ocr3.ReportingPluginClient
 }
 
@@ -221,11 +224,11 @@ func (o *reportingPluginClient) Close() error {
 	defer cancel()
 
 	_, err := o.grpc.Close(ctx, &emptypb.Empty{})
-	return err
+	return errors.Join(err, o.cc.Close())
 }
 
-func newReportingPluginClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *reportingPluginClient {
-	return &reportingPluginClient{b.WithName("OCR3ReportingPluginClient"), ocr3.NewReportingPluginClient(cc)}
+func newReportingPluginClient(b *net.BrokerExt, cc net.ClientConnInterface) *reportingPluginClient {
+	return &reportingPluginClient{b.WithName("OCR3ReportingPluginClient"), cc, ocr3.NewReportingPluginClient(cc)}
 }
 
 var _ ocr3.ReportingPluginServer = (*reportingPluginServer)(nil)

--- a/pkg/loop/internal/core/services/reportingplugin/ocr3/reporting_plugin_service.go
+++ b/pkg/loop/internal/core/services/reportingplugin/ocr3/reporting_plugin_service.go
@@ -60,7 +60,7 @@ func (o *ReportingPluginServiceClient) NewReportingPluginFactory(
 			pb.RegisterPipelineRunnerServiceServer(s, pipeline.NewRunnerServer(pipelineRunner))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(pipelineRunnerRes)
 
@@ -68,7 +68,7 @@ func (o *ReportingPluginServiceClient) NewReportingPluginFactory(
 			pb.RegisterTelemetryServer(s, telemetry.NewTelemetryServer(telemetryService))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(telemetryRes)
 
@@ -76,7 +76,7 @@ func (o *ReportingPluginServiceClient) NewReportingPluginFactory(
 			pb.RegisterErrorLogServer(s, errorlog.NewServer(errorLog))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(errorLogRes)
 
@@ -84,7 +84,7 @@ func (o *ReportingPluginServiceClient) NewReportingPluginFactory(
 			pb.RegisterCapabilitiesRegistryServer(s, capability.NewCapabilitiesRegistryServer(o.BrokerExt, capRegistry))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(capRegistryRes)
 
@@ -92,7 +92,7 @@ func (o *ReportingPluginServiceClient) NewReportingPluginFactory(
 			pb.RegisterKeyValueStoreServer(s, keyvalue.NewServer(keyValueStore))
 		})
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to serve KeyValueStore: %w", err)
+			return 0, deps, fmt.Errorf("failed to serve KeyValueStore: %w", err)
 		}
 		deps.Add(keyValueStoreRes)
 
@@ -103,7 +103,7 @@ func (o *ReportingPluginServiceClient) NewReportingPluginFactory(
 		})
 
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to serve new relayer set: %w", err)
+			return 0, deps, fmt.Errorf("failed to serve new relayer set: %w", err)
 		}
 
 		deps.Add(relayerSetRes)
@@ -126,9 +126,9 @@ func (o *ReportingPluginServiceClient) NewReportingPluginFactory(
 			RelayerSetID:     relayerSetID,
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
-		return reply.ID, nil, nil
+		return reply.ID, deps, nil
 	})
 	return NewReportingPluginFactoryClient(o.BrokerExt, cc), nil
 }

--- a/pkg/loop/internal/core/services/validation/validation.go
+++ b/pkg/loop/internal/core/services/validation/validation.go
@@ -3,7 +3,6 @@ package validation
 import (
 	"context"
 
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin"
@@ -29,7 +28,7 @@ func (v *validationServiceClient) ValidateConfig(ctx context.Context, config map
 	return err
 }
 
-func NewValidationServiceClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *validationServiceClient {
+func NewValidationServiceClient(b *net.BrokerExt, cc net.ClientConnInterface) *validationServiceClient {
 	b = b.WithName("ReportingPluginProviderClient")
 	return &validationServiceClient{b, goplugin.NewServiceClient(b, cc), pb.NewValidationServiceClient(cc)}
 }

--- a/pkg/loop/internal/goplugin/plugin.go
+++ b/pkg/loop/internal/goplugin/plugin.go
@@ -1,6 +1,7 @@
 package goplugin
 
 import (
+	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net"
@@ -19,7 +20,7 @@ func NewPluginClient(brokerCfg net.BrokerConfig) *PluginClient {
 	return &pc
 }
 
-func (p *PluginClient) Refresh(broker net.Broker, conn *grpc.ClientConn) {
+func (p *PluginClient) Refresh(broker *plugin.GRPCBroker, conn *grpc.ClientConn) {
 	p.AtomicBroker.Store(broker)
 	p.AtomicClient.Store(conn)
 	p.Logger.Debugw("Refreshed PluginClient connection", "state", conn.GetState())

--- a/pkg/loop/internal/goplugin/service.go
+++ b/pkg/loop/internal/goplugin/service.go
@@ -24,11 +24,11 @@ var (
 // to another loop that is proxied through the core node.
 type ServiceClient struct {
 	b    *net.BrokerExt
-	cc   grpc.ClientConnInterface
+	cc   net.ClientConnInterface
 	grpc pb.ServiceClient
 }
 
-func NewServiceClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *ServiceClient {
+func NewServiceClient(b *net.BrokerExt, cc net.ClientConnInterface) *ServiceClient {
 	return &ServiceClient{b, cc, pb.NewServiceClient(cc)}
 }
 
@@ -41,7 +41,7 @@ func (s *ServiceClient) Close() error {
 	defer cancel()
 
 	_, err := s.grpc.Close(ctx, &emptypb.Empty{})
-	return err
+	return errors.Join(err, s.cc.Close())
 }
 
 func (s *ServiceClient) Ready() error {

--- a/pkg/loop/internal/net/client.go
+++ b/pkg/loop/internal/net/client.go
@@ -20,13 +20,40 @@ var _ ClientConnInterface = (*grpc.ClientConn)(nil)
 type ClientConnInterface interface {
 	grpc.ClientConnInterface
 	GetState() connectivity.State
+	Close() error
 }
+
+func ClientConnInterfaceFromGRPC(conn grpc.ClientConnInterface) ClientConnInterface {
+	connCloser, ok := conn.(ClientConnInterface)
+	if !ok {
+		connCloser = &noopClientConnInterface{conn}
+	}
+	return connCloser
+}
+
+// noopClientConnInterface adapts ClientConnInterface to implement net.ClientConnInterface with no-ops.
+type noopClientConnInterface struct {
+	grpc.ClientConnInterface
+}
+
+func (c *noopClientConnInterface) GetState() connectivity.State {
+	return connectivity.State(-1)
+}
+
+func (*noopClientConnInterface) Close() error { return nil }
 
 var _ ClientConnInterface = (*AtomicClient)(nil)
 
 // An AtomicClient implements [grpc.ClientConnInterface] and is backed by a swappable [*grpc.ClientConn].
 type AtomicClient struct {
 	cc atomic.Pointer[grpc.ClientConn]
+}
+
+func (a *AtomicClient) Close() error {
+	if v := a.cc.Swap(nil); v != nil {
+		return (*v).Close()
+	}
+	return nil
 }
 
 func (a *AtomicClient) GetState() connectivity.State {
@@ -59,6 +86,23 @@ type clientConn struct {
 	mu   sync.RWMutex
 	deps Resources
 	cc   *grpc.ClientConn
+}
+
+func (c *clientConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.close()
+}
+
+func (c *clientConn) close() error {
+	if c.cc != nil {
+		err := c.cc.Close()
+		c.CloseAll(c.deps...)
+		c.cc = nil
+		c.deps = nil
+		return err
+	}
+	return nil
 }
 
 func (c *clientConn) GetState() connectivity.State {
@@ -127,11 +171,8 @@ func (c *clientConn) refresh(ctx context.Context, orig *grpc.ClientConn) (*grpc.
 	if c.cc != orig {
 		return c.cc, nil
 	}
-	if c.cc != nil {
-		if err := c.cc.Close(); err != nil {
-			c.Logger.Errorw("Client close failed", "err", err)
-		}
-		c.CloseAll(c.deps...)
+	if err := c.close(); err != nil {
+		c.Logger.Errorw("Client close failed", "err", err)
 	}
 
 	try := func() error {

--- a/pkg/loop/internal/relayer/pluginprovider/contractwriter/contract_writer.go
+++ b/pkg/loop/internal/relayer/pluginprovider/contractwriter/contract_writer.go
@@ -25,7 +25,7 @@ type Client struct {
 	encodeWith codecpb.EncodingVersion
 }
 
-func NewClient(b *net.BrokerExt, cc grpc.ClientConnInterface, opts ...ClientOpt) *Client {
+func NewClient(b *net.BrokerExt, cc net.ClientConnInterface, opts ...ClientOpt) *Client {
 	client := &Client{
 		ServiceClient: goplugin.NewServiceClient(b, cc),
 		grpc:          pb.NewContractWriterClient(cc),

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/commit_provider.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/commit_provider.go
@@ -34,7 +34,7 @@ type CommitProviderClient struct {
 	grpcClient ccippb.CommitCustomHandlersClient
 }
 
-func NewCommitProviderClient(b *net.BrokerExt, conn grpc.ClientConnInterface) *CommitProviderClient {
+func NewCommitProviderClient(b *net.BrokerExt, conn net.ClientConnInterface) *CommitProviderClient {
 	pluginProviderClient := ocr2.NewPluginProviderClient(b, conn)
 	client := ccippb.NewCommitCustomHandlersClient(conn)
 	return &CommitProviderClient{

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/commit_store.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/commit_store.go
@@ -35,7 +35,7 @@ type CommitStoreGRPCClient struct {
 	conn grpc.ClientConnInterface
 }
 
-func NewCommitStoreReaderGRPCClient(brokerExt *net.BrokerExt, cc grpc.ClientConnInterface) *CommitStoreGRPCClient {
+func NewCommitStoreReaderGRPCClient(brokerExt *net.BrokerExt, cc net.ClientConnInterface) *CommitStoreGRPCClient {
 	return &CommitStoreGRPCClient{client: ccippb.NewCommitStoreReaderClient(cc), b: brokerExt, conn: cc}
 }
 

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/execution_provider.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/execution_provider.go
@@ -34,7 +34,7 @@ type ExecProviderClient struct {
 	grpcClient ccippb.ExecutionCustomHandlersClient
 }
 
-func NewExecProviderClient(b *net.BrokerExt, conn grpc.ClientConnInterface) *ExecProviderClient {
+func NewExecProviderClient(b *net.BrokerExt, conn net.ClientConnInterface) *ExecProviderClient {
 	pluginProviderClient := ocr2.NewPluginProviderClient(b, conn)
 	grpc := ccippb.NewExecutionCustomHandlersClient(conn)
 	return &ExecProviderClient{

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/offramp.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/offramp.go
@@ -36,7 +36,7 @@ type OffRampReaderGRPCClient struct {
 // NewOffRampReaderGRPCClient creates a new OffRampReaderGRPCClient. It is used by the reporting plugin to call the offramp reader service.
 // The client is created by wrapping a grpc client connection. It requires a brokerExt to allocate and serve the gas estimator server.
 // *must* be the same broker used by the server BCF-3061
-func NewOffRampReaderGRPCClient(brokerExt *net.BrokerExt, cc grpc.ClientConnInterface) *OffRampReaderGRPCClient {
+func NewOffRampReaderGRPCClient(brokerExt *net.BrokerExt, cc net.ClientConnInterface) *OffRampReaderGRPCClient {
 	return &OffRampReaderGRPCClient{client: ccippb.NewOffRampReaderClient(cc), b: brokerExt, conn: cc}
 }
 

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/commit_gas_estimator_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/commit_gas_estimator_test.go
@@ -74,6 +74,6 @@ func setupCommitGasEstimatorServer(t *testing.T, s *grpc.Server, b *loopnet.Brok
 }
 
 // adapt the client constructor so we can use it with the grpc scaffold
-func setupCommitGasEstimatorClient(b *loopnet.BrokerExt, conn grpc.ClientConnInterface) *ccip.CommitGasEstimatorGRPCClient {
+func setupCommitGasEstimatorClient(b *loopnet.BrokerExt, conn loopnet.ClientConnInterface) *ccip.CommitGasEstimatorGRPCClient {
 	return ccip.NewCommitGasEstimatorGRPCClient(conn)
 }

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/exec_gas_estimator_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/exec_gas_estimator_test.go
@@ -74,7 +74,7 @@ func setupExecGasEstimatorServer(t *testing.T, s *grpc.Server, b *loopnet.Broker
 }
 
 // adapt the client constructor so we can use it with the grpc scaffold
-func setupExecGasEstimatorClient(b *loopnet.BrokerExt, conn grpc.ClientConnInterface) *ccip.ExecGasEstimatorGRPCClient {
+func setupExecGasEstimatorClient(b *loopnet.BrokerExt, conn loopnet.ClientConnInterface) *ccip.ExecGasEstimatorGRPCClient {
 	return ccip.NewExecGasEstimatorGRPCClient(conn)
 }
 

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/onramp_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/onramp_test.go
@@ -98,6 +98,6 @@ func setupOnRampServer(t *testing.T, server *grpc.Server, b *loopnet.BrokerExt) 
 	return onRamp
 }
 
-func setupOnRampClient(b *loopnet.BrokerExt, conn grpc.ClientConnInterface) *ccip.OnRampReaderGRPCClient {
+func setupOnRampClient(b *loopnet.BrokerExt, conn loopnet.ClientConnInterface) *ccip.OnRampReaderGRPCClient {
 	return ccip.NewOnRampReaderGRPCClient(conn)
 }

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/price_registry_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/price_registry_test.go
@@ -107,6 +107,6 @@ func setupPriceRegistryServer(t *testing.T, server *grpc.Server, b *loopnet.Brok
 }
 
 // wrapper to enable use of the grpc scaffold
-func setupPriceRegistryClient(b *loopnet.BrokerExt, conn grpc.ClientConnInterface) *ccip.PriceRegistryGRPCClient {
+func setupPriceRegistryClient(b *loopnet.BrokerExt, conn loopnet.ClientConnInterface) *ccip.PriceRegistryGRPCClient {
 	return ccip.NewPriceRegistryGRPCClient(conn)
 }

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/pricegetter_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/pricegetter_test.go
@@ -70,7 +70,7 @@ func setupPriceGetterServer(t *testing.T, s *grpc.Server, b *loopnet.BrokerExt) 
 	return priceGetter
 }
 
-func setupPriceGetterClient(b *loopnet.BrokerExt, conn grpc.ClientConnInterface) *ccip.PriceGetterGRPCClient {
+func setupPriceGetterClient(b *loopnet.BrokerExt, conn loopnet.ClientConnInterface) *ccip.PriceGetterGRPCClient {
 	return ccip.NewPriceGetterGRPCClient(conn)
 }
 

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/token_data_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/token_data_test.go
@@ -58,7 +58,7 @@ func setupTokenDataServer(t *testing.T, s *grpc.Server, b *loopnet.BrokerExt) *c
 	return tokenData
 }
 
-func setupTokenDataClient(b *loopnet.BrokerExt, conn grpc.ClientConnInterface) *ccip.TokenDataReaderGRPCClient {
+func setupTokenDataClient(b *loopnet.BrokerExt, conn loopnet.ClientConnInterface) *ccip.TokenDataReaderGRPCClient {
 	return ccip.NewTokenDataReaderGRPCClient(conn)
 }
 

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/token_pool_test.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccip/test/token_pool_test.go
@@ -58,7 +58,7 @@ func setupTokenPoolServer(t *testing.T, s *grpc.Server, b *loopnet.BrokerExt) *c
 	return tokenPool
 }
 
-func setupTokenPoolClient(b *loopnet.BrokerExt, conn grpc.ClientConnInterface) *ccip.TokenPoolBatchedReaderGRPCClient {
+func setupTokenPoolClient(b *loopnet.BrokerExt, conn loopnet.ClientConnInterface) *ccip.TokenPoolBatchedReaderGRPCClient {
 	return ccip.NewTokenPoolBatchedReaderGRPCClient(conn)
 }
 

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ccipocr3/ccip_provider.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ccipocr3/ccip_provider.go
@@ -32,7 +32,7 @@ type CCIPProviderClient struct {
 	messageHasher             ccipocr3.MessageHasher
 }
 
-func NewCCIPProviderClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *CCIPProviderClient {
+func NewCCIPProviderClient(b *net.BrokerExt, cc net.ClientConnInterface) *CCIPProviderClient {
 	c := &CCIPProviderClient{
 		ServiceClient: goplugin.NewServiceClient(b.WithName("CCIPProviderClient"), cc),
 	}
@@ -87,7 +87,7 @@ type CCIPProviderServer struct{}
 
 func (s CCIPProviderServer) ConnToProvider(conn grpc.ClientConnInterface, broker net.Broker, brokerCfg net.BrokerConfig) types.CCIPProvider {
 	be := &net.BrokerExt{Broker: broker, BrokerConfig: brokerCfg}
-	return NewCCIPProviderClient(be, conn)
+	return NewCCIPProviderClient(be, net.ClientConnInterfaceFromGRPC(conn))
 }
 
 func RegisterProviderServices(s *grpc.Server, provider types.CCIPProvider) {

--- a/pkg/loop/internal/relayer/pluginprovider/ext/median/median.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/median/median.go
@@ -39,7 +39,7 @@ type ProviderClient struct {
 	codec              types.Codec
 }
 
-func NewProviderClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *ProviderClient {
+func NewProviderClient(b *net.BrokerExt, cc net.ClientConnInterface) *ProviderClient {
 	m := &ProviderClient{PluginProviderClient: ocr2.NewPluginProviderClient(b.WithName("MedianProviderClient"), cc)}
 	m.reportCodec = &reportCodecClient{b, pb.NewReportCodecClient(cc)}
 	m.medianContract = &medianContractClient{pb.NewMedianContractClient(cc)}
@@ -313,7 +313,7 @@ type ProviderServer struct{}
 
 func (m ProviderServer) ConnToProvider(conn grpc.ClientConnInterface, broker net.Broker, brokerCfg net.BrokerConfig) types.MedianProvider {
 	be := &net.BrokerExt{Broker: broker, BrokerConfig: brokerCfg}
-	pc := NewProviderClient(be, conn)
+	pc := NewProviderClient(be, net.ClientConnInterfaceFromGRPC(conn))
 	pc.RmUnimplemented(context.Background())
 	return pc
 }

--- a/pkg/loop/internal/relayer/pluginprovider/ext/mercury/mercury.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/mercury/mercury.go
@@ -40,7 +40,7 @@ type ProviderClient struct {
 	mercuryChainReader mercury.ChainReader
 }
 
-func NewProviderClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *ProviderClient {
+func NewProviderClient(b *net.BrokerExt, cc net.ClientConnInterface) *ProviderClient {
 	m := &ProviderClient{PluginProviderClient: ocr2.NewPluginProviderClient(b.WithName("MercuryProviderClient"), cc)}
 
 	m.reportCodecV1 = newReportCodecV1Client(mercury_v1_internal.NewReportCodecClient(cc))

--- a/pkg/loop/internal/relayer/pluginprovider/ext/ocr3capability/capability.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ext/ocr3capability/capability.go
@@ -29,7 +29,7 @@ func (p *ProviderClient) OCR3ContractTransmitter() ocr3types.ContractTransmitter
 	return p.ocr3ContractTransmitter
 }
 
-func NewProviderClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *ProviderClient {
+func NewProviderClient(b *net.BrokerExt, cc net.ClientConnInterface) *ProviderClient {
 	m := &ProviderClient{
 		PluginProviderClient:    ocr2.NewPluginProviderClient(b.WithName("OCR3CapabilityProviderClient"), cc),
 		ocr3ContractTransmitter: ocr3.NewContractTransmitterClient(b.WithName("OCR3ContractTransmitter"), cc),
@@ -42,7 +42,7 @@ type ProviderServer struct{}
 
 func (m ProviderServer) ConnToProvider(conn grpc.ClientConnInterface, broker net.Broker, brokerCfg net.BrokerConfig) types.OCR3CapabilityProvider {
 	be := &net.BrokerExt{Broker: broker, BrokerConfig: brokerCfg}
-	return NewProviderClient(be, conn)
+	return NewProviderClient(be, net.ClientConnInterfaceFromGRPC(conn))
 }
 
 func RegisterProviderServices(s *grpc.Server, provider types.OCR3CapabilityProvider) {

--- a/pkg/loop/internal/relayer/pluginprovider/ocr2/config.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ocr2/config.go
@@ -27,7 +27,7 @@ type ConfigProviderClient struct {
 	contractTracker  libocr.ContractConfigTracker
 }
 
-func NewConfigProviderClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *ConfigProviderClient {
+func NewConfigProviderClient(b *net.BrokerExt, cc net.ClientConnInterface) *ConfigProviderClient {
 	c := &ConfigProviderClient{ServiceClient: goplugin.NewServiceClient(b, cc)}
 	c.offchainDigester = &offchainConfigDigesterClient{b, pb.NewOffchainConfigDigesterClient(cc)}
 	c.contractTracker = &contractConfigTrackerClient{pb.NewContractConfigTrackerClient(cc)}

--- a/pkg/loop/internal/relayer/pluginprovider/ocr2/plugin_provider.go
+++ b/pkg/loop/internal/relayer/pluginprovider/ocr2/plugin_provider.go
@@ -1,9 +1,8 @@
 package ocr2
 
 import (
-	"google.golang.org/grpc"
-
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"google.golang.org/grpc"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/goplugin"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/net"
@@ -24,7 +23,7 @@ var _ types.PluginProvider = (*PluginProviderClient)(nil)
 // in practice, inherited from configProviderClient.
 var _ goplugin.GRPCClientConn = (*PluginProviderClient)(nil)
 
-func NewPluginProviderClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *PluginProviderClient {
+func NewPluginProviderClient(b *net.BrokerExt, cc net.ClientConnInterface) *PluginProviderClient {
 	p := &PluginProviderClient{ConfigProviderClient: NewConfigProviderClient(b.WithName("PluginProviderClient"), cc)}
 	p.contractTransmitter = &contractTransmitterClient{b, pb.NewContractTransmitterClient(cc)}
 	p.contractReader = contractreader.NewClient(goplugin.NewServiceClient(b, cc), pb.NewContractReaderClient(cc))
@@ -48,5 +47,5 @@ type PluginProviderServer struct{}
 
 func (p PluginProviderServer) ConnToProvider(conn grpc.ClientConnInterface, broker net.Broker, brokerCfg net.BrokerConfig) types.PluginProvider {
 	be := &net.BrokerExt{Broker: broker, BrokerConfig: brokerCfg}
-	return NewPluginProviderClient(be, conn)
+	return NewPluginProviderClient(be, net.ClientConnInterfaceFromGRPC(conn))
 }

--- a/pkg/loop/internal/relayer/relayer.go
+++ b/pkg/loop/internal/relayer/relayer.go
@@ -190,7 +190,7 @@ type relayerClient struct {
 	aptosClient aptospb.AptosClient
 }
 
-func newRelayerClient(b *net.BrokerExt, conn grpc.ClientConnInterface) *relayerClient {
+func newRelayerClient(b *net.BrokerExt, conn net.ClientConnInterface) *relayerClient {
 	b = b.WithName("RelayerClient")
 	return &relayerClient{
 		b, goplugin.NewServiceClient(b, conn),
@@ -276,7 +276,7 @@ type PluginProviderClient interface {
 	goplugin.GRPCClientConn
 }
 
-func WrapProviderClientConnection(ctx context.Context, providerType string, cc grpc.ClientConnInterface, broker *net.BrokerExt) (PluginProviderClient, error) {
+func WrapProviderClientConnection(ctx context.Context, providerType string, cc net.ClientConnInterface, broker *net.BrokerExt) (PluginProviderClient, error) {
 	// TODO: Remove this when we have fully transitioned all relayers to running in LOOPPs.
 	// This allows callers to type assert a PluginProvider into a product provider type (eg. MedianProvider)
 	// for interoperability with legacy code.

--- a/pkg/loop/internal/relayerset/client.go
+++ b/pkg/loop/internal/relayerset/client.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"google.golang.org/grpc"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/chains/aptos"
 	"github.com/smartcontractkit/chainlink-common/pkg/chains/evm"
 	"github.com/smartcontractkit/chainlink-common/pkg/chains/solana"
@@ -36,7 +34,7 @@ type Client struct {
 	aptosRelayerSetClient  aptos.AptosClient
 }
 
-func NewRelayerSetClient(log logger.Logger, b *net.BrokerExt, conn grpc.ClientConnInterface) *Client {
+func NewRelayerSetClient(log logger.Logger, b *net.BrokerExt, conn net.ClientConnInterface) *Client {
 	b = b.WithName("ChainRelayerClient")
 	return &Client{
 		log:                    log,

--- a/pkg/loop/internal/reportingplugin/ccip/commit.go
+++ b/pkg/loop/internal/reportingplugin/ccip/commit.go
@@ -74,7 +74,7 @@ func (c *CommitLOOPClient) NewCommitFactory(ctx context.Context, provider types.
 			ProviderServiceId: providerID,
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		return resp.CommitFactoryServiceId, deps, nil
 	}

--- a/pkg/loop/internal/reportingplugin/ccip/execution.go
+++ b/pkg/loop/internal/reportingplugin/ccip/execution.go
@@ -84,7 +84,7 @@ func (c *ExecutionLOOPClient) NewExecutionFactory(ctx context.Context, srcProvid
 			})
 		}
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(dstProviderResource)
 
@@ -96,7 +96,7 @@ func (c *ExecutionLOOPClient) NewExecutionFactory(ctx context.Context, srcProvid
 			SrcTokenAddress:      srcTokenAddress,
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		return resp.ExecutionFactoryServiceId, deps, nil
 	}

--- a/pkg/loop/internal/reportingplugin/median/median.go
+++ b/pkg/loop/internal/reportingplugin/median/median.go
@@ -51,7 +51,7 @@ func (m *PluginMedianClient) NewMedianFactory(ctx context.Context, provider type
 			pb.RegisterDataSourceServer(s, newDataSourceServer(juelsPerFeeCoin))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(juelsPerFeeCoinDataSourceRes)
 
@@ -59,7 +59,7 @@ func (m *PluginMedianClient) NewMedianFactory(ctx context.Context, provider type
 			pb.RegisterDataSourceServer(s, newDataSourceServer(gasPriceSubunits))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(gasPriceSubunitsDataSourceRes)
 
@@ -75,7 +75,7 @@ func (m *PluginMedianClient) NewMedianFactory(ctx context.Context, provider type
 			})
 		}
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(providerRes)
 
@@ -83,7 +83,7 @@ func (m *PluginMedianClient) NewMedianFactory(ctx context.Context, provider type
 			pb.RegisterErrorLogServer(s, errorlog.NewServer(errorLog))
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(errorLogRes)
 
@@ -91,7 +91,7 @@ func (m *PluginMedianClient) NewMedianFactory(ctx context.Context, provider type
 		if deviationFuncDefinition != nil {
 			deviationFuncDefinitionJSON, err = json.Marshal(deviationFuncDefinition)
 			if err != nil {
-				return 0, nil, fmt.Errorf("failed to marshal deviationFuncDefinition: %w", err)
+				return 0, deps, fmt.Errorf("failed to marshal deviationFuncDefinition: %w", err)
 			}
 		}
 
@@ -105,9 +105,9 @@ func (m *PluginMedianClient) NewMedianFactory(ctx context.Context, provider type
 			DeviationFuncDefinition:      deviationFuncDefinitionJSON,
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
-		return reply.ReportingPluginFactoryID, nil, nil
+		return reply.ReportingPluginFactoryID, deps, nil
 	})
 	return ocr2.NewReportingPluginFactoryClient(m.BrokerExt, cc), nil
 }

--- a/pkg/loop/internal/reportingplugin/mercury/mercury.go
+++ b/pkg/loop/internal/reportingplugin/mercury/mercury.go
@@ -77,7 +77,7 @@ func (c *AdapterClient) NewMercuryV1Factory(ctx context.Context,
 			})
 		}
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(providerRes)
 
@@ -86,7 +86,7 @@ func (c *AdapterClient) NewMercuryV1Factory(ctx context.Context,
 			DataSourceV1ID:    dataSourceID,
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		return reply.MercuryV1FactoryID, deps, nil
 	}
@@ -125,7 +125,7 @@ func (c *AdapterClient) NewMercuryV2Factory(ctx context.Context,
 			})
 		}
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(providerRes)
 
@@ -134,7 +134,7 @@ func (c *AdapterClient) NewMercuryV2Factory(ctx context.Context,
 			DataSourceV2ID:    dataSourceID,
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		return reply.MercuryV2FactoryID, deps, nil
 	}
@@ -175,7 +175,7 @@ func (c *AdapterClient) NewMercuryV3Factory(ctx context.Context,
 			})
 		}
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(providerRes)
 
@@ -184,7 +184,7 @@ func (c *AdapterClient) NewMercuryV3Factory(ctx context.Context,
 			DataSourceV3ID:    dataSourceID,
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		return reply.MercuryV3FactoryID, deps, nil
 	}
@@ -225,7 +225,7 @@ func (c *AdapterClient) NewMercuryV4Factory(ctx context.Context,
 			})
 		}
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		deps.Add(providerRes)
 
@@ -234,7 +234,7 @@ func (c *AdapterClient) NewMercuryV4Factory(ctx context.Context,
 			DataSourceV4ID:    dataSourceID,
 		})
 		if err != nil {
-			return 0, nil, err
+			return 0, deps, err
 		}
 		return reply.MercuryV4FactoryID, deps, nil
 	}

--- a/pkg/loop/internal/reportingplugin/mercury/mercury_reporting.go
+++ b/pkg/loop/internal/reportingplugin/mercury/mercury_reporting.go
@@ -23,7 +23,7 @@ type PluginFactoryClient struct {
 	client mercurypb.MercuryPluginFactoryClient
 }
 
-func NewPluginFactoryClient(b *net.BrokerExt, cc grpc.ClientConnInterface) *PluginFactoryClient {
+func NewPluginFactoryClient(b *net.BrokerExt, cc net.ClientConnInterface) *PluginFactoryClient {
 	b = b.WithName("MercuryPluginProviderClient")
 	return &PluginFactoryClient{b, goplugin.NewServiceClient(b, cc), mercurypb.NewMercuryPluginFactoryClient(cc)}
 }

--- a/pkg/loop/internal/test/grpc_scaffold.go
+++ b/pkg/loop/internal/test/grpc_scaffold.go
@@ -102,7 +102,7 @@ type SetupGRPCServer[S any] func(t *testing.T, s *grpc.Server, b *loopnet.Broker
 
 // SetupGRPCClient is a function that sets up a grpc client with a given broker and connection
 // analogous to SetupGRPCServer. Typically it is implemented as a light wrapper around the grpc client constructor
-type SetupGRPCClient[T Client] func(b *loopnet.BrokerExt, conn grpc.ClientConnInterface) T
+type SetupGRPCClient[T Client] func(b *loopnet.BrokerExt, conn loopnet.ClientConnInterface) T
 
 // MockDep is a mock dependency that can be used to test that a grpc client closes its dependencies
 // to be used in tests that require a grpc client to close its dependencies

--- a/pkg/loop/relayer_service_test.go
+++ b/pkg/loop/relayer_service_test.go
@@ -39,7 +39,8 @@ var relayerServiceNames = []string{
 }
 
 func TestRelayerService(t *testing.T) {
-	t.Parallel()
+	tests.VerifyNoLeaks(t)
+
 	capRegistry := mocks.NewCapabilitiesRegistry(t)
 	relayer := loop.NewRelayerService(logger.Test(t), loop.GRPCOpts{}, func() *exec.Cmd {
 		return NewHelperProcessCommand(loop.PluginRelayerName, false, 0)
@@ -56,7 +57,7 @@ func TestRelayerService(t *testing.T) {
 		hook.Kill()
 
 		// wait for relaunch
-		time.Sleep(2 * goplugin.KeepAliveTickDuration)
+		time.Sleep(goplugin.KeepAliveTickDuration)
 
 		relayertest.Run(t, relayer)
 		servicetest.AssertHealthReportNames(t, relayer.HealthReport(), relayerServiceNames...)
@@ -66,7 +67,7 @@ func TestRelayerService(t *testing.T) {
 		hook.Reset()
 
 		// wait for relaunch
-		time.Sleep(2 * goplugin.KeepAliveTickDuration)
+		time.Sleep(goplugin.KeepAliveTickDuration)
 
 		relayertest.Run(t, relayer)
 		servicetest.AssertHealthReportNames(t, relayer.HealthReport(), relayerServiceNames...)

--- a/pkg/loop/reportingplugins/grpc.go
+++ b/pkg/loop/reportingplugins/grpc.go
@@ -50,7 +50,7 @@ type serverAdapter struct {
 	NewReportingPluginFactoryFn func(
 		ctx context.Context,
 		config core.ReportingPluginServiceConfig,
-		conn grpc.ClientConnInterface,
+		conn net.ClientConnInterface,
 		pr core.PipelineRunnerService,
 		ts core.TelemetryService,
 		errorLog core.ErrorLog,
@@ -79,14 +79,14 @@ func (s serverAdapter) NewReportingPluginFactory(
 	kv core.KeyValueStore,
 	rs core.RelayerSet,
 ) (types.ReportingPluginFactory, error) {
-	return s.NewReportingPluginFactoryFn(ctx, config, conn, pr, ts, errorLog, kv, rs)
+	return s.NewReportingPluginFactoryFn(ctx, config, net.ClientConnInterfaceFromGRPC(conn), pr, ts, errorLog, kv, rs)
 }
 
 func (g *GRPCService[T]) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
 	newReportingPluginFactoryFn := func(
 		ctx context.Context,
 		cfg core.ReportingPluginServiceConfig,
-		conn grpc.ClientConnInterface,
+		conn net.ClientConnInterface,
 		pr core.PipelineRunnerService,
 		ts core.TelemetryService,
 		el core.ErrorLog,

--- a/pkg/loop/reportingplugins/ocr3/grpc.go
+++ b/pkg/loop/reportingplugins/ocr3/grpc.go
@@ -37,7 +37,7 @@ type serverAdapter struct {
 	NewReportingPluginFactoryFn func(
 		context.Context,
 		core.ReportingPluginServiceConfig,
-		grpc.ClientConnInterface,
+		net.ClientConnInterface,
 		core.PipelineRunnerService,
 		core.TelemetryService,
 		core.ErrorLog,
@@ -69,14 +69,14 @@ func (s serverAdapter) NewReportingPluginFactory(
 	kv core.KeyValueStore,
 	rs core.RelayerSet,
 ) (core.OCR3ReportingPluginFactory, error) {
-	return s.NewReportingPluginFactoryFn(ctx, config, conn, pr, ts, errorLog, capRegistry, kv, rs)
+	return s.NewReportingPluginFactoryFn(ctx, config, net.ClientConnInterfaceFromGRPC(conn), pr, ts, errorLog, capRegistry, kv, rs)
 }
 
 func (g *GRPCService[T]) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
 	newReportingPluginFactoryFn := func(
 		ctx context.Context,
 		cfg core.ReportingPluginServiceConfig,
-		conn grpc.ClientConnInterface,
+		conn net.ClientConnInterface,
 		pr core.PipelineRunnerService,
 		ts core.TelemetryService,
 		el core.ErrorLog,

--- a/pkg/utils/tests/leak.go
+++ b/pkg/utils/tests/leak.go
@@ -1,0 +1,25 @@
+package tests
+
+import (
+	"math/rand/v2"
+	"strconv"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// VerifyNoLeaks verifies that the test does not leak any goroutines.
+// Must be called at the start of the test, before any goroutines have spawned.
+// Cannot be used from parallel tests.
+func VerifyNoLeaks(t testing.TB) {
+	// Set a random environment variable to trigger testing.checkParallel()
+	t.Setenv(strconv.Itoa(rand.Int()), strconv.Itoa(rand.Int()))
+	current := goleak.IgnoreCurrent()
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Log("Test failed - skipping goroutine leak check")
+			return
+		}
+		goleak.VerifyNone(t, current)
+	})
+}


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CRE-3973

Before this PR, `TestRelayerService` was leaking ~40 goroutines, mostly client side `CallbackSerializer`s. Now they are all cleaned up, and the test will continue to check for leaks going forward.
 
- fail `TestRelayerService` if goroutines leak
- return more dependency resources
- expose `Close` through `ClientConnInterface`
- close final client, not just refreshed ones
- bump github.com/hashicorp/go-plugin to v1.8.0, including fd leak fix