### PR TITLE
DurableEmitter: Fix queue depth bug

### DIFF
--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -475,7 +475,7 @@ func (d *DurableEmitter) deliveryCallback(id int64, eventPb *chipingress.CloudEv
 			h.OnBatchPublish(publishElapsed, 1, sendErr)
 		}
 
-		cbCtx, cbCancel := context.WithTimeout(context.Background(), d.cfg.PublishTimeout)
+		cbCtx, cbCancel := d.stopCh.NewCtx()
 		defer cbCancel()
 
 		if d.metrics != nil {

--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -537,7 +537,10 @@ func (d *DurableEmitter) tryFallback(id int64, eventPb *chipingress.CloudEventPb
 // the pending counter. On failure, it logs and returns — the event remains in
 // the DB and the retransmit loop will eventually deliver it.
 func (d *DurableEmitter) singleEventFallback(id int64, eventPb *chipingress.CloudEventPb) {
-	pubCtx, pubCancel := context.WithTimeout(context.Background(), d.cfg.PublishTimeout)
+	stopCtx, stopCancel := d.stopCh.NewCtx()
+	defer stopCancel()
+
+	pubCtx, pubCancel := context.WithTimeout(stopCtx, d.cfg.PublishTimeout)
 	defer pubCancel()
 
 	if _, err := d.fallbackClient.Publish(pubCtx, eventPb); err != nil {
@@ -546,17 +549,14 @@ func (d *DurableEmitter) singleEventFallback(id int64, eventPb *chipingress.Clou
 		return
 	}
 
-	markCtx, markCancel := context.WithTimeout(context.Background(), d.cfg.PublishTimeout)
-	defer markCancel()
-
-	marked, markErr := d.store.MarkDeliveredBatch(markCtx, []int64{id})
+	marked, markErr := d.store.MarkDeliveredBatch(stopCtx, []int64{id})
 	if markErr != nil {
 		d.eng.Errorw("DurableEmitter: failed to mark fallback event delivered", "id", id, "error", markErr)
 		return
 	}
 	d.decPending(marked)
 	if d.metrics != nil {
-		d.metrics.deliverComplete.Add(markCtx, marked)
+		d.metrics.deliverComplete.Add(stopCtx, marked)
 	}
 }
 

--- a/pkg/durableemitter/observable_store.go
+++ b/pkg/durableemitter/observable_store.go
@@ -61,7 +61,12 @@ type DurableEventStore interface {
 	// ListPending returns events created before the given cutoff, ordered by
 	// creation time ascending, up to limit rows.
 	ListPending(ctx context.Context, createdBefore time.Time, limit int) ([]DurableEvent, error)
-	// DeleteExpired removes events older than ttl and returns the count deleted.
+	// DeleteExpired removes undelivered events older than ttl and returns the
+	// count deleted. Implementations MUST NOT delete or count already-delivered
+	// rows here (those are reclaimed by PurgeDelivered): the returned count is
+	// used to decrement the in-memory pending/queue-depth counter, which only
+	// tracks undelivered events. Counting delivered rows would double-subtract
+	// them and drive the queue-depth gauge negative.
 	DeleteExpired(ctx context.Context, ttl time.Duration) (int64, error)
 }
 

--- a/pkg/durableemitter/store.go
+++ b/pkg/durableemitter/store.go
@@ -149,7 +149,8 @@ func (s *PgDurableEventStore) DeleteExpired(ctx context.Context, ttl time.Durati
 	const q = `
 WITH deleted AS (
     DELETE FROM ` + chipDurableEventsTable + `
-    WHERE created_at <= now() - $1::interval
+    WHERE delivered_at IS NULL
+      AND created_at <= now() - $1::interval
     RETURNING id
 )
 SELECT count(*) FROM deleted`


### PR DESCRIPTION
Leave delivered events to be purged by purge loop.