### PR TITLE
pkg/settings/cresettings: add ConfidentialWorkflows.Enabled feature gate

### DIFF
--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -223,6 +223,9 @@ flowchart
             PerWorkflow.ConfidentialHTTP.RequestSizeLimit{{RequestSizeLimit}}:::bound
             PerWorkflow.ConfidentialHTTP.ResponseSizeLimit{{ResponseSizeLimit}}:::bound
         end
+        subgraph PerWorkflow.ConfidentialWorkflows
+            PerWorkflow.ConfidentialWorkflows.Enabled[/Enabled\]:::gate
+        end
         subgraph PerWorkflow.Secrets
             PerWorkflow.Secrets.CallLimit{{CallLimit}}:::bound
         end

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -151,6 +151,9 @@
 			"RequestSizeLimit": "10kb",
 			"ResponseSizeLimit": "100kb"
 		},
+		"ConfidentialWorkflows": {
+			"Enabled": "true"
+		},
 		"Secrets": {
 			"CallLimit": "5"
 		},

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -152,7 +152,7 @@
 			"ResponseSizeLimit": "100kb"
 		},
 		"ConfidentialWorkflows": {
-			"Enabled": "true"
+			"Enabled": "false"
 		},
 		"Secrets": {
 			"CallLimit": "5"

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -160,7 +160,7 @@ RequestSizeLimit = '10kb'
 ResponseSizeLimit = '100kb'
 
 [PerWorkflow.ConfidentialWorkflows]
-Enabled = 'true'
+Enabled = 'false'
 
 [PerWorkflow.Secrets]
 CallLimit = '5'

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -159,5 +159,8 @@ ConnectionTimeout = '10s'
 RequestSizeLimit = '10kb'
 ResponseSizeLimit = '100kb'
 
+[PerWorkflow.ConfidentialWorkflows]
+Enabled = 'true'
+
 [PerWorkflow.Secrets]
 CallLimit = '5'

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -244,7 +244,7 @@ var Default = Schema{
 			ResponseSizeLimit: Size(100 * config.KByte),
 		},
 		ConfidentialWorkflows: confidentialWorkflows{
-			Enabled: Bool(true),
+			Enabled: Bool(false),
 		},
 		Secrets: secrets{
 			CallLimit: Int(5),

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -243,6 +243,9 @@ var Default = Schema{
 			RequestSizeLimit:  Size(10 * config.KByte),
 			ResponseSizeLimit: Size(100 * config.KByte),
 		},
+		ConfidentialWorkflows: confidentialWorkflows{
+			Enabled: Bool(true),
+		},
 		Secrets: secrets{
 			CallLimit: Int(5),
 		},
@@ -366,12 +369,13 @@ type Workflows struct {
 	HTTPTrigger httpTrigger
 	LogTrigger  logTrigger
 
-	ChainWrite       chainWrite
-	ChainRead        chainRead
-	Consensus        consensus
-	HTTPAction       httpAction
-	ConfidentialHTTP confidentialHTTP
-	Secrets          secrets
+	ChainWrite            chainWrite
+	ChainRead             chainRead
+	Consensus             consensus
+	HTTPAction            httpAction
+	ConfidentialHTTP      confidentialHTTP
+	ConfidentialWorkflows confidentialWorkflows
+	Secrets               secrets
 
 	FeatureMultiTriggerExecutionIDsActiveAt        Setting[config.Timestamp] // Deprecated
 	FeatureMultiTriggerExecutionIDsActivePeriod    Setting[Range[config.Timestamp]]
@@ -434,6 +438,13 @@ type confidentialHTTP struct {
 	ConnectionTimeout Setting[time.Duration]
 	RequestSizeLimit  Setting[config.Size]
 	ResponseSizeLimit Setting[config.Size]
+}
+
+type confidentialWorkflows struct {
+	// Enabled gates the confidential-workflows capability. When false, confidential
+	// workflow executions are rejected. Scoped per workflow/owner/org/global so it
+	// can be toggled in production without a redeploy.
+	Enabled Setting[bool]
 }
 type secrets struct {
 	CallLimit Setting[int] `unit:"{call}"`


### PR DESCRIPTION
Adds `PerWorkflow.ConfidentialWorkflows.Enabled` (Setting[bool], default true) to the CRE settings schema.

This gives the confidential-workflows capability a feature flag that can be flipped in production through the scoped settings registry, with overrides resolvable at workflow, owner, org, or global level. The consuming GateLimiter lands separately in confidential-compute.

Regenerated defaults.toml / defaults.json and added the key to the README flowchart (both required by the package tests).