### PR TITLE
Add insufficient observations error code

### DIFF
--- a/pkg/capabilities/errors/error_codes.go
+++ b/pkg/capabilities/errors/error_codes.go
@@ -130,6 +130,9 @@ const (
 
 	// LimitExceeded indicates that a CRE limit breach has occurred.
 	LimitExceeded ErrorCode = 101
+
+	// InsufficientObservations indicates that there are not enough observations to enable the operation to complete.
+	InsufficientObservations ErrorCode = 102
 )
 
 // String returns the string representation of the ErrorCode.
@@ -157,8 +160,9 @@ var errorCodeToString = map[ErrorCode]string{
 	Unavailable:        "Unavailable",
 	DataLoss:           "DataLoss",
 	Unauthenticated:    "Unauthenticated",
-	ConsensusFailed:    "ConsensusFailed",
-	LimitExceeded:      "LimitExceeded",
+	ConsensusFailed:          "ConsensusFailed",
+	LimitExceeded:            "LimitExceeded",
+	InsufficientObservations: "InsufficientObservations",
 }
 
 var stringToErrorCode = map[string]ErrorCode{
@@ -178,8 +182,9 @@ var stringToErrorCode = map[string]ErrorCode{
 	"Unavailable":        Unavailable,
 	"DataLoss":           DataLoss,
 	"Unauthenticated":    Unauthenticated,
-	"ConsensusFailed":    ConsensusFailed,
-	"LimitExceeded":      LimitExceeded,
+	"ConsensusFailed":          ConsensusFailed,
+	"LimitExceeded":            LimitExceeded,
+	"InsufficientObservations": InsufficientObservations,
 }
 
 func FromErrorCodeString(str string) ErrorCode {

--- a/pkg/capabilities/errors/error_serialization_test.go
+++ b/pkg/capabilities/errors/error_serialization_test.go
@@ -13,7 +13,7 @@ func TestErrorSerializationAndDeserialization(t *testing.T) {
 	// Assuming you have types: Visibility, Origin, and a custom Error type with serialization logic.
 	visibilities := []caperrors.Visibility{caperrors.VisibilityPublic, caperrors.VisibilityPrivate}
 	origins := []caperrors.Origin{caperrors.OriginUser, caperrors.OriginSystem}
-	errorCodes := []caperrors.ErrorCode{caperrors.Unknown, caperrors.ConsensusFailed, caperrors.InvalidArgument}
+	errorCodes := []caperrors.ErrorCode{caperrors.Unknown, caperrors.ConsensusFailed, caperrors.InsufficientObservations, caperrors.InvalidArgument}
 
 	for _, v := range visibilities {
 		for _, o := range origins {
@@ -33,7 +33,7 @@ func TestRemoteErrorSerializationAndDeserialization(t *testing.T) {
 	// Assuming you have types: Visibility, Origin, and a custom Error type with serialization logic.
 	visibilities := []caperrors.Visibility{caperrors.VisibilityPublic, caperrors.VisibilityPrivate}
 	origins := []caperrors.Origin{caperrors.OriginUser, caperrors.OriginSystem}
-	errorCodes := []caperrors.ErrorCode{caperrors.Unknown, caperrors.ConsensusFailed, caperrors.InvalidArgument}
+	errorCodes := []caperrors.ErrorCode{caperrors.Unknown, caperrors.ConsensusFailed, caperrors.InsufficientObservations, caperrors.InvalidArgument}
 
 	for _, v := range visibilities {
 		for _, o := range origins {


### PR DESCRIPTION
Additional CRE specific error code to be used to indicate that consensus failure is due to insufficient observation, this will replace DeadlineExceeded code at the relevant points in consensus capability code.
