### PR TITLE
grafana: change default exec err state to Error to match Grafana default

### DIFF
--- a/observability-lib/grafana/alerts.go
+++ b/observability-lib/grafana/alerts.go
@@ -210,7 +210,7 @@ func NewAlertRule(options *AlertOptions) *alerting.RuleBuilder {
 	}
 
 	if options.RuleExecErrState == "" {
-		options.RuleExecErrState = alerting.RuleExecErrStateAlerting
+		options.RuleExecErrState = alerting.RuleExecErrStateError
 	}
 
 	if options.QueryRefCondition == "" {


### PR DESCRIPTION
change default exec err state to Error to match Grafana default