### PR TITLE
Sync vendored ComputeRequest.Hash with confidential-compute: Version only for legacy

### DIFF
--- a/pkg/capabilities/v2/actions/confidentialrelay/computerequest.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/computerequest.go
@@ -22,6 +22,14 @@ const computeRequestDomainSeparator = "CONFIDENTIAL_COMPUTE_PAYLOAD"
 // is the signature prefix, distinct from computeRequestDomainSeparator (the hash prefix).
 const signedComputeRequestSignaturePrefix = "CONFIDENTIAL_COMPUTE_PAYLOAD_"
 
+// computeRequestLegacyVersion is vendored from confidential-compute
+// types.ServiceConfidentialComputeVersionLegacy. Hash includes the Version field only
+// when it equals this value, matching the source (confidential-compute is migrating
+// Version out of the hash for newer versions). It MUST stay in sync with the source, or
+// ComputeRequest.Hash will diverge from the digest the Workflow DON nodes signed once the
+// enclave moves past the legacy version.
+const computeRequestLegacyVersion = "0.0.6"
+
 // SignedComputeRequestSignaturePayload reconstructs the exact payload a Workflow DON node
 // signed over a ComputeRequest hash, so the relay DON can verify the signature with the
 // node's public key.
@@ -53,8 +61,8 @@ type ComputeRequest struct {
 // Hash mirrors confidential-compute types.ComputeRequest.Hash byte-for-byte. It
 // reuses this package's length-prefix helpers (writeBytes/writeString/
 // writeLengthPrefix), which are identical to the source's writeWithLength/
-// writeLengthPrefix. EncryptedDecryptionKeyShares is intentionally excluded,
-// matching the source.
+// writeLengthPrefix. EncryptedDecryptionKeyShares is intentionally excluded, and
+// Version is included only for the legacy version, both matching the source.
 func (cr ComputeRequest) Hash() [32]byte {
 	h := sha256.New()
 
@@ -79,7 +87,11 @@ func (cr ComputeRequest) Hash() [32]byte {
 	writeBytes(h, cr.MasterPublicKey)
 
 	writeString(h, cr.AppID)
-	writeString(h, cr.Version)
+	// Version is included in the hash only for the legacy version, matching
+	// confidential-compute (which is migrating Version out of the hash).
+	if cr.Version == computeRequestLegacyVersion {
+		writeString(h, cr.Version)
+	}
 
 	var result [32]byte
 	h.Sum(result[:0])

--- a/pkg/capabilities/v2/actions/confidentialrelay/computerequest_test.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/computerequest_test.go
@@ -19,7 +19,7 @@ func sampleComputeRequest() ComputeRequest {
 		EnclaveEphemeralPublicKey: []byte("ephemeral-pub-key"),
 		MasterPublicKey:           []byte("master-pub-key"),
 		AppID:                     "test-app",
-		Version:                   "v1.2.3",
+		Version:                   computeRequestLegacyVersion,
 	}
 }
 
@@ -58,4 +58,19 @@ func TestComputeRequestHash_IgnoresEncryptedShares(t *testing.T) {
 	withShares := sampleComputeRequest()
 	withShares.EncryptedDecryptionKeyShares = [][][]byte{{[]byte("share")}}
 	require.Equal(t, sampleComputeRequest().Hash(), withShares.Hash())
+}
+
+// Version is hashed only for the legacy version, matching confidential-compute (which is
+// migrating Version out of the hash). Non-legacy versions are excluded, so different
+// non-legacy versions hash identically, while the legacy version is bound.
+func TestComputeRequestHash_VersionOnlyHashedForLegacy(t *testing.T) {
+	nonLegacyA := sampleComputeRequest()
+	nonLegacyA.Version = "0.0.7"
+	nonLegacyB := sampleComputeRequest()
+	nonLegacyB.Version = "1.2.3"
+	require.Equal(t, nonLegacyA.Hash(), nonLegacyB.Hash(), "non-legacy Version must not affect the hash")
+
+	legacy := sampleComputeRequest()
+	legacy.Version = computeRequestLegacyVersion
+	require.NotEqual(t, legacy.Hash(), nonLegacyA.Hash(), "legacy Version must be bound into the hash")
 }


### PR DESCRIPTION
confidential-compute #360 made Version conditional in ComputeRequest.Hash: it is hashed only when Version == ServiceConfidentialComputeVersionLegacy, as CC migrates Version out of the hash. The vendored copy here still hashed Version unconditionally.

They agree today (version 0.0.6 == legacy), so relay-DON F+1 verification works. But once the enclave moves past the legacy version, CC stops hashing Version while this copy keeps hashing it, so the relay would compute a different ComputeRequest.Hash than the Workflow DON signed and silently reject every valid secrets request.

Mirror the conditional and vendor the legacy-version const. PRIV-433.