### PR TITLE
fix(teeattestation): length-prefix tag and data in DomainHash [CL112-14]

### DIFF
--- a/pkg/teeattestation/hash.go
+++ b/pkg/teeattestation/hash.go
@@ -3,18 +3,29 @@
 // live in subpackages.
 package teeattestation
 
-import "crypto/sha256"
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"hash"
+)
 
 // DomainSeparator is prepended to attestation payloads before hashing.
 const DomainSeparator = "CONFIDENTIAL_COMPUTE_PAYLOAD"
 
-// DomainHash computes SHA-256 over DomainSeparator + "\n" + tag + "\n" + data.
-// This is the standard domain-separated hash used for attestation UserData
-// throughout the system.
+// DomainHash computes SHA-256 over the DomainSeparator and the length-prefixed
+// tag and data, so distinct (tag, data) pairs can never share a pre-image. [CL112-14]
 func DomainHash(tag string, data []byte) []byte {
 	h := sha256.New()
 	h.Write([]byte(DomainSeparator))
-	h.Write([]byte("\n" + tag + "\n"))
-	h.Write(data)
+	writeWithLength(h, []byte(tag))
+	writeWithLength(h, data)
 	return h.Sum(nil)
+}
+
+// writeWithLength writes an 8-byte big-endian length prefix followed by data.
+func writeWithLength(h hash.Hash, data []byte) {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(len(data)))
+	h.Write(buf[:])
+	h.Write(data)
 }

--- a/pkg/teeattestation/hash_test.go
+++ b/pkg/teeattestation/hash_test.go
@@ -1,6 +1,7 @@
 package teeattestation
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"testing"
 )
@@ -13,8 +14,8 @@ func TestDomainHash(t *testing.T) {
 
 	h := sha256.New()
 	h.Write([]byte(DomainSeparator))
-	h.Write([]byte("\n" + tag + "\n"))
-	h.Write(data)
+	writeWithLength(h, []byte(tag))
+	writeWithLength(h, data)
 	want := h.Sum(nil)
 
 	if len(got) != sha256.Size {
@@ -51,4 +52,11 @@ func TestDomainHash_DifferentData(t *testing.T) {
 		}
 	}
 	t.Fatal("different data should produce different hashes")
+}
+
+// CL112-14 regression: the old newline scheme let ("A\nB","C") and ("A","B\nC") collide.
+func TestDomainHash_NoBoundaryCollision(t *testing.T) {
+	if bytes.Equal(DomainHash("A\nB", []byte("C")), DomainHash("A", []byte("B\nC"))) {
+		t.Fatal("tag/data boundary collision: distinct pairs must not share a hash")
+	}
 }


### PR DESCRIPTION
`DomainHash` delimited `DomainSeparator`, `tag`, and `data` with newlines, so a tag or data value containing a newline could make distinct `(tag, data)` pairs share a pre-image (e.g. `("A\nB", "C")` and `("A", "B\nC")`). It length-prefixes each variable field instead, matching the `writeWithLength` scheme `ComputeRequest.Hash` already uses.

Not exploitable today (tags are newline-free constants); this hardens against future tag changes. Adds a boundary-collision regression test.

**Note:** this changes `DomainHash`'s output, so attestation producers and verifiers must run the same version. Acceptable since confidential workflows is unreleased.

Audit finding CL112-14 / PRIV-467.