### PR TITLE
batch: reserve 10KiB gRPC framing overhead in split and add batch_splits_total metric

### DIFF
--- a/pkg/chipingress/batch/client.go
+++ b/pkg/chipingress/batch/client.go
@@ -31,10 +31,11 @@ type seqnumKey struct {
 
 // Client is a batching client that accumulates messages and sends them in batches.
 type Client struct {
-	client             chipingress.Client
-	batchSize          int
-	maxGRPCRequestSize int
-	cloneEvent         bool
+	client                  chipingress.Client
+	batchSize               int
+	maxGRPCRequestSize      int // configured max, used for metrics/error reporting
+	effectiveMaxRequestSize int // maxGRPCRequestSize minus grpcFramingOverhead, used for splitting
+	cloneEvent              bool
 	maxConcurrentSends chan struct{}
 	batchInterval      time.Duration
 	maxPublishTimeout  time.Duration
@@ -57,6 +58,7 @@ type batchClientMetrics struct {
 	requestSizeBytes    otelmetric.Int64Histogram
 	requestLatencyMS    otelmetric.Float64Histogram
 	configInfo          otelmetric.Int64Gauge
+	batchSplitsTotal    otelmetric.Int64Counter
 	batchSizeAttr       otelmetric.MeasurementOption
 	maxGRPCReqSizeAttr  otelmetric.MeasurementOption
 	successStatusAttr   otelmetric.MeasurementOption
@@ -69,11 +71,12 @@ type Opt func(*Client)
 // NewBatchClient creates a new batching client with the given options.
 func NewBatchClient(client chipingress.Client, opts ...Opt) (*Client, error) {
 	c := &Client{
-		client:             client,
-		log:                zap.NewNop().Sugar(),
-		batchSize:          10,
-		maxGRPCRequestSize: 10 * 1024 * 1024,
-		cloneEvent:         true,
+		client:                  client,
+		log:                     zap.NewNop().Sugar(),
+		batchSize:               10,
+		maxGRPCRequestSize:      10 * 1024 * 1024,
+		effectiveMaxRequestSize: 10*1024*1024 - grpcFramingOverhead,
+		cloneEvent:              true,
 		maxConcurrentSends: make(chan struct{}, 1),
 		messageBuffer:      make(chan *messageWithCallback, 200),
 		batchInterval:      100 * time.Millisecond,
@@ -260,7 +263,11 @@ func (b *Client) sendBatch(ctx context.Context, messages []*messageWithCallback)
 	go func() {
 		defer func() { <-b.maxConcurrentSends }()
 
-		for _, batchMessages := range splitMessagesByRequestSize(messages, b.maxGRPCRequestSize) {
+		splitBatches := splitMessagesByRequestSize(messages, b.effectiveMaxRequestSize)
+		if len(splitBatches) > 1 {
+			b.metrics.batchSplitsTotal.Add(ctx, 1)
+		}
+		for _, batchMessages := range splitBatches {
 			batchReq, batchBytes := newBatchRequest(batchMessages)
 			if b.maxGRPCRequestSize > 0 && batchBytes > b.maxGRPCRequestSize {
 				err := fmt.Errorf("publish batch serialized size %d exceeds max gRPC request size %d", batchBytes, b.maxGRPCRequestSize)
@@ -297,6 +304,15 @@ func (b *Client) completeBatchCallbacks(messages []*messageWithCallback, err err
 		}
 	})
 }
+
+// grpcFramingOverhead accounts for gRPC framing, HTTP/2 headers, auth tokens,
+// tracing metadata, and other per-request overhead not captured by proto.Size.
+const grpcFramingOverhead = 10 * 1024 // 10 KiB
+
+// minMaxGRPCRequestSize is the minimum allowed value for maxGRPCRequestSize.
+// Values below this threshold are clamped to ensure the framing overhead
+// reservation remains meaningful.
+const minMaxGRPCRequestSize = 1024 * 1024 // 1 MiB
 
 func splitMessagesByRequestSize(messages []*messageWithCallback, maxRequestSize int) [][]*messageWithCallback {
 	if len(messages) == 0 {
@@ -340,10 +356,14 @@ func WithBatchSize(batchSize int) Opt {
 	}
 }
 
-// WithMaxGRPCRequestSize sets the max gRPC request size in bytes used for metric comparison attributes.
+// WithMaxGRPCRequestSize sets the max gRPC request size in bytes used for splitting batches.
+// Values below minMaxGRPCRequestSize (1 MiB) are clamped up to ensure the framing
+// overhead reservation remains meaningful.
 func WithMaxGRPCRequestSize(maxReqSize int) Opt {
 	return func(c *Client) {
-		c.maxGRPCRequestSize = maxReqSize
+		clamped := max(maxReqSize, minMaxGRPCRequestSize)
+		c.maxGRPCRequestSize = clamped
+		c.effectiveMaxRequestSize = clamped - grpcFramingOverhead
 	}
 }
 
@@ -439,6 +459,14 @@ func newBatchClientMetrics() (batchClientMetrics, error) {
 	if err != nil {
 		return batchClientMetrics{}, err
 	}
+	batchSplitsTotal, err := meter.Int64Counter(
+		"chip_ingress.batch.batch_splits_total",
+		otelmetric.WithDescription("Total number of times a batch was split due to exceeding the effective gRPC request size limit (max request size minus reserved framing overhead)"),
+		otelmetric.WithUnit("{split}"),
+	)
+	if err != nil {
+		return batchClientMetrics{}, err
+	}
 
 	return batchClientMetrics{
 		sendRequestsTotal: sendRequestsTotal,
@@ -447,6 +475,7 @@ func newBatchClientMetrics() (batchClientMetrics, error) {
 		requestSizeBytes:    requestSizeBytes,
 		requestLatencyMS:    requestLatencyMS,
 		configInfo:          configInfo,
+		batchSplitsTotal:    batchSplitsTotal,
 		successStatusAttr: otelmetric.WithAttributeSet(attribute.NewSet(
 			attribute.String("status", "success"),
 		)),

--- a/pkg/chipingress/batch/client_test.go
+++ b/pkg/chipingress/batch/client_test.go
@@ -64,6 +64,43 @@ func TestNewBatchClient(t *testing.T) {
 		assert.Equal(t, 1000, cap(client.messageBuffer))
 	})
 
+	t.Run("WithMaxGRPCRequestSize", func(t *testing.T) {
+		t.Run("applies value at or above minimum", func(t *testing.T) {
+			client, err := NewBatchClient(mocks.NewClient(t), WithMaxGRPCRequestSize(4*1024*1024))
+			require.NoError(t, err)
+			assert.Equal(t, 4*1024*1024, client.maxGRPCRequestSize)
+			assert.Equal(t, 4*1024*1024-grpcFramingOverhead, client.effectiveMaxRequestSize)
+		})
+
+		t.Run("clamps value below minimum to minMaxGRPCRequestSize", func(t *testing.T) {
+			client, err := NewBatchClient(mocks.NewClient(t), WithMaxGRPCRequestSize(512))
+			require.NoError(t, err)
+			assert.Equal(t, minMaxGRPCRequestSize, client.maxGRPCRequestSize)
+			assert.Equal(t, minMaxGRPCRequestSize-grpcFramingOverhead, client.effectiveMaxRequestSize)
+		})
+
+		t.Run("clamps zero to minMaxGRPCRequestSize", func(t *testing.T) {
+			client, err := NewBatchClient(mocks.NewClient(t), WithMaxGRPCRequestSize(0))
+			require.NoError(t, err)
+			assert.Equal(t, minMaxGRPCRequestSize, client.maxGRPCRequestSize)
+			assert.Equal(t, minMaxGRPCRequestSize-grpcFramingOverhead, client.effectiveMaxRequestSize)
+		})
+
+		t.Run("clamps negative to minMaxGRPCRequestSize", func(t *testing.T) {
+			client, err := NewBatchClient(mocks.NewClient(t), WithMaxGRPCRequestSize(-1))
+			require.NoError(t, err)
+			assert.Equal(t, minMaxGRPCRequestSize, client.maxGRPCRequestSize)
+			assert.Equal(t, minMaxGRPCRequestSize-grpcFramingOverhead, client.effectiveMaxRequestSize)
+		})
+
+		t.Run("exact minimum is accepted as-is", func(t *testing.T) {
+			client, err := NewBatchClient(mocks.NewClient(t), WithMaxGRPCRequestSize(minMaxGRPCRequestSize))
+			require.NoError(t, err)
+			assert.Equal(t, minMaxGRPCRequestSize, client.maxGRPCRequestSize)
+			assert.Equal(t, minMaxGRPCRequestSize-grpcFramingOverhead, client.effectiveMaxRequestSize)
+		})
+	})
+
 	t.Run("records failure metrics when request exceeds configured max grpc size", func(t *testing.T) {
 		reader, restore := useTestMeterProvider(t)
 		defer restore()
@@ -79,8 +116,10 @@ func TestNewBatchClient(t *testing.T) {
 			WithBatchSize(1),
 			WithBatchInterval(time.Second),
 			WithMessageBuffer(10),
-			WithMaxGRPCRequestSize(maxGRPCSize),
 		)
+		require.NoError(t, err)
+		client.maxGRPCRequestSize = maxGRPCSize
+		client.effectiveMaxRequestSize = maxGRPCSize
 		require.NoError(t, err)
 		client.Start(t.Context())
 
@@ -303,8 +342,10 @@ func TestSendBatch(t *testing.T) {
 			}).
 			Times(3)
 
-		client, err := NewBatchClient(mockClient, WithMaxGRPCRequestSize(maxRequestSize))
+		client, err := NewBatchClient(mockClient)
 		require.NoError(t, err)
+		client.maxGRPCRequestSize = maxRequestSize
+		client.effectiveMaxRequestSize = maxRequestSize
 
 		messages := make([]*messageWithCallback, 0, len(events))
 		for _, event := range events {
@@ -339,14 +380,71 @@ func TestSendBatch(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
+	t.Run("records batch_splits_total metric when batch is split", func(t *testing.T) {
+		reader, restore := useTestMeterProvider(t)
+		defer restore()
+
+		events := []*chipingress.CloudEventPb{
+			largeTestEvent("split-metric-1"),
+			largeTestEvent("split-metric-2"),
+			largeTestEvent("split-metric-3"),
+		}
+		// Set maxRequestSize so that 2 events fit but 3 do not, forcing a split.
+		maxRequestSize := proto.Size(&chipingress.CloudEventBatch{Events: events[:2]})
+
+		mockClient := mocks.NewClient(t)
+		done := make(chan struct{})
+		var mu sync.Mutex
+		var publishCount int
+
+		mockClient.
+			On("PublishBatch", mock.Anything, mock.Anything).
+			Return(&chipingress.PublishResponse{}, nil).
+			Run(func(args mock.Arguments) {
+				mu.Lock()
+				publishCount++
+				if publishCount == 2 {
+					close(done)
+				}
+				mu.Unlock()
+			})
+
+		client, err := NewBatchClient(mockClient)
+		require.NoError(t, err)
+		client.maxGRPCRequestSize = maxRequestSize
+		client.effectiveMaxRequestSize = maxRequestSize
+
+		messages := make([]*messageWithCallback, 0, len(events))
+		for _, event := range events {
+			messages = append(messages, &messageWithCallback{event: event})
+		}
+
+		client.sendBatch(t.Context(), messages)
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for split batches to be sent")
+		}
+
+		rm := collectResourceMetrics(t, reader)
+		splitsMetric := mustMetric(t, rm, "chip_ingress.batch.batch_splits_total")
+		splitsSum, ok := splitsMetric.Data.(metricdata.Sum[int64])
+		require.True(t, ok)
+		require.Len(t, splitsSum.DataPoints, 1)
+		assert.Equal(t, int64(1), splitsSum.DataPoints[0].Value)
+	})
+
 	t.Run("doesn't publish a single event over max gRPC request size", func(t *testing.T) {
 		mockClient := mocks.NewClient(t)
 		callbackDone := make(chan error, 1)
 		event := largeTestEvent("oversized-id")
 		maxRequestSize := proto.Size(&chipingress.CloudEventBatch{Events: []*chipingress.CloudEventPb{event}}) - 1
 
-		client, err := NewBatchClient(mockClient, WithMaxGRPCRequestSize(maxRequestSize))
+		client, err := NewBatchClient(mockClient)
 		require.NoError(t, err)
+		client.maxGRPCRequestSize = maxRequestSize
+		client.effectiveMaxRequestSize = maxRequestSize
 
 		client.sendBatch(t.Context(), []*messageWithCallback{
 			{
@@ -1350,7 +1448,7 @@ func TestBatchClient_Metrics(t *testing.T) {
 			WithBatchSize(1),
 			WithBatchInterval(time.Second),
 			WithMessageBuffer(10),
-			WithMaxGRPCRequestSize(2048),
+			WithMaxGRPCRequestSize(minMaxGRPCRequestSize),
 		)
 		require.NoError(t, err)
 		client.Start(t.Context())
@@ -1386,7 +1484,7 @@ func TestBatchClient_Metrics(t *testing.T) {
 		reqSize := mustMetric(t, rm, "chip_ingress.batch.request_size_bytes")
 		reqSizeHist, ok := reqSize.Data.(metricdata.Histogram[int64])
 		require.True(t, ok)
-		reqSizePoint := mustInt64HistogramPointWithIntAttr(t, reqSizeHist, "max_grpc_request_size_bytes", 2048)
+		reqSizePoint := mustInt64HistogramPointWithIntAttr(t, reqSizeHist, "max_grpc_request_size_bytes", minMaxGRPCRequestSize)
 		assert.GreaterOrEqual(t, reqSizePoint.Count, uint64(1))
 
 		latency := mustMetric(t, rm, "chip_ingress.batch.request_latency_ms")
@@ -1401,7 +1499,7 @@ func TestBatchClient_Metrics(t *testing.T) {
 		require.NotEmpty(t, configGauge.DataPoints)
 		assert.Equal(t, int64(1), configGauge.DataPoints[0].Value)
 		assert.True(t, hasIntAttr(configGauge.DataPoints[0].Attributes, "max_batch_size", 1))
-		assert.True(t, hasIntAttr(configGauge.DataPoints[0].Attributes, "max_grpc_request_size_bytes", 2048))
+		assert.True(t, hasIntAttr(configGauge.DataPoints[0].Attributes, "max_grpc_request_size_bytes", minMaxGRPCRequestSize))
 	})
 
 	t.Run("records failure counters and latency", func(t *testing.T) {
@@ -1540,11 +1638,12 @@ func BenchmarkSendBatch(b *testing.B) {
 			WithBatchSize(100),
 			WithMessageBuffer(b.N*100+10),
 			WithBatchInterval(time.Hour),
-			WithMaxGRPCRequestSize(512),
 		)
 		if err != nil {
 			b.Fatal(err)
 		}
+		client.maxGRPCRequestSize = 512
+		client.effectiveMaxRequestSize = 512
 		client.Start(b.Context())
 		defer client.Stop()
 


### PR DESCRIPTION
## Summary

Add observability for batch splitting in the chipingress batch client:

- **New metric `chip_ingress.batch.batch_splits_total`** — Int64Counter that increments each time `splitMessagesByRequestSize` produces more than one sub-batch, indicating the original batch exceeded the effective gRPC request size limit.
- **Reserve 10 KiB framing overhead** — `splitMessagesByRequestSize` now subtracts a 10 KiB buffer from `maxGRPCRequestSize` to account for gRPC framing, HTTP/2 headers, auth tokens, and tracing metadata not captured by `proto.Size`.

## Changes

- `pkg/chipingress/batch/client.go`: Add `batchSplitsTotal` counter, register it in `newBatchClientMetrics()`, record it in `sendBatch()` when a split occurs, and apply `grpcFramingOverhead` in the split logic.