### PR TITLE
feat(ci): apidiff reusable workflow, enforce compatible

### DIFF
--- a/.github/workflows/api-diff.yml
+++ b/.github/workflows/api-diff.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   api-diff:
     uses: smartcontractkit/.github/.github/workflows/reusable-apidiff-go-analysis.yml@reusable-apidiff-go-analysis/v1

--- a/.github/workflows/api-diff.yml
+++ b/.github/workflows/api-diff.yml
@@ -7,59 +7,13 @@ on:
   pull_request:
 
 jobs:
-  changed-modules:
-    name: Determine Changed Modules
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      modules-json: ${{ steps.changed-modules.outputs.modules-json }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Changed modules
-        id: changed-modules
-        uses: smartcontractkit/.github/actions/changed-modules-go@changed-modules-go/v1
-        with:
-          file-patterns: |
-            **/*.go
-            **/go.mod
-            **/go.sum
-          module-patterns: |
-            **
-
-  analyze-api-changes:
-    if: ${{ needs.changed-modules.outputs.modules-json != '[]' }}
-    name: Analyze (${{ matrix.module }})
-    runs-on: ubuntu-latest
-    needs: changed-modules
-    permissions:
-      pull-requests: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        module: ${{ fromJson(needs.changed-modules.outputs.modules-json) }}
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: ${{ matrix.module }}/go.mod
-          cache: false
-
-      - uses: smartcontractkit/.github/actions/apidiff-go@apidiff-go/v2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          module-directory: ${{ matrix.module }}
-          enforce-compatible: false
-          post-comment: true
+  api-diff:
+    uses: smartcontractkit/.github/.github/workflows/reusable-apidiff-go-analysis.yml@reusable-apidiff-go-analysis/v1
+    with:
+      file-patterns: |
+        **/*.go
+        **/go.mod
+        **/go.sum
+      module-patterns: |
+        **
+      enforce-compatible: ${{ !contains(github.event.pull_request.labels.*.name, 'allow-incompatible') }}


### PR DESCRIPTION
### Changes

* Migrates apidiff-go to the reusable workflow
* Enforces compatibility

### Testing

- No-op on no go changes: https://github.com/smartcontractkit/chainlink-common/actions/runs/26161773643/job/76955205589?pr=2075
- Failure on incompatible changes: https://github.com/smartcontractkit/chainlink-common/actions/runs/26165378803/job/76968002244?pr=2076#step:4:101
- Bypass failure when PR is labeled: https://github.com/smartcontractkit/chainlink-common/actions/runs/26165543893/job/76968614722?pr=2076#step:4:99