### PR TITLE
Add privacy as CODEOWNER for confidentialrelay and confidentialworkflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /keystore @smartcontractkit/prodsec-public @smartcontractkit/foundations
 /pkg/beholder/ @smartcontractkit/data-tooling
 /pkg/capabilities/v2/actions/confidentialhttp @smartcontractkit/privacy
+/pkg/capabilities/v2/actions/confidentialrelay @smartcontractkit/privacy @smartcontractkit/foundations
 /pkg/capabilities/v2/chain-capabilities @smartcontractkit/keystone @smartcontractkit/capabilities-team @smartcontractkit/bix-framework
 /pkg/chains/evm @smartcontractkit/bix-framework
 /pkg/chipingress/ @smartcontractkit/data-tooling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /pkg/beholder/ @smartcontractkit/data-tooling
 /pkg/capabilities/v2/actions/confidentialhttp @smartcontractkit/privacy
 /pkg/capabilities/v2/actions/confidentialrelay @smartcontractkit/privacy
+/pkg/capabilities/v2/actions/confidentialworkflow @smartcontractkit/privacy
 /pkg/capabilities/v2/chain-capabilities @smartcontractkit/keystone @smartcontractkit/capabilities-team @smartcontractkit/bix-framework
 /pkg/chains/evm @smartcontractkit/bix-framework
 /pkg/chipingress/ @smartcontractkit/data-tooling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /keystore @smartcontractkit/prodsec-public @smartcontractkit/foundations
 /pkg/beholder/ @smartcontractkit/data-tooling
 /pkg/capabilities/v2/actions/confidentialhttp @smartcontractkit/privacy
-/pkg/capabilities/v2/actions/confidentialrelay @smartcontractkit/privacy @smartcontractkit/foundations
+/pkg/capabilities/v2/actions/confidentialrelay @smartcontractkit/privacy
 /pkg/capabilities/v2/chain-capabilities @smartcontractkit/keystone @smartcontractkit/capabilities-team @smartcontractkit/bix-framework
 /pkg/chains/evm @smartcontractkit/bix-framework
 /pkg/chipingress/ @smartcontractkit/data-tooling


### PR DESCRIPTION
confidentialrelay (relay-DON authorization logic, PRIV-433) and confidentialworkflow are privacy-owned capability code. Neither had a specific CODEOWNERS entry, so both fell under the catch-all @smartcontractkit/foundations and privacy reviews were not required as code owners (e.g. #2109).

This adds explicit @smartcontractkit/privacy entries for both, mirroring the existing confidentialhttp entry. All three confidential capability folders under pkg/capabilities/v2/actions/ are now privacy-owned.