### PR TITLE
feat(stellar): add ContractWriter configuration types

### DIFF
--- a/pkg/types/stellar/contract_writer.go
+++ b/pkg/types/stellar/contract_writer.go
@@ -1,0 +1,16 @@
+package stellar
+
+type ContractWriterConfig struct {
+	Contracts map[string]*ContractWriterContract `json:"contracts"`
+}
+
+type ContractWriterContract struct {
+	// The contract name (optional). When not provided, the key in the map under which this contract
+	// is stored is used.
+	Name      string                             `json:"name,omitempty"`
+	Functions map[string]*ContractWriterFunction `json:"functions"`
+}
+
+type ContractWriterFunction struct {
+	FromAddress string `json:"fromAddress"`
+}


### PR DESCRIPTION
## Description
This PR adds the configuration structs for the Stellar `ContractWriter` into `chainlink-common`. 

These types (`ContractWriterConfig`, `ContractConfig`, and `FunctionConfig`) define how the core node passes down contract and function metadata (such as `FromAddress`) to the Stellar plugin. This aligns the Stellar relayer configuration with the existing standards established for EVM, Solana, and Aptos.

## Changes
- Created `pkg/types/stellar/contract_writer.go` containing the configuration domain types.