### PR TITLE
Allow cre sdk tests to be optional if they aren't released yet.

### DIFF
--- a/pkg/workflows/wasm/host/standard_test.go
+++ b/pkg/workflows/wasm/host/standard_test.go
@@ -622,17 +622,23 @@ func makeOptionalTestModuleWithConfig(t *testing.T, cfg *ModuleConfig) *module {
 
 func makeTestModuleByName(t *testing.T, testName string, cfg *ModuleConfig, required bool) *module {
 	wasmName := path.Join(testName, "test.wasm")
-	cmd := exec.Command("make", wasmName) // #nosec
 	absPath, err := filepath.Abs(testPath)
 	require.NoError(t, err, "Failed to get absolute path for test directory")
+
+	// An optional test is one whose SDK feature may not be released yet, in which case its
+	// source directory won't exist. Skip only in that case; any other make failure (e.g. a
+	// compilation error in an existing test) must still fail so we don't hide regressions.
+	if !required {
+		if _, statErr := os.Stat(filepath.Join(absPath, testName)); errors.Is(statErr, os.ErrNotExist) {
+			t.Skipf("Optional test %q not found", testName)
+		}
+	}
+
+	cmd := exec.Command("make", wasmName) // #nosec
 	cmd.Dir = absPath
 
 	output, err := cmd.CombinedOutput()
-	if required {
-		require.NoError(t, err, string(output))
-	} else if err != nil {
-		t.Skip("Optional test not found")
-	}
+	require.NoError(t, err, string(output))
 
 	binary, err := os.ReadFile(filepath.Join(absPath, wasmName))
 	require.NoError(t, err)

--- a/pkg/workflows/wasm/host/standard_test.go
+++ b/pkg/workflows/wasm/host/standard_test.go
@@ -529,7 +529,7 @@ func TestStandardTeeRuntime(t *testing.T) {
 	t.Parallel()
 
 	cfg := defaultNoDAGModCfg(t)
-	m := makeTestModuleWithConfig(t, cfg)
+	m := makeOptionalTestModuleWithConfig(t, cfg)
 	mockExecutionHelper := mocks.NewMockExecutionHelper(t)
 	mockExecutionHelper.EXPECT().GetWorkflowExecutionID().Return("id")
 	mockExecutionHelper.EXPECT().GetNodeTime().RunAndReturn(func() time.Time {
@@ -612,10 +612,15 @@ func makeTestModule(t *testing.T) *module {
 
 func makeTestModuleWithConfig(t *testing.T, cfg *ModuleConfig) *module {
 	testName := strcase.ToSnake(t.Name()[len("TestStandard"):])
-	return makeTestModuleByName(t, testName, cfg)
+	return makeTestModuleByName(t, testName, cfg, true)
 }
 
-func makeTestModuleByName(t *testing.T, testName string, cfg *ModuleConfig) *module {
+func makeOptionalTestModuleWithConfig(t *testing.T, cfg *ModuleConfig) *module {
+	testName := strcase.ToSnake(t.Name()[len("TestStandard"):])
+	return makeTestModuleByName(t, testName, cfg, false)
+}
+
+func makeTestModuleByName(t *testing.T, testName string, cfg *ModuleConfig, required bool) *module {
 	wasmName := path.Join(testName, "test.wasm")
 	cmd := exec.Command("make", wasmName) // #nosec
 	absPath, err := filepath.Abs(testPath)
@@ -623,7 +628,11 @@ func makeTestModuleByName(t *testing.T, testName string, cfg *ModuleConfig) *mod
 	cmd.Dir = absPath
 
 	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(output))
+	if required {
+		require.NoError(t, err, string(output))
+	} else if err != nil {
+		t.Skip("Optional test not found")
+	}
 
 	binary, err := os.ReadFile(filepath.Join(absPath, wasmName))
 	require.NoError(t, err)


### PR DESCRIPTION
This enables testing on capabilites-dev while still allowing the standard tests to evolve for main if a feature isn't released