### PR TITLE
teeattestation: expose parsed Nitro attestation via ValidateAndParse

### DIFF
--- a/pkg/teeattestation/nitro/fake/fake.go
+++ b/pkg/teeattestation/nitro/fake/fake.go
@@ -96,9 +96,24 @@ func NewAttestor() (*Attestor, error) {
 	}, nil
 }
 
+// Option customizes the optional fields of a fake attestation document.
+type Option func(*attestationDocument)
+
+// WithNonce sets the attestation nonce field.
+func WithNonce(nonce []byte) Option {
+	return func(d *attestationDocument) { d.Nonce = nonce }
+}
+
+// WithPublicKey sets the attestation public_key field, modeling an enclave
+// that publishes a long-lived identity key.
+func WithPublicKey(publicKey []byte) Option {
+	return func(d *attestationDocument) { d.PublicKey = publicKey }
+}
+
 // CreateAttestation builds a COSE Sign1 document encoding a Nitro-like
-// attestation with the given userData.
-func (f *Attestor) CreateAttestation(userData []byte) ([]byte, error) {
+// attestation with the given userData. Optional nonce and public_key fields
+// can be set via opts.
+func (f *Attestor) CreateAttestation(userData []byte, opts ...Option) ([]byte, error) {
 	doc := attestationDocument{
 		ModuleID:    "fake-enclave-module",
 		Timestamp:   uint64(time.Now().UnixMilli()), //nolint:gosec // timestamp is always positive
@@ -107,6 +122,9 @@ func (f *Attestor) CreateAttestation(userData []byte) ([]byte, error) {
 		Certificate: f.leafCertDER,
 		CABundle:    [][]byte{f.rootCertDER},
 		UserData:    userData,
+	}
+	for _, opt := range opts {
+		opt(&doc)
 	}
 
 	payloadBytes, err := cbor.Marshal(doc)
@@ -153,6 +171,12 @@ func (f *Attestor) CreateAttestation(userData []byte) ([]byte, error) {
 		return nil, fmt.Errorf("cbor encode cose sign1: %w", err)
 	}
 	return result, nil
+}
+
+// LeafPublicKeyDER returns the SPKI (DER) encoding of the leaf certificate
+// public key, matching the format of nitro.Document.LeafPublicKey.
+func (f *Attestor) LeafPublicKeyDER() ([]byte, error) {
+	return x509.MarshalPKIXPublicKey(&f.leafKey.PublicKey)
 }
 
 // CARoots returns an x509.CertPool containing the fake root CA certificate.

--- a/pkg/teeattestation/nitro/validate.go
+++ b/pkg/teeattestation/nitro/validate.go
@@ -46,6 +46,36 @@ type PCRs struct {
 // Downloaded from: https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip
 const DefaultCARoots = "-----BEGIN CERTIFICATE-----\nMIICETCCAZagAwIBAgIRAPkxdWgbkK/hHUbMtOTn+FYwCgYIKoZIzj0EAwMwSTEL\nMAkGA1UEBhMCVVMxDzANBgNVBAoMBkFtYXpvbjEMMAoGA1UECwwDQVdTMRswGQYD\nVQQDDBJhd3Mubml0cm8tZW5jbGF2ZXMwHhcNMTkxMDI4MTMyODA1WhcNNDkxMDI4\nMTQyODA1WjBJMQswCQYDVQQGEwJVUzEPMA0GA1UECgwGQW1hem9uMQwwCgYDVQQL\nDANBV1MxGzAZBgNVBAMMEmF3cy5uaXRyby1lbmNsYXZlczB2MBAGByqGSM49AgEG\nBSuBBAAiA2IABPwCVOumCMHzaHDimtqQvkY4MpJzbolL//Zy2YlES1BR5TSksfbb\n48C8WBoyt7F2Bw7eEtaaP+ohG2bnUs990d0JX28TcPQXCEPZ3BABIeTPYwEoCWZE\nh8l5YoQwTcU/9KNCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUkCW1DdkF\nR+eWw5b6cp3PmanfS5YwDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49BAMDA2kAMGYC\nMQCjfy+Rocm9Xue4YnwWmNJVA44fA0P5W2OpYow9OYCVRaEevL8uO1XYru5xtMPW\nrfMCMQCi85sWBbJwKKXdS6BptQFuZbT73o/gBh1qUxl/nNr12UO8Yfwr6wPLb+6N\nIwLz3/Y=\n-----END CERTIFICATE-----\n"
 
+// Document holds the validated, parsed fields of a Nitro attestation that a
+// caller needs in order to bind an attestation to a specific enclave identity
+// and to check freshness. A Document is returned only after the full
+// validation chain (certificate chain, COSE signature, expected user data,
+// trusted PCR0/1/2) has passed.
+type Document struct {
+	// PCRs holds every platform configuration register present in the
+	// attestation, keyed by index. PCR0/1/2 have already been checked against
+	// the trusted measurements; higher PCRs (e.g. 3/4/8) are exposed unchecked.
+	PCRs map[uint][]byte
+	// LeafPublicKey is the SPKI (DER) of the attestation's end-entity
+	// certificate public key. AWS rotates the end-entity certificate per
+	// enclave instance (roughly every few hours), so this is not a stable
+	// identity anchor on its own.
+	LeafPublicKey []byte
+	// PublicKey is the enclave-supplied public_key field of the attestation
+	// (nil if the enclave did not set one). This is the field an enclave can
+	// use to publish a long-lived identity key it generated inside the TEE.
+	PublicKey []byte
+	// UserData is the attestation user_data field. It has already been checked
+	// to equal the expectedUserData argument.
+	UserData []byte
+	// Nonce is the attestation nonce field (nil if the enclave did not set
+	// one). ValidateAndParse does NOT check it: callers that want replay
+	// protection must compare it against a freshly generated challenge.
+	Nonce []byte
+	// ModuleID is the attestation module_id field.
+	ModuleID string
+}
+
 // ValidateAttestation verifies an AWS Nitro attestation document against
 // expected user data and trusted PCR measurements. Always validates against
 // the AWS Nitro Enclaves root certificate.
@@ -53,49 +83,75 @@ const DefaultCARoots = "-----BEGIN CERTIFICATE-----\nMIICETCCAZagAwIBAgIRAPkxdWg
 // For testing with fake enclaves, use ValidateAttestationWithRoots or inject
 // a custom validator function.
 func ValidateAttestation(attestation, expectedUserData, trustedMeasurements []byte) error {
-	return ValidateAttestationWithRoots(attestation, expectedUserData, trustedMeasurements, DefaultCARoots)
+	_, err := ValidateAndParse(attestation, expectedUserData, trustedMeasurements)
+	return err
 }
 
 // ValidateAttestationWithRoots verifies an AWS Nitro attestation document
 // using a custom CA root certificate. This is primarily for testing with
 // fake enclaves that use self-signed CA roots.
 func ValidateAttestationWithRoots(attestation, expectedUserData, trustedMeasurements []byte, caRootsPEM string) error {
+	_, err := ValidateAndParseWithRoots(attestation, expectedUserData, trustedMeasurements, caRootsPEM)
+	return err
+}
+
+// ValidateAndParse runs the same validation as ValidateAttestation and, on
+// success, returns the parsed attestation fields. Callers that need to bind
+// the attestation to a specific enclave identity (via Document.PublicKey or
+// Document.LeafPublicKey) or to check freshness (via Document.Nonce) should
+// use this instead of ValidateAttestation.
+func ValidateAndParse(attestation, expectedUserData, trustedMeasurements []byte) (*Document, error) {
+	return ValidateAndParseWithRoots(attestation, expectedUserData, trustedMeasurements, DefaultCARoots)
+}
+
+// ValidateAndParseWithRoots is ValidateAndParse against a custom CA root
+// certificate. This is primarily for testing with fake enclaves that use
+// self-signed CA roots.
+func ValidateAndParseWithRoots(attestation, expectedUserData, trustedMeasurements []byte, caRootsPEM string) (*Document, error) {
 	if attestation == nil {
-		return errors.New("attestation is nil")
+		return nil, errors.New("attestation is nil")
 	}
 
 	pool := x509.NewCertPool()
 	ok := pool.AppendCertsFromPEM([]byte(caRootsPEM))
 	if !ok {
-		return errors.New("failed to parse CA roots")
+		return nil, errors.New("failed to parse CA roots")
 	}
 	result, err := verifyAttestationDocument(attestation, pool, time.Now())
 	if err != nil {
-		return fmt.Errorf("failed to verify nitro attestation: %w", err)
+		return nil, fmt.Errorf("failed to verify nitro attestation: %w", err)
 	}
 	if !result.signatureOK {
-		return errors.New("signature verification failed")
+		return nil, errors.New("signature verification failed")
 	}
 
 	if !bytes.Equal(expectedUserData, result.document.UserData) {
-		return fmt.Errorf("expected user data %x, got %x", expectedUserData, result.document.UserData)
+		return nil, fmt.Errorf("expected user data %x, got %x", expectedUserData, result.document.UserData)
 	}
 
 	var trustedPCRs PCRs
 	if err := json.Unmarshal(trustedMeasurements, &trustedPCRs); err != nil {
-		return fmt.Errorf("failed to unmarshal trusted PCRs: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal trusted PCRs: %w", err)
 	}
 	if len(result.document.PCRs) < 3 {
-		return fmt.Errorf("attestation document has %d PCRs, need at least 3", len(result.document.PCRs))
+		return nil, fmt.Errorf("attestation document has %d PCRs, need at least 3", len(result.document.PCRs))
 	}
 	if !bytes.Equal(result.document.PCRs[0], trustedPCRs.PCR0) {
-		return fmt.Errorf("PCR0 mismatch: expected %x", trustedPCRs.PCR0)
+		return nil, fmt.Errorf("PCR0 mismatch: expected %x", trustedPCRs.PCR0)
 	}
 	if !bytes.Equal(result.document.PCRs[1], trustedPCRs.PCR1) {
-		return fmt.Errorf("PCR1 mismatch: expected %x", trustedPCRs.PCR1)
+		return nil, fmt.Errorf("PCR1 mismatch: expected %x", trustedPCRs.PCR1)
 	}
 	if !bytes.Equal(result.document.PCRs[2], trustedPCRs.PCR2) {
-		return fmt.Errorf("PCR2 mismatch: expected %x", trustedPCRs.PCR2)
+		return nil, fmt.Errorf("PCR2 mismatch: expected %x", trustedPCRs.PCR2)
 	}
-	return nil
+
+	return &Document{
+		PCRs:          result.document.PCRs,
+		LeafPublicKey: result.leafPublicKey,
+		PublicKey:     result.document.PublicKey,
+		UserData:      result.document.UserData,
+		Nonce:         result.document.Nonce,
+		ModuleID:      result.document.ModuleID,
+	}, nil
 }

--- a/pkg/teeattestation/nitro/validate_test.go
+++ b/pkg/teeattestation/nitro/validate_test.go
@@ -3,6 +3,7 @@ package nitro
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/teeattestation"
@@ -47,4 +48,49 @@ func TestValidateAttestation_WrongPCRs(t *testing.T) {
 	err = ValidateAttestationWithRoots(doc, userData, wrongPCRs, fa.CARootsPEM())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "PCR0 mismatch")
+}
+
+func TestValidateAndParse_SurfacesIdentityFields(t *testing.T) {
+	fa, err := nitrofake.NewAttestor()
+	require.NoError(t, err)
+
+	userData := teeattestation.DomainHash("test-tag", []byte(`{"key":"value"}`))
+	nonce := []byte("request-id-as-nonce")
+	identityKey := []byte("enclave-long-lived-identity-pubkey")
+
+	doc, err := fa.CreateAttestation(userData,
+		nitrofake.WithNonce(nonce),
+		nitrofake.WithPublicKey(identityKey),
+	)
+	require.NoError(t, err)
+
+	parsed, err := ValidateAndParseWithRoots(doc, userData, fa.TrustedPCRsJSON(), fa.CARootsPEM())
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	assert.Equal(t, userData, parsed.UserData)
+	assert.Equal(t, nonce, parsed.Nonce)
+	assert.Equal(t, identityKey, parsed.PublicKey)
+	assert.NotEmpty(t, parsed.PCRs)
+
+	wantLeaf, err := fa.LeafPublicKeyDER()
+	require.NoError(t, err)
+	assert.Equal(t, wantLeaf, parsed.LeafPublicKey)
+}
+
+// ValidateAndParse does not check the nonce itself; freshness is the caller's
+// responsibility. A mismatched user data still fails, and the same validation
+// failures surface as for ValidateAttestation.
+func TestValidateAndParse_FailsOnWrongUserData(t *testing.T) {
+	fa, err := nitrofake.NewAttestor()
+	require.NoError(t, err)
+
+	userData := teeattestation.DomainHash("test-tag", []byte(`{"key":"value"}`))
+	doc, err := fa.CreateAttestation(userData, nitrofake.WithNonce([]byte("n")))
+	require.NoError(t, err)
+
+	parsed, err := ValidateAndParseWithRoots(doc, []byte("wrong"), fa.TrustedPCRsJSON(), fa.CARootsPEM())
+	require.Error(t, err)
+	require.Nil(t, parsed)
+	require.Contains(t, err.Error(), "expected user data")
 }

--- a/pkg/teeattestation/nitro/verify.go
+++ b/pkg/teeattestation/nitro/verify.go
@@ -39,6 +39,9 @@ var (
 type verifyResult struct {
 	document    *attestationDocument
 	signatureOK bool
+	// leafPublicKey is the SPKI (DER) encoding of the end-entity certificate
+	// public key. Populated only when signatureOK is true.
+	leafPublicKey []byte
 }
 
 type attestationDocument struct {
@@ -139,7 +142,12 @@ func verifyAttestationDocument(data []byte, roots *x509.CertPool, currentTime ti
 		return &verifyResult{document: &doc, signatureOK: false}, errBadSignature
 	}
 
-	return &verifyResult{document: &doc, signatureOK: true}, nil
+	leafPublicKey, err := x509.MarshalPKIXPublicKey(leafCert.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("marshal leaf public key: %w", err)
+	}
+
+	return &verifyResult{document: &doc, signatureOK: true, leafPublicKey: leafPublicKey}, nil
 }
 
 func validateProtectedAlgorithm(alg any) error {


### PR DESCRIPTION
## What

Adds `ValidateAndParse` / `ValidateAndParseWithRoots`. They run the exact same validation as `ValidateAttestation` (cert chain, COSE signature, expected user data, trusted PCR0/1/2) and, on success, return a `Document` exposing the parsed fields: all PCRs, the end-entity (leaf) certificate public key, the enclave-supplied `public_key`, the `nonce`, and the module id.

`ValidateAttestation` / `ValidateAttestationWithRoots` become thin wrappers over the new functions, so existing callers are unchanged.

## Why

The parsed attestation document was package-private, so callers could only get a pass/fail. confidential-compute needs two things this PR unblocks:

- bind an attestation to a specific enclave identity, via the enclave-supplied `public_key`
- check freshness, via the `nonce`

Both are policy that stays on the consumer side. This PR only exposes the data; it does not check the nonce or pin any key.

## Notes

- `LeafPublicKey` is exposed but, as its doc comment says, the leaf cert rotates per enclave instance (~hours), so it is not a stable identity anchor on its own. The intended pin target is the enclave-generated `public_key`.
- The fake attestor gains `WithNonce` / `WithPublicKey` options and `LeafPublicKeyDER` so the new fields are testable.