### PR TITLE
Regenerate confidentialworkflow + solana from chainlink-protos #387/#398

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.100
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260528204832-58c7145c53f8
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4
-	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a
+	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260611115617-b3feadd222f2
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260205130626-db2a2aab956b
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.202605282
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260528204832-58c7145c53f8/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4 h1:GCzrxDWn3b7jFfEA+WiYRi8CKoegsayiDoJBCjYkneE=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4/go.mod h1:HHGeDUpAsPa0pmOx7wrByCitjQ0mbUxf0R9v+g67uCA=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a h1:alnfvQgCKPFqsfijZQnr6Sbus2GT5YZ9BT/KzVrbszE=
-github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260609153034-c8423a41ef9a/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260611115617-b3feadd222f2 h1:Pfl5SreAWpMNU7YJVgHo3jTx/scdvkCS5nXIbRFHGLM=
+github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260611115617-b3feadd222f2/go.mod h1:vTFHTCbLui4Vn8fTmAadfE3rdnvfrDwOmMujmW857D0=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b h1:QuI6SmQFK/zyUlVWEf0GMkiUYBPY4lssn26nKSd/bOM=
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
 github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260205130626-db2a2aab956b h1:36knUpKHHAZ86K4FGWXtx8i/EQftGdk2bqCoEu/Cha8=

--- a/pkg/capabilities/v2/actions/confidentialworkflow/client.pb.go
+++ b/pkg/capabilities/v2/actions/confidentialworkflow/client.pb.go
@@ -84,10 +84,12 @@ type WorkflowExecution struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// workflow_id identifies the workflow to execute.
 	WorkflowId string `protobuf:"bytes,1,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
-	// binary_url is retained for backward compatibility with existing consumers.
-	// New consumers must use ConfidentialWorkflowRequest.binary_url, which lives
-	// outside the hash envelope so each node can mint its own per-node URL
-	// without breaking F+1 quorum. See ConfidentialWorkflowRequest.binary_url.
+	// binary_url is the URL from which the enclave fetches the compiled WASM
+	// binary. It lives inside WorkflowExecution (PublicData), covered by
+	// ComputeRequest.Hash() for F+1 quorum, so every node agrees on the same
+	// canonical locator. Authentication to the storage service is handled out of
+	// band by the fetch sidecar, so this is a stable, node-agnostic locator
+	// rather than a per-node pre-signed URL.
 	BinaryUrl string `protobuf:"bytes,2,opt,name=binary_url,json=binaryUrl,proto3" json:"binary_url,omitempty"`
 	// binary_hash is the expected SHA-256 hash of the WASM binary, for integrity verification.
 	BinaryHash []byte `protobuf:"bytes,3,opt,name=binary_hash,json=binaryHash,proto3" json:"binary_hash,omitempty"`
@@ -215,17 +217,12 @@ type ConfidentialWorkflowRequest struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	VaultDonSecrets []*SecretIdentifier    `protobuf:"bytes,1,rep,name=vault_don_secrets,json=vaultDonSecrets,proto3" json:"vault_don_secrets,omitempty"`
 	Execution       *WorkflowExecution     `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
-	// binary_url is the pre-signed URL used by the enclave to fetch the WASM
-	// binary. It lives here, on ConfidentialWorkflowRequest, rather than inside
-	// WorkflowExecution: every workflow DON node mints its own URL with its own
-	// signature and expiry timestamp, so the value differs across nodes.
-	// WorkflowExecution serializes into ComputeRequest.PublicData, which is
-	// covered by ComputeRequest.Hash() for F+1 quorum matching at the enclave.
-	// A per-node value inside that envelope would break quorum.
+	// Deprecated: the per-node pre-signed URL approach is superseded. binary_url
+	// now travels inside WorkflowExecution (PublicData) as a canonical locator,
+	// with authentication to the storage service handled out of band by the fetch
+	// sidecar. Retained for back-compat; no longer populated.
 	//
-	// The integrity anchor for the fetched bytes is execution.binary_hash, inside
-	// PublicData (and therefore signed and quorum-checked). The URL is a fetch
-	// hint; tampering with it is caught by the hash check on the returned bytes.
+	// Deprecated: Marked as deprecated in capabilities/compute/confidentialworkflow/v1alpha/client.proto.
 	BinaryUrl     string `protobuf:"bytes,3,opt,name=binary_url,json=binaryUrl,proto3" json:"binary_url,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -275,6 +272,7 @@ func (x *ConfidentialWorkflowRequest) GetExecution() *WorkflowExecution {
 	return nil
 }
 
+// Deprecated: Marked as deprecated in capabilities/compute/confidentialworkflow/v1alpha/client.proto.
 func (x *ConfidentialWorkflowRequest) GetBinaryUrl() string {
 	if x != nil {
 		return x.BinaryUrl
@@ -405,12 +403,12 @@ const file_capabilities_compute_confidentialworkflow_v1alpha_client_proto_rawDes
 	"\fexecution_id\x18\x06 \x01(\tR\vexecutionId\x12\x15\n" +
 	"\x06org_id\x18\a \x01(\tR\x05orgId\x12=\n" +
 	"\frequirements\x18\b \x01(\v2\x19.sdk.v1alpha.RequirementsR\frequirements\x12K\n" +
-	"\x13sdk_execute_request\x18\t \x01(\v2\x1b.sdk.v1alpha.ExecuteRequestR\x11sdkExecuteRequest\"\x91\x02\n" +
+	"\x13sdk_execute_request\x18\t \x01(\v2\x1b.sdk.v1alpha.ExecuteRequestR\x11sdkExecuteRequest\"\x95\x02\n" +
 	"\x1bConfidentialWorkflowRequest\x12o\n" +
 	"\x11vault_don_secrets\x18\x01 \x03(\v2C.capabilities.compute.confidentialworkflow.v1alpha.SecretIdentifierR\x0fvaultDonSecrets\x12b\n" +
-	"\texecution\x18\x02 \x01(\v2D.capabilities.compute.confidentialworkflow.v1alpha.WorkflowExecutionR\texecution\x12\x1d\n" +
+	"\texecution\x18\x02 \x01(\v2D.capabilities.compute.confidentialworkflow.v1alpha.WorkflowExecutionR\texecution\x12!\n" +
 	"\n" +
-	"binary_url\x18\x03 \x01(\tR\tbinaryUrl\"\x99\x01\n" +
+	"binary_url\x18\x03 \x01(\tB\x02\x18\x01R\tbinaryUrl\"\x99\x01\n" +
 	"\x1cConfidentialWorkflowResponse\x12)\n" +
 	"\x10execution_result\x18\x01 \x01(\fR\x0fexecutionResult\x12N\n" +
 	"\x14sdk_execution_result\x18\x02 \x01(\v2\x1c.sdk.v1alpha.ExecutionResultR\x12sdkExecutionResult\"H\n" +

--- a/pkg/capabilities/v2/chain-capabilities/solana/client.pb.go
+++ b/pkg/capabilities/v2/chain-capabilities/solana/client.pb.go
@@ -3981,7 +3981,7 @@ const file_capabilities_blockchain_solana_v1alpha_client_proto_rawDesc = "" +
 	"\x17COMPARISON_OPERATOR_LTE\x10\x05*\x82\x01\n" +
 	"\x1fReceiverContractExecutionStatus\x12.\n" +
 	"*RECEIVER_CONTRACT_EXECUTION_STATUS_SUCCESS\x10\x00\x12/\n" +
-	"+RECEIVER_CONTRACT_EXECUTION_STATUS_REVERTED\x10\x012\x9b\r\n" +
+	"+RECEIVER_CONTRACT_EXECUTION_STATUS_REVERTED\x10\x012\xb7\r\n" +
 	"\x06Client\x12\xa4\x01\n" +
 	"\x16GetAccountInfoWithOpts\x12E.capabilities.blockchain.solana.v1alpha.GetAccountInfoWithOptsRequest\x1aC.capabilities.blockchain.solana.v1alpha.GetAccountInfoWithOptsReply\x12\x80\x01\n" +
 	"\n" +
@@ -3995,10 +3995,12 @@ const file_capabilities_blockchain_solana_v1alpha_client_proto_rawDesc = "" +
 	"\x0eGetTransaction\x12=.capabilities.blockchain.solana.v1alpha.GetTransactionRequest\x1a;.capabilities.blockchain.solana.v1alpha.GetTransactionReply\x12|\n" +
 	"\n" +
 	"LogTrigger\x12?.capabilities.blockchain.solana.v1alpha.FilterLogTriggerRequest\x1a+.capabilities.blockchain.solana.v1alpha.Log0\x01\x12\x83\x01\n" +
-	"\vWriteReport\x12:.capabilities.blockchain.solana.v1alpha.WriteReportRequest\x1a8.capabilities.blockchain.solana.v1alpha.WriteReportReply\x1aE\x82\xb5\x18A\b\x01\x12\fsolana@1.0.0\x1a/\n" +
-	"\rChainSelector\x12\x1e\x12\x1c\n" +
+	"\vWriteReport\x12:.capabilities.blockchain.solana.v1alpha.WriteReportRequest\x1a8.capabilities.blockchain.solana.v1alpha.WriteReportReply\x1aa\x82\xb5\x18]\b\x01\x12\fsolana@1.0.0\x1aK\n" +
+	"\rChainSelector\x12:\x128\n" +
 	"\x1a\n" +
-	"\rsolana-devnet\x10\xdf\uf327\xa9\xfc\xb1\xf6\xe3\x01b\x06proto3"
+	"\rsolana-devnet\x10\xdf\uf327\xa9\xfc\xb1\xf6\xe3\x01\n" +
+	"\x1a\n" +
+	"\x0esolana-mainnet\x10\xe7\x93ߌ\xb6\x9f\xae\xdd\x01b\x06proto3"
 
 var (
 	file_capabilities_blockchain_solana_v1alpha_client_proto_rawDescOnce sync.Once


### PR DESCRIPTION
Bumps `chainlink-protos/cre/go` to the #387 merge commit (`b3feadd`) and
regenerates the affected capability packages.

- **confidentialworkflow** (protos #387, the binary-fetch pivot):
  `ConfidentialWorkflowRequest.binary_url` is now `[deprecated = true]`. The
  per-node outside-envelope URL is superseded; `binary_url` moves back into
  `WorkflowExecution` (PublicData, covered by the consensus hash) as the
  canonical locator. The Go field gets a `// Deprecated:` marker so downstream
  code still using it is flagged.
- **solana** (protos #398, Solana mainnet): in the same bump range, so its
  generated client is refreshed too.

Generated via `make generate`; `make gomodtidy` and `make modgraph` produce no
further delta. No hand-edits to generated files.
