### PR TITLE
DurableEmitter: Add extension to messages

### DIFF
--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -325,6 +325,8 @@ func (d *DurableEmitter) Emit(ctx context.Context, body []byte, attrKVs ...any) 
 			return err
 		}
 
+		event.SetExtension("emitter", "DurableEmitter")
+
 		eventPb, err := chipingress.EventToProto(event)
 		if err != nil {
 			emitFail()


### PR DESCRIPTION
Add extension to differentiate between beholder messages for tesing with mock chip server.