### PR TITLE
SDK Standard Test for capability errors

### DIFF
--- a/pkg/capabilities/errors/error_codes.go
+++ b/pkg/capabilities/errors/error_codes.go
@@ -135,6 +135,29 @@ const (
 	InsufficientObservations ErrorCode = 102
 )
 
+// AllErrorCodes lists every defined capability error code in ascending order.
+var AllErrorCodes = []ErrorCode{
+	Canceled,
+	Unknown,
+	InvalidArgument,
+	DeadlineExceeded,
+	NotFound,
+	AlreadyExists,
+	PermissionDenied,
+	ResourceExhausted,
+	FailedPrecondition,
+	Aborted,
+	OutOfRange,
+	Unimplemented,
+	Internal,
+	Unavailable,
+	DataLoss,
+	Unauthenticated,
+	ConsensusFailed,
+	LimitExceeded,
+	InsufficientObservations,
+}
+
 // String returns the string representation of the ErrorCode.
 func (e ErrorCode) String() string {
 	if s, ok := errorCodeToString[e]; ok {

--- a/pkg/workflows/wasm/host/standard_test.go
+++ b/pkg/workflows/wasm/host/standard_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/host/mocks"
 
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/protoc/pkg/test_capabilities/actionandtrigger"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/protoc/pkg/test_capabilities/basicaction"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/protoc/pkg/test_capabilities/basictrigger"
@@ -72,6 +73,44 @@ func TestStandardErrors(t *testing.T) {
 	}).Maybe()
 	errMsg := runWithBasicTrigger(t, mockExecutionHelper)
 	assert.Contains(t, errMsg.GetError(), "workflow execution failure")
+}
+
+func TestStandardCapabilityErrors(t *testing.T) {
+	t.Parallel()
+	mockExecutionHelper := mocks.NewMockExecutionHelper(t)
+	mockExecutionHelper.EXPECT().GetWorkflowExecutionID().Return("id")
+	mockExecutionHelper.EXPECT().GetNodeTime().RunAndReturn(func() time.Time {
+		return time.Now()
+	}).Maybe()
+	mockExecutionHelper.EXPECT().GetDONTime().RunAndReturn(func() (time.Time, error) {
+		return time.Now(), nil
+	}).Maybe()
+
+	callIndex := 0
+	mockExecutionHelper.EXPECT().CallCapability(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, request *sdk.CapabilityRequest) (*sdk.CapabilityResponse, error) {
+		assert.Equal(t, "basic-test-action@1.0.0", request.Id)
+		assert.Equal(t, "PerformAction", request.Method)
+		input := &basicaction.Inputs{}
+		assert.NoError(t, request.Payload.UnmarshalTo(input))
+
+		if callIndex < len(caperrors.AllErrorCodes) {
+			code := caperrors.AllErrorCodes[callIndex]
+			callIndex++
+			return nil, caperrors.NewPublicSystemError(errors.New(code.String()+" error"), code)
+		}
+
+		callIndex++
+		payload, err := anypb.New(&basicaction.Outputs{AdaptedThing: "Done"})
+		require.NoError(t, err)
+		return &sdk.CapabilityResponse{
+			Response: &sdk.CapabilityResponse_Payload{Payload: payload},
+		}, nil
+	}).Times(len(caperrors.AllErrorCodes) + 1)
+
+	m := makeTestModule(t)
+	request := triggerExecuteRequest(t, 0, &basictrigger.Outputs{CoolOutput: anyTestTriggerValue})
+	result := executeWithResult[string](t, m, request, mockExecutionHelper)
+	assert.Equal(t, "Done", result)
 }
 
 func TestStandardCapabilityCallsAreAsync(t *testing.T) {

--- a/pkg/workflows/wasm/host/standard_tests/capability_errors/main_wasip1.go
+++ b/pkg/workflows/wasm/host/standard_tests/capability_errors/main_wasip1.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+
+	caperrors "github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/protoc/pkg/test_capabilities/basicaction"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host/internal/rawsdk"
+	"github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+)
+
+func main() {
+	for _, code := range caperrors.AllErrorCodes {
+		err := rawsdk.DoRequestErr(
+			"basic-test-action@1.0.0",
+			"PerformAction",
+			sdk.Mode_MODE_DON,
+			&basicaction.Inputs{InputThing: true},
+		)
+		if err == nil {
+			rawsdk.SendError(fmt.Errorf("expected capability error for code %s", code))
+		}
+
+		capErr := caperrors.DeserializeErrorFromString(err.Error())
+		if capErr.Code() != code {
+			rawsdk.SendError(fmt.Errorf("expected error code %s, got %s", code, capErr.Code()))
+		}
+		if capErr.Origin() != caperrors.OriginSystem {
+			rawsdk.SendError(fmt.Errorf("expected system origin for code %s, got %s", code, capErr.Origin()))
+		}
+		if capErr.Visibility() != caperrors.VisibilityPublic {
+			rawsdk.SendError(fmt.Errorf("expected public visibility for code %s, got %s", code, capErr.Visibility()))
+		}
+	}
+
+	output := &basicaction.Outputs{}
+	rawsdk.DoRequest(
+		"basic-test-action@1.0.0",
+		"PerformAction",
+		sdk.Mode_MODE_DON,
+		&basicaction.Inputs{InputThing: true},
+		output,
+	)
+	if output.AdaptedThing != "Done" {
+		rawsdk.SendError(fmt.Errorf("expected Done response, got %s", output.AdaptedThing))
+	}
+
+	rawsdk.SendResponse("Done")
+}


### PR DESCRIPTION
The standard test defined here is used to check capability error handling, this test is also used in the SDK to ensure that new error codes stay in sync.
