### PR TITLE
PLEX-2683: wrap executableClient.Execute transport errors

### DIFF
--- a/pkg/loop/internal/core/services/capability/capabilities.go
+++ b/pkg/loop/internal/core/services/capability/capabilities.go
@@ -484,12 +484,12 @@ var _ capabilities.Executable = (*executableClient)(nil)
 func (c *executableClient) Execute(ctx context.Context, req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
 	responseStream, err := c.grpc.Execute(ctx, pb.CapabilityRequestToProto(req))
 	if err != nil {
-		return capabilities.CapabilityResponse{}, fmt.Errorf("error executing capability request: %w", err)
+		return capabilities.CapabilityResponse{}, caperrors.NewPublicSystemError(fmt.Errorf("error executing capability request: %w", err), caperrors.Unavailable)
 	}
 
 	resp, err := responseStream.Recv()
 	if err != nil {
-		return capabilities.CapabilityResponse{}, fmt.Errorf("error waiting for response message: %w", err)
+		return capabilities.CapabilityResponse{}, caperrors.NewPublicSystemError(fmt.Errorf("error waiting for response message: %w", err), caperrors.Unavailable)
 	}
 
 	if resp.Error != "" {
@@ -498,7 +498,7 @@ func (c *executableClient) Execute(ctx context.Context, req capabilities.Capabil
 
 	r, err := pb.CapabilityResponseFromProto(resp)
 	if err != nil {
-		return capabilities.CapabilityResponse{}, fmt.Errorf("could not unmarshal response: %w", err)
+		return capabilities.CapabilityResponse{}, caperrors.NewPublicSystemError(fmt.Errorf("could not unmarshal response: %w", err), caperrors.Internal)
 	}
 
 	return r, err

--- a/pkg/loop/internal/core/services/capability/capabilities_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_test.go
@@ -591,35 +591,6 @@ func Test_Capabilities(t *testing.T) {
 		require.Equal(t, caperrors.OriginSystem, capErr.Origin())
 	})
 
-	t.Run("fetching an action capability, and executing it with private system error", func(t *testing.T) {
-		ma := mustMockExecutable(t, capabilities.CapabilityTypeAction)
-		c, _, _, err := newCapabilityPlugin(t, ma)
-		require.NoError(t, err)
-
-		cmap, err := values.NewMap(map[string]any{"foo": "bar"})
-		require.NoError(t, err)
-
-		imap, err := values.NewMap(map[string]any{"bar": "baz"})
-		require.NoError(t, err)
-		expectedRequest := capabilities.CapabilityRequest{
-			Config: cmap,
-			Inputs: imap,
-		}
-
-		ma.responseError = caperrors.NewPrivateSystemError(errors.New("bang"), caperrors.DeadlineExceeded)
-
-		_, err = c.(capabilities.ActionCapability).Execute(
-			t.Context(),
-			expectedRequest)
-		require.Error(t, err)
-		capErr, ok := errors.AsType[caperrors.Error](err)
-		require.True(t, ok)
-		require.Equal(t, "[4]DeadlineExceeded: bang", capErr.Error())
-		require.Equal(t, caperrors.DeadlineExceeded, capErr.Code())
-		require.Equal(t, caperrors.VisibilityPrivate, capErr.Visibility())
-		require.Equal(t, caperrors.OriginSystem, capErr.Origin())
-	})
-
 	// This will only happen a local capability has not had it's API migrated to always return capability.Error
 	t.Run("fetching an action capability, and executing it without capability error", func(t *testing.T) {
 		ma := mustMockExecutable(t, capabilities.CapabilityTypeAction)

--- a/pkg/loop/internal/core/services/capability/capabilities_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-plugin"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -89,8 +91,9 @@ func mustMockTrigger(t *testing.T) *mockTrigger {
 
 type mockExecutable struct {
 	capabilities.BaseCapability
-	callback      chan capabilities.CapabilityResponse
-	responseError error
+	callback       chan capabilities.CapabilityResponse
+	responseError  error
+	executeEntered chan struct{}
 
 	regRequest   capabilities.RegisterToWorkflowRequest
 	unregRequest capabilities.UnregisterFromWorkflowRequest
@@ -107,6 +110,12 @@ func (m *mockExecutable) UnregisterFromWorkflow(ctx context.Context, request cap
 }
 
 func (m *mockExecutable) Execute(ctx context.Context, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+	if m.executeEntered != nil {
+		select {
+		case m.executeEntered <- struct{}{}:
+		default:
+		}
+	}
 	if m.responseError != nil {
 		return capabilities.CapabilityResponse{}, m.responseError
 	}
@@ -119,6 +128,38 @@ func mustMockExecutable(t *testing.T, _type capabilities.CapabilityType) *mockEx
 		BaseCapability: capabilities.MustNewCapabilityInfo(fmt.Sprintf("callback-%s@1.0.0", _type), _type, fmt.Sprintf("a mock %s", _type)),
 		callback:       make(chan capabilities.CapabilityResponse, 10),
 	}
+}
+
+// malformedExecutableServer emits a raw pb.CapabilityResponse that the
+// generated CapabilityResponseFromProto rejects (ConfigDigest is not 32
+// bytes). It is used to drive the unmarshal-failure path in
+// executableClient.Execute without going through executableServer's
+// CapabilityResponseToProto conversion.
+type malformedExecutableServer struct {
+	pb.UnimplementedExecutableServer
+}
+
+func (m *malformedExecutableServer) Execute(_ *pb.CapabilityRequest, stream grpc.ServerStreamingServer[pb.CapabilityResponse]) error {
+	return stream.Send(&pb.CapabilityResponse{
+		OcrAttestation: &pb.OCRAttestation{
+			ConfigDigest: []byte{1}, // 1 byte, CapabilityResponseFromProto() requires 32
+		},
+	})
+}
+
+type malformedExecutablePlugin struct {
+	plugin.NetRPCUnsupportedPlugin
+	brokerCfg net.BrokerConfig
+}
+
+func (p *malformedExecutablePlugin) GRPCClient(_ context.Context, broker *plugin.GRPCBroker, client *grpc.ClientConn) (any, error) {
+	bext := &net.BrokerExt{BrokerConfig: p.brokerCfg, Broker: broker}
+	return NewExecutableCapabilityClient(bext, client), nil
+}
+
+func (p *malformedExecutablePlugin) GRPCServer(_ *plugin.GRPCBroker, server *grpc.Server) error {
+	pb.RegisterExecutableServer(server, &malformedExecutableServer{})
+	return nil
 }
 
 type capabilityPlugin struct {
@@ -656,6 +697,121 @@ func Test_Capabilities(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, ma.executeCalled)
+	})
+
+	t.Run("Execute wraps transport error when client connection is closed before call", func(t *testing.T) {
+		ma := mustMockExecutable(t, capabilities.CapabilityTypeAction)
+		c, client, _, err := newCapabilityPlugin(t, ma)
+		require.NoError(t, err)
+
+		// Close the underlying client connection so c.grpc.Execute fails at the
+		// initial gRPC call site.
+		require.NoError(t, client.Close())
+
+		cmap, err := values.NewMap(map[string]any{"foo": "bar"})
+		require.NoError(t, err)
+		imap, err := values.NewMap(map[string]any{"bar": "baz"})
+		require.NoError(t, err)
+
+		_, err = c.(capabilities.ExecutableCapability).Execute(
+			t.Context(),
+			capabilities.CapabilityRequest{Config: cmap, Inputs: imap})
+		require.Error(t, err)
+
+		var capErr caperrors.Error
+		ok := errors.As(err, &capErr)
+		require.True(t, ok, "expected caperrors.Error, got %T: %v", err, err)
+		require.Equal(t, caperrors.Unavailable, capErr.Code())
+		require.Equal(t, caperrors.VisibilityPublic, capErr.Visibility())
+		require.Equal(t, caperrors.OriginSystem, capErr.Origin())
+		require.Contains(t, capErr.Error(), "[14]Unavailable: error executing capability request:") // capping the error as it might change in CI
+	})
+
+	t.Run("Execute wraps responseStream.Recv error when stream breaks mid-flight", func(t *testing.T) {
+		ma := mustMockExecutable(t, capabilities.CapabilityTypeAction)
+		ma.executeEntered = make(chan struct{}, 1)
+		// Do NOT preload ma.callback — the server-side impl.Execute will block
+		// on `<-m.callback` after signalling executeEntered, leaving the client
+		// parked in responseStream.Recv() so we can break the stream below.
+		c, _, server, err := newCapabilityPlugin(t, ma)
+		require.NoError(t, err)
+
+		cmap, err := values.NewMap(map[string]any{"foo": "bar"})
+		require.NoError(t, err)
+		imap, err := values.NewMap(map[string]any{"bar": "baz"})
+		require.NoError(t, err)
+
+		done := make(chan error, 1)
+		go func() {
+			_, execErr := c.(capabilities.ExecutableCapability).Execute(
+				t.Context(),
+				capabilities.CapabilityRequest{Config: cmap, Inputs: imap})
+			done <- execErr
+		}()
+
+		select {
+		case <-ma.executeEntered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("server-side Execute was never invoked")
+		}
+
+		// Stream is established and client is blocked in Recv(); tear the
+		// server down so Recv() returns an error.
+		server.Stop()
+
+		var execErr error
+		select {
+		case execErr = <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Execute did not return after server stop")
+		}
+		require.Error(t, execErr)
+
+		var capErr caperrors.Error
+		ok := errors.As(execErr, &capErr)
+		require.True(t, ok, "expected caperrors.Error, got %T: %v", execErr, execErr)
+		require.Equal(t, caperrors.Unavailable, capErr.Code())
+		require.Equal(t, caperrors.VisibilityPublic, capErr.Visibility())
+		require.Equal(t, caperrors.OriginSystem, capErr.Origin())
+		require.Contains(t, capErr.Error(), "[14]Unavailable: error waiting for response message: rpc error:") // capping the error as it might change in CI
+	})
+
+	t.Run("Execute wraps CapabilityResponseFromProto unmarshal error as caperrors.Error", func(t *testing.T) {
+		stopCh := make(chan struct{})
+		pluginName := "malformed"
+		cl, _ := plugin.TestPluginGRPCConn(
+			t,
+			false,
+			map[string]plugin.Plugin{
+				pluginName: &malformedExecutablePlugin{
+					brokerCfg: net.BrokerConfig{
+						StopCh: stopCh,
+						Logger: logger.Test(t),
+					},
+				},
+			},
+		)
+
+		raw, err := cl.Dispense(pluginName)
+		require.NoError(t, err)
+
+		cmap, err := values.NewMap(map[string]any{"foo": "bar"})
+		require.NoError(t, err)
+		imap, err := values.NewMap(map[string]any{"bar": "baz"})
+		require.NoError(t, err)
+
+		_, err = raw.(capabilities.ExecutableCapability).Execute(
+			t.Context(),
+			capabilities.CapabilityRequest{Config: cmap, Inputs: imap})
+		require.Error(t, err)
+
+		var capErr caperrors.Error
+		ok := errors.As(err, &capErr)
+		require.True(t, ok, "expected caperrors.Error, got %T: %v", err, err)
+		require.Equal(t, caperrors.Internal, capErr.Code())
+		require.Equal(t, caperrors.VisibilityPublic, capErr.Visibility())
+		require.Equal(t, caperrors.OriginSystem, capErr.Origin())
+		require.Contains(t, capErr.Error(), "[13]Internal: could not unmarshal response: invalid config digest length: expected 32 bytes, got 1")
 	})
 }
 


### PR DESCRIPTION
Jira: https://smartcontract-it.atlassian.net/browse/PLEX-2683

Currently we are getting "error executing request: INTERNAL_ERROR : failed to execute capability" if the executableClient.Execute grpc transport fails due to 2 reasons: 1 is not adding the origina source of the problem and it is also not properly discriminating it as a caperror for further classification down the pipe.



<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
