### PR TITLE
bump chipingress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.100
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260528204832-58c7145c53f8
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260611211700-a034c8d80da3
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260611123141-db97012a6c32
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/smartcontractkit/chain-selectors v1.0.100 h1:wpiSpmI/eFjY+wx/nPr5VuNF4hki0prIBMKEaQWn3g4=
 github.com/smartcontractkit/chain-selectors v1.0.100/go.mod h1:qy7whtgG5g+7z0jt0nRyii9bLND9m15NZTzuQPkMZ5w=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260528204832-58c7145c53f8 h1:5O2qAtvBLzTHBeSIPcxt9i9BCqqOyeroVxN0xbXwoS0=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260528204832-58c7145c53f8/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260611211700-a034c8d80da3 h1:OIIN2f48uyyj/eNJ7smPLINes8w9CBQdteQ6T/cUrpY=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260611211700-a034c8d80da3/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4 h1:GCzrxDWn3b7jFfEA+WiYRi8CKoegsayiDoJBCjYkneE=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4/go.mod h1:HHGeDUpAsPa0pmOx7wrByCitjQ0mbUxf0R9v+g67uCA=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260611123141-db97012a6c32 h1:GNl+lLK0QCakqA1J1i7FoOai2JrOGOzNzSniMijaCjA=


### PR DESCRIPTION
## What's Changed

This bump spans 2 commits on `pkg/chipingress`:

| Commit | PR | Summary |
|---|---|---|
| `6a4c28faa` | #2085 | Batch partial delivery support |
| `050026b00` | #2136 | Explicit histogram buckets for `request_size_bytes` |

**Range:** `58c7145c53f8` → `a034c8d80da3` · **8 files, +1085 / −158**

<details>
<summary>Files changed</summary>

```
pkg/chipingress/batch/client.go            | +213
pkg/chipingress/batch/client_test.go       | +415
pkg/chipingress/client.go                  |  +37
pkg/chipingress/client_test.go             | +107
pkg/chipingress/pb/chip_ingress.pb.go      | +352
pkg/chipingress/pb/chip_ingress.proto      |  +78
pkg/chipingress/pb/chip_ingress_grpc.pb.go |  +38
pkg/chipingress/types.go                   |   +3
```

</details>

---

### 1. Proto / API (#2085)

`PublishBatch` is no longer strictly atomic. New behavior:

- **Default (partial delivery):** `transaction_enabled` unset or `false` → valid events are produced; invalid ones return per-event errors in `PublishResponse.results`
- **All-or-nothing:** `transaction_enabled = true` → any per-event failure fails the whole batch

**New proto types:**
- `PublishOptions` with optional `bool transaction_enabled`
- `PublishErrorCode` enum (validation, schema missing, encode error, domain misconfig, …)
- `PublishError` on `PublishResult` (field renamed `eventId` → `event_id`)
- `CloudEventBatch.options` field

---

### 2. Client layer (`client.go`, `types.go`)

- `EventsToBatchWithOpts(events, opts...)` — new; `EventsToBatch` delegates to it
- `WithTransactionEnabled(bool) BatchOpt` — always emits `PublishOptions` on the wire
- Default: `PublishOptions{TransactionEnabled: false}` (explicit partial delivery)
- Type aliases added: `PublishOptions`, `PublishError`, `PublishErrorCode`

---

### 3. Batch client (`batch/client.go`)

- `WithTransactionEnabled(bool)` opt (default `false`)
- `PublishError` type + error code constants (including client-side `ErrCodeResultsMismatch`)
- On partial delivery: dispatches per-event callbacks from `resp.Results` via `completeBatchCallbacksFromResults`
- On RPC error or `transaction_enabled=true`: all callbacks get the same error
- `newBatchRequest` always includes `PublishOptions`
- New metric: `chip_ingress.batch.results_mismatch_total`
- Config gauge now includes `transaction_enabled`

---

### 4. Metrics (#2136)

`chip_ingress.batch.request_size_bytes` histogram gets explicit buckets:

`1KiB · 4KiB · 16KiB · 64KiB · 256KiB · 512KiB · 1MiB · 2MiB · 4MiB · 8MiB · 10MiB`

---

### 5. Tests

Large additions in `batch/client_test.go` and `client_test.go` covering partial delivery callbacks, transaction modes, proto roundtrips, and result-count mismatches.