### PR TITLE
pkg/services/orgresolver: track pass/fail metrics

### DIFF
--- a/pkg/services/orgresolver/linking.go
+++ b/pkg/services/orgresolver/linking.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -33,6 +34,9 @@ type Config struct {
 	WorkflowRegistryAddress       string
 	WorkflowRegistryChainSelector uint64
 	JWTGenerator                  JWTGenerator
+
+	Client linkingclient.LinkingServiceClient // optional
+	Meter  metric.Meter                       // optional
 }
 
 // orgResolver makes direct calls to the linking service to resolve organization IDs from workflow owners.
@@ -45,15 +49,25 @@ type orgResolver struct {
 	conn         *grpc.ClientConn // nil if client was injected
 	logger       log.SugaredLogger
 	jwtGenerator JWTGenerator
+
+	passCount metric.Int64Counter
+	failCount metric.Int64Counter
 }
 
 // NewOrgResolver creates a new org resolver with the specified configuration
+// Deprecated: Use Config.New
 func NewOrgResolver(cfg Config, logger log.Logger) (*orgResolver, error) {
-	return NewOrgResolverWithClient(cfg, nil, logger)
+	return cfg.New(logger)
 }
 
 // NewOrgResolverWithClient creates a new org resolver with an optional injected client (for testing)
+// Deprecated: Use Config.New
 func NewOrgResolverWithClient(cfg Config, client linkingclient.LinkingServiceClient, logger log.Logger) (*orgResolver, error) {
+	cfg.Client = client
+	return cfg.New(logger)
+}
+
+func (cfg *Config) New(logger log.Logger) (*orgResolver, error) {
 	resolver := &orgResolver{
 		workflowRegistryAddress:       cfg.WorkflowRegistryAddress,
 		workflowRegistryChainSelector: cfg.WorkflowRegistryChainSelector,
@@ -61,8 +75,8 @@ func NewOrgResolverWithClient(cfg Config, client linkingclient.LinkingServiceCli
 		jwtGenerator:                  cfg.JWTGenerator,
 	}
 
-	if client != nil {
-		resolver.client = client
+	if cfg.Client != nil {
+		resolver.client = cfg.Client
 	} else {
 		if cfg.URL == "" {
 			return nil, errors.New("URL is required when client is not provided")
@@ -82,6 +96,18 @@ func NewOrgResolverWithClient(cfg Config, client linkingclient.LinkingServiceCli
 
 		resolver.conn = conn
 		resolver.client = linkingclient.NewLinkingServiceClient(conn)
+	}
+
+	if cfg.Meter != nil {
+		var err error
+		resolver.passCount, err = cfg.Meter.Int64Counter("org_resolver_success")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create success count metric: %w", err)
+		}
+		resolver.failCount, err = cfg.Meter.Int64Counter("org_resolver_fail")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create failure count metric: %w", err)
+		}
 	}
 
 	return resolver, nil
@@ -119,9 +145,15 @@ func (o *orgResolver) Get(ctx context.Context, owner string) (string, error) {
 
 	resp, err := o.client.GetOrganizationFromWorkflowOwner(ctx, req)
 	if err != nil {
+		if o.failCount != nil {
+			o.failCount.Add(ctx, 1)
+		}
 		return "", fmt.Errorf("failed to fetch organization from workflow owner: %w", err)
 	}
 
+	if o.passCount != nil {
+		o.passCount.Add(ctx, 1)
+	}
 	return resp.OrganizationId, nil
 }
 


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CRE-3887
Support passing a `metric.Meter` to the org resolver to report pass/fail metrics.