### PR TITLE
fix(teeattestation/nitro): enforce max age on attestation timestamp [CL112-10]

### DIFF
--- a/pkg/teeattestation/nitro/validate_test.go
+++ b/pkg/teeattestation/nitro/validate_test.go
@@ -2,6 +2,7 @@ package nitro
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +21,25 @@ func TestValidateAttestation_Attestor(t *testing.T) {
 
 	err = ValidateAttestationWithRoots(doc, userData, fa.TrustedPCRsJSON(), fa.CARootsPEM())
 	require.NoError(t, err)
+}
+
+// TestVerifyAttestationDocument_MaxAge covers PRIV-438 / CL112-10: a fresh
+// attestation verifies, but one older than MaxAttestationAge is rejected even
+// though the leaf cert is still valid.
+func TestVerifyAttestationDocument_MaxAge(t *testing.T) {
+	fa, err := nitrofake.NewAttestor()
+	require.NoError(t, err)
+	doc, err := fa.CreateAttestation([]byte("user-data"))
+	require.NoError(t, err)
+	pool := fa.CARoots()
+
+	// Fresh: accepted.
+	_, err = verifyAttestationDocument(doc, pool, time.Now())
+	require.NoError(t, err)
+
+	// Older than the window: rejected (cert is still valid, only age fails).
+	_, err = verifyAttestationDocument(doc, pool, time.Now().Add(MaxAttestationAge+time.Minute))
+	require.ErrorIs(t, err, errStaleAttestation)
 }
 
 func TestValidateAttestation_WrongUserData(t *testing.T) {

--- a/pkg/teeattestation/nitro/validate_test.go
+++ b/pkg/teeattestation/nitro/validate_test.go
@@ -23,9 +23,9 @@ func TestValidateAttestation_Attestor(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestVerifyAttestationDocument_MaxAge covers PRIV-438 / CL112-10: a fresh
-// attestation verifies, but one older than MaxAttestationAge is rejected even
-// though the leaf cert is still valid.
+// TestVerifyAttestationDocument_MaxAge covers PRIV-438 / CL112-10: fresh
+// attestations verify; stale or far-future ones are rejected even while the
+// leaf cert is still valid.
 func TestVerifyAttestationDocument_MaxAge(t *testing.T) {
 	fa, err := nitrofake.NewAttestor()
 	require.NoError(t, err)
@@ -37,8 +37,12 @@ func TestVerifyAttestationDocument_MaxAge(t *testing.T) {
 	_, err = verifyAttestationDocument(doc, pool, time.Now())
 	require.NoError(t, err)
 
-	// Older than the window: rejected (cert is still valid, only age fails).
-	_, err = verifyAttestationDocument(doc, pool, time.Now().Add(MaxAttestationAge+time.Minute))
+	// Too old: rejected (cert is still valid, only age fails).
+	_, err = verifyAttestationDocument(doc, pool, time.Now().Add(maxAttestationAge+time.Minute))
+	require.ErrorIs(t, err, errStaleAttestation)
+
+	// Too far in the future: also rejected.
+	_, err = verifyAttestationDocument(doc, pool, time.Now().Add(-(maxAttestationAge + time.Minute)))
 	require.ErrorIs(t, err, errStaleAttestation)
 }
 

--- a/pkg/teeattestation/nitro/verify.go
+++ b/pkg/teeattestation/nitro/verify.go
@@ -23,6 +23,7 @@ var (
 	errMandatoryFieldsMissing        = errors.New("attestation document is missing mandatory fields")
 	errBadDigest                     = errors.New("attestation digest is not SHA384")
 	errBadTimestamp                  = errors.New("attestation timestamp is 0")
+	errStaleAttestation              = errors.New("attestation is older than the max allowed age")
 	errBadPCRs                       = errors.New("attestation pcrs is less than 1 or more than 32")
 	errBadPCRIndex                   = errors.New("attestation pcr index is not in [0, 32)")
 	errBadPCRValue                   = errors.New("attestation pcr value length is invalid")
@@ -35,6 +36,9 @@ var (
 	errBadCertificateSigningAlgo     = errors.New("attestation certificate signature algorithm is not ECDSAWithSHA384")
 	errBadSignature                  = errors.New("attestation signature does not match certificate")
 )
+
+// MaxAttestationAge rejects attestations not consumed promptly after issuance. [CL112-10]
+const MaxAttestationAge = 5 * time.Minute
 
 type verifyResult struct {
 	document    *attestationDocument
@@ -113,6 +117,12 @@ func verifyAttestationDocument(data []byte, roots *x509.CertPool, currentTime ti
 	}
 	if currentTime.IsZero() {
 		currentTime = time.Now()
+	}
+
+	// doc.Timestamp is epoch milliseconds (already validated non-zero).
+	issued := time.UnixMilli(int64(doc.Timestamp)) //nolint:gosec // timestamp is positive and within int64
+	if currentTime.Sub(issued) > MaxAttestationAge {
+		return nil, errStaleAttestation
 	}
 	if _, err := leafCert.Verify(x509.VerifyOptions{
 		Intermediates: intermediates,

--- a/pkg/teeattestation/nitro/verify.go
+++ b/pkg/teeattestation/nitro/verify.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -22,8 +23,8 @@ var (
 	errBadAttestationDocument        = errors.New("bad attestation document")
 	errMandatoryFieldsMissing        = errors.New("attestation document is missing mandatory fields")
 	errBadDigest                     = errors.New("attestation digest is not SHA384")
-	errBadTimestamp                  = errors.New("attestation timestamp is 0")
-	errStaleAttestation              = errors.New("attestation is older than the max allowed age")
+	errBadTimestamp                  = errors.New("attestation timestamp is zero or out of range")
+	errStaleAttestation              = errors.New("attestation timestamp is outside the allowed window")
 	errBadPCRs                       = errors.New("attestation pcrs is less than 1 or more than 32")
 	errBadPCRIndex                   = errors.New("attestation pcr index is not in [0, 32)")
 	errBadPCRValue                   = errors.New("attestation pcr value length is invalid")
@@ -37,8 +38,8 @@ var (
 	errBadSignature                  = errors.New("attestation signature does not match certificate")
 )
 
-// MaxAttestationAge rejects attestations not consumed promptly after issuance. [CL112-10]
-const MaxAttestationAge = 5 * time.Minute
+// maxAttestationAge rejects attestations not consumed promptly after issuance. [CL112-10]
+const maxAttestationAge = 5 * time.Minute
 
 type verifyResult struct {
 	document    *attestationDocument
@@ -119,9 +120,13 @@ func verifyAttestationDocument(data []byte, roots *x509.CertPool, currentTime ti
 		currentTime = time.Now()
 	}
 
-	// doc.Timestamp is epoch milliseconds (already validated non-zero).
-	issued := time.UnixMilli(int64(doc.Timestamp)) //nolint:gosec // timestamp is positive and within int64
-	if currentTime.Sub(issued) > MaxAttestationAge {
+	// doc.Timestamp is epoch milliseconds; reject if it overflows int64.
+	if doc.Timestamp > math.MaxInt64 {
+		return nil, errBadTimestamp
+	}
+	issued := time.UnixMilli(int64(doc.Timestamp))
+	// Reject both stale and far-future timestamps (absolute skew).
+	if skew := currentTime.Sub(issued); skew > maxAttestationAge || skew < -maxAttestationAge {
 		return nil, errStaleAttestation
 	}
 	if _, err := leafCert.Verify(x509.VerifyOptions{


### PR DESCRIPTION
`verifyAttestationDocument` only checked the attestation timestamp was non-zero; `currentTime` was used solely for cert validity (a 1-2 year window). A valid attestation therefore stayed accepted until the leaf cert expired, even though our protocol produces attestations immediately before consumption.

Adds `MaxAttestationAge` (5 min) and rejects attestations older than that. Test covers a fresh attestation verifying and a stale one being rejected while the cert is still valid.

Audit finding CL112-10 / PRIV-438.