### PR TITLE
DurableEmitter: Mark Delivered Coalescer

### DIFF
--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -654,10 +654,13 @@ func (d *DurableEmitter) insertBatchLoop() {
 		for i, r := range batch {
 			payloads[i] = r.payload
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), d.cfg.PublishTimeout)
-		ids, batchErr := d.batchInserter.InsertBatch(ctx, payloads)
-		cancel()
-		for i, r := range batch {
+	ctx, cancel := context.WithTimeout(context.Background(), d.cfg.PublishTimeout)
+	ids, batchErr := d.batchInserter.InsertBatch(ctx, payloads)
+	cancel()
+	if batchErr == nil {
+		d.eng.Debugw("DurableEmitter: coalesced insert flushed", "count", len(payloads))
+	}
+	for i, r := range batch {
 			if batchErr != nil {
 				r.result <- insertResult{err: batchErr}
 			} else {
@@ -743,6 +746,7 @@ func (d *DurableEmitter) flushMarks(ids []int64) {
 		d.eng.Errorw("failed to batch mark events delivered", "count", len(ids), "error", err)
 		return
 	}
+	d.eng.Debugw("DurableEmitter: coalesced mark delivered flushed", "submitted", len(ids), "marked", marked)
 	if d.metrics != nil {
 		d.metrics.deliverComplete.Add(ctx, marked)
 	}
@@ -853,15 +857,20 @@ func (d *DurableEmitter) purgeLoop() {
 		case <-d.stopCh:
 			return
 		case <-ticker.C:
+			var purged int64
 			for {
 				n, err := d.store.PurgeDelivered(ctx, batch)
 				if err != nil {
 					d.eng.Errorw("failed to purge delivered chip durable events", "error", err)
 					break
 				}
+				purged += n
 				if n == 0 {
 					break
 				}
+			}
+			if purged > 0 {
+				d.eng.Debugw("DurableEmitter: purged delivered events", "count", purged)
 			}
 		}
 	}

--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -668,11 +668,9 @@ func (d *DurableEmitter) insertBatchLoop() {
 }
 
 // enqueueMark hands a delivered event id to the mark coalescer. It returns
-// false when mark coalescing is disabled so the caller can mark inline. The
-// send is a blocking hand-off (the channel is large); back-pressure here slows
-// the delivery callback rather than dropping a mark. It never sends after
-// markCh is closed because stop() closes the channel only once all producers
-// (delivery callbacks and fallback goroutines) have quiesced.
+// false when mark coalescing is disabled so the caller can mark inline.
+// Send is a blocking hand-off; back-pressure here slows the delivery callback
+// rather than dropping a mark.
 func (d *DurableEmitter) enqueueMark(id int64) bool {
 	if d.markCh == nil {
 		return false

--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -86,6 +86,18 @@ type Config struct {
 	// InsertBatchWorkers is the number of concurrent batch-insert goroutines.
 	// Zero defaults to 4.
 	InsertBatchWorkers int
+	// MarkBatchSize enables mark coalescing when > 0. Instead of issuing one
+	// MarkDeliveredBatch UPDATE per delivered event from the delivery callback,
+	// ids are funneled to background workers that collapse many ids into a
+	// single UPDATE, drastically reducing per-event UPDATE/connection churn.
+	// Each worker collects up to MarkBatchSize ids before flushing.
+	MarkBatchSize int
+	// MarkBatchFlushInterval is the linger time after the first id arrives in a
+	// coalescing batch before it is flushed. Zero defaults to 100ms.
+	MarkBatchFlushInterval time.Duration
+	// MarkBatchWorkers is the number of concurrent batch-mark goroutines.
+	// Zero defaults to 2.
+	MarkBatchWorkers int
 }
 
 // Hooks records delivery latency to locate pipeline bottlenecks.
@@ -114,6 +126,9 @@ func DefaultConfig() Config {
 		PurgeBatchSize:           500,
 		InsertBatchFlushInterval: 100 * time.Millisecond,
 		InsertBatchSize:          100,
+		MarkBatchSize:            100,
+		MarkBatchFlushInterval:   100 * time.Millisecond,
+		MarkBatchWorkers:         2,
 		// Metrics is opt-in: callers who want instrumentation must set this
 		// and pass a metric.Meter to NewDurableEmitter.
 		Metrics: nil,
@@ -178,6 +193,15 @@ type DurableEmitter struct {
 	// callers inside the coalesced path so stop can close(insertCh) after wait
 	insertShutdown atomic.Bool
 	insertInFlight atomic.Int32
+
+	// markCh funnels delivered event ids to the mark coalescer. Nil when mark
+	// coalescing is disabled (MarkBatchSize <= 0). Its only producers are the
+	// delivery callbacks and single-event fallback goroutines, so it is closed
+	// during shutdown only after both have quiesced (see stop). markWg tracks
+	// the markBatchLoop workers, which must outlive d.wg so callbacks running
+	// during the batch emitter's final flush can still enqueue marks.
+	markCh chan int64
+	markWg sync.WaitGroup
 
 	// fallbackInFlightCount is incremented when a single-event fallback
 	// goroutine starts and decremented on its defer. metricsLoop samples
@@ -266,6 +290,18 @@ func NewDurableEmitter(
 				"insertBatchFlushInterval", cfg.InsertBatchFlushInterval)
 		}
 	}
+
+	if cfg.MarkBatchSize > 0 {
+		chanSize := cfg.MarkBatchSize * 200
+		if chanSize < 10_000 {
+			chanSize = 10_000
+		}
+		d.markCh = make(chan int64, chanSize)
+		d.eng.Infow("DurableEmitter: mark coalescing enabled",
+			"markBatchSize", cfg.MarkBatchSize,
+			"markBatchWorkers", cfg.MarkBatchWorkers,
+			"markBatchFlushInterval", cfg.MarkBatchFlushInterval)
+	}
 	return d, nil
 }
 
@@ -282,6 +318,18 @@ func (d *DurableEmitter) start(ctx context.Context) error {
 	if d.insertCh != nil {
 		for i := 0; i < insertWorkers; i++ {
 			d.wg.Go(d.insertBatchLoop)
+		}
+	}
+
+	if d.markCh != nil {
+		markWorkers := d.cfg.MarkBatchWorkers
+		if markWorkers <= 0 {
+			markWorkers = 2
+		}
+		// markWg (not d.wg) so the workers keep draining while the batch
+		// emitter flushes its final callbacks during stop().
+		for i := 0; i < markWorkers; i++ {
+			d.markWg.Go(d.markBatchLoop)
 		}
 	}
 
@@ -462,6 +510,12 @@ func (d *DurableEmitter) deliveryCallback(id int64, eventPb *chipingress.CloudEv
 			d.metrics.publishBatchEvOK.Add(cbCtx, 1)
 		}
 
+		// When mark coalescing is enabled the id is handed to the batch-mark
+		// workers (one UPDATE for many ids); otherwise mark it inline.
+		if d.enqueueMark(id) {
+			return
+		}
+
 		tMark := time.Now()
 		marked, markErr := d.store.MarkDeliveredBatch(cbCtx, []int64{id})
 		markElapsed := time.Since(tMark)
@@ -512,6 +566,10 @@ func (d *DurableEmitter) singleEventFallback(id int64, eventPb *chipingress.Clou
 		return
 	}
 
+	if d.enqueueMark(id) {
+		return
+	}
+
 	marked, markErr := d.store.MarkDeliveredBatch(stopCtx, []int64{id})
 	if markErr != nil {
 		d.eng.Errorw("DurableEmitter: failed to mark fallback event delivered", "id", id, "error", markErr)
@@ -542,6 +600,13 @@ func (d *DurableEmitter) stop() error {
 	// fallbackWg, so we wait on those next.
 	d.batchEmitter.Stop()
 	d.fallbackWg.Wait()
+	// The delivery callbacks (drained by batchEmitter.Stop) and the fallback
+	// goroutines (drained by fallbackWg) are the only producers of markCh, so
+	// it is now safe to close it and let the workers flush any buffered marks.
+	if d.markCh != nil {
+		close(d.markCh)
+		d.markWg.Wait()
+	}
 	if d.fallbackClient != nil {
 		if err := d.fallbackClient.Close(); err != nil {
 			d.eng.Warnw("DurableEmitter: error closing fallback chip client", "error", err)
@@ -599,6 +664,89 @@ func (d *DurableEmitter) insertBatchLoop() {
 				r.result <- insertResult{id: ids[i]}
 			}
 		}
+	}
+}
+
+// enqueueMark hands a delivered event id to the mark coalescer. It returns
+// false when mark coalescing is disabled so the caller can mark inline. The
+// send is a blocking hand-off (the channel is large); back-pressure here slows
+// the delivery callback rather than dropping a mark. It never sends after
+// markCh is closed because stop() closes the channel only once all producers
+// (delivery callbacks and fallback goroutines) have quiesced.
+func (d *DurableEmitter) enqueueMark(id int64) bool {
+	if d.markCh == nil {
+		return false
+	}
+	d.markCh <- id
+	return true
+}
+
+// markBatchLoop collects delivered event ids from markCh and flushes them as
+// batched MarkDeliveredBatch UPDATEs, collapsing many single-row UPDATEs into
+// one and decoupling the mark from the delivery-callback path. On channel close
+// it flushes any partially-collected batch before returning.
+func (d *DurableEmitter) markBatchLoop() {
+	batchSize := d.cfg.MarkBatchSize
+	linger := d.cfg.MarkBatchFlushInterval
+	if linger <= 0 {
+		linger = 100 * time.Millisecond
+	}
+	batch := make([]int64, 0, batchSize)
+
+	for {
+		batch = batch[:0]
+
+		id, ok := <-d.markCh
+		if !ok {
+			return
+		}
+		batch = append(batch, id)
+
+		timer := time.NewTimer(linger)
+	collecting:
+		for len(batch) < batchSize {
+			select {
+			case id, ok := <-d.markCh:
+				if !ok {
+					timer.Stop()
+					d.flushMarks(batch)
+					return
+				}
+				batch = append(batch, id)
+			case <-timer.C:
+				break collecting
+			}
+		}
+		timer.Stop()
+		d.flushMarks(batch)
+	}
+}
+
+// flushMarks marks a batch of delivered event ids in a single UPDATE. Marks are
+// best-effort: on failure the rows keep delivered_at IS NULL and the retransmit
+// loop re-delivers them (MarkDeliveredBatch is idempotent via the
+// delivered_at IS NULL predicate), so failures are logged rather than retried
+// here.
+func (d *DurableEmitter) flushMarks(ids []int64) {
+	if len(ids) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), d.cfg.PublishTimeout)
+	defer cancel()
+
+	tMark := time.Now()
+	marked, err := d.store.MarkDeliveredBatch(ctx, ids)
+	markElapsed := time.Since(tMark)
+
+	if h := d.cfg.Hooks; h != nil && h.OnBatchMarkDelivered != nil {
+		h.OnBatchMarkDelivered(markElapsed, int(marked))
+	}
+	if err != nil {
+		d.eng.Errorw("failed to batch mark events delivered", "count", len(ids), "error", err)
+		return
+	}
+	if d.metrics != nil {
+		d.metrics.deliverComplete.Add(ctx, marked)
 	}
 }
 
@@ -788,6 +936,13 @@ func (d *DurableEmitter) metricsLoop() {
 				}
 			} else {
 				d.metrics.insertCoalescerFill.Record(ctx, 0)
+			}
+			if d.markCh != nil {
+				if c := cap(d.markCh); c > 0 {
+					d.metrics.markCoalescerFill.Record(ctx, float64(len(d.markCh))/float64(c))
+				}
+			} else {
+				d.metrics.markCoalescerFill.Record(ctx, 0)
 			}
 			d.metrics.pollProcessGauges(ctx)
 		}

--- a/pkg/durableemitter/durable_emitter_metrics.go
+++ b/pkg/durableemitter/durable_emitter_metrics.go
@@ -58,6 +58,9 @@ type durableEmitterMetrics struct {
 	// insertCoalescerFill reports the write-coalescer channel fill ratio
 	// (len/cap). Only meaningful when InsertBatchSize > 0; otherwise 0.
 	insertCoalescerFill metric.Float64Gauge
+	// markCoalescerFill reports the mark-coalescer channel fill ratio
+	// (len/cap). Only meaningful when MarkBatchSize > 0; otherwise 0.
+	markCoalescerFill metric.Float64Gauge
 	// fallbackInFlight reports the number of single-event fallback Publish
 	// goroutines currently in flight.
 	fallbackInFlight metric.Int64Gauge
@@ -264,6 +267,13 @@ func newDurableEmitterMetrics(meter metric.Meter) (*durableEmitterMetrics, error
 		"durable_emitter.insert_coalescer.queue_fill_ratio",
 		metric.WithUnit("1"),
 		metric.WithDescription("Write-coalescer channel fill ratio (len/cap); 0 when write coalescing is disabled"),
+	); err != nil {
+		return nil, err
+	}
+	if m.markCoalescerFill, err = meter.Float64Gauge(
+		"durable_emitter.mark_coalescer.queue_fill_ratio",
+		metric.WithUnit("1"),
+		metric.WithDescription("Mark-coalescer channel fill ratio (len/cap); 0 when mark coalescing is disabled"),
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/durableemitter/durable_emitter_test.go
+++ b/pkg/durableemitter/durable_emitter_test.go
@@ -120,6 +120,27 @@ func (s *stallBatchStore) InsertBatch(ctx context.Context, payloads [][]byte) ([
 	return s.MemDurableEventStore.InsertBatch(ctx, payloads)
 }
 
+// markRecordingStore wraps MemDurableEventStore and records the size of every
+// MarkDeliveredBatch call so tests can assert how marks were coalesced.
+type markRecordingStore struct {
+	*MemDurableEventStore
+	mu        sync.Mutex
+	callSizes []int
+}
+
+func (s *markRecordingStore) MarkDeliveredBatch(ctx context.Context, ids []int64) (int64, error) {
+	s.mu.Lock()
+	s.callSizes = append(s.callSizes, len(ids))
+	s.mu.Unlock()
+	return s.MemDurableEventStore.MarkDeliveredBatch(ctx, ids)
+}
+
+func (s *markRecordingStore) sizes() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]int(nil), s.callSizes...)
+}
+
 func TestDurableEmitter_CloseCoalescedInsertShutdown(t *testing.T) {
 	stall := new(sync.Mutex)
 	stall.Lock()
@@ -168,6 +189,104 @@ func TestDurableEmitter_CloseCoalescedInsertShutdown(t *testing.T) {
 	err := em.Emit(ctx, []byte("after-close"), testEmitAttrs()...)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not started")
+}
+
+func TestDurableEmitter_MarkCoalescingBatchesIds(t *testing.T) {
+	store := &markRecordingStore{MemDurableEventStore: NewMemDurableEventStore()}
+	be := newTestBatchEmitter()
+
+	cfg := DefaultConfig()
+	cfg.DisablePruning = true
+	cfg.MarkBatchSize = 100
+	cfg.MarkBatchWorkers = 1
+	cfg.MarkBatchFlushInterval = 200 * time.Millisecond
+
+	em := newTestDurableEmitter(t, store, be, &cfg)
+	servicetest.Run(t, em)
+	ctx := t.Context()
+
+	const n = 25
+	for i := 0; i < n; i++ {
+		require.NoError(t, em.Emit(ctx, []byte("coalesce-me"), testEmitAttrs()...))
+	}
+
+	// Every delivered event must end up marked (MemStore deletes on mark).
+	require.Eventually(t, func() bool {
+		return store.Len() == 0
+	}, 3*time.Second, 10*time.Millisecond, "all delivered events should be marked")
+
+	sizes := store.sizes()
+	total, maxBatch := 0, 0
+	for _, s := range sizes {
+		total += s
+		if s > maxBatch {
+			maxBatch = s
+		}
+	}
+	assert.Equal(t, n, total, "every delivered id must be marked exactly once")
+	assert.Less(t, len(sizes), n, "marks must be coalesced into fewer UPDATEs than events")
+	assert.Greater(t, maxBatch, 1, "at least one UPDATE must mark multiple ids")
+}
+
+func TestDurableEmitter_MarkCoalescingFlushesPendingOnClose(t *testing.T) {
+	store := NewMemDurableEventStore()
+	be := newTestBatchEmitter()
+
+	cfg := DefaultConfig()
+	cfg.DisablePruning = true
+	cfg.MarkBatchSize = 100
+	cfg.MarkBatchWorkers = 1
+	// Long linger so marks stay buffered until Close drains them.
+	cfg.MarkBatchFlushInterval = time.Hour
+
+	em := newTestDurableEmitter(t, store, be, &cfg)
+	require.NoError(t, em.Start(t.Context()))
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		require.NoError(t, em.Emit(t.Context(), []byte("buffer-me"), testEmitAttrs()...))
+	}
+
+	require.Eventually(t, func() bool {
+		return be.callCount.Load() == int64(n)
+	}, 2*time.Second, 10*time.Millisecond, "all events should be handed to the batch emitter")
+
+	// Marks are buffered in the coalescer (1h linger), so nothing is flushed yet
+	// regardless of worker scheduling — rows are only removed on a flush.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, n, store.Len(), "marks should still be buffered before Close")
+
+	require.NoError(t, em.Close())
+
+	assert.Equal(t, 0, store.Len(), "Close must flush buffered marks before returning")
+}
+
+func TestDurableEmitter_MarkCoalescingDisabledMarksInline(t *testing.T) {
+	store := &markRecordingStore{MemDurableEventStore: NewMemDurableEventStore()}
+	be := newTestBatchEmitter()
+
+	cfg := DefaultConfig()
+	cfg.DisablePruning = true
+	cfg.MarkBatchSize = 0 // disable coalescing
+
+	em := newTestDurableEmitter(t, store, be, &cfg)
+	require.Nil(t, em.markCh, "mark coalescer channel must be nil when disabled")
+	servicetest.Run(t, em)
+	ctx := t.Context()
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		require.NoError(t, em.Emit(ctx, []byte("inline"), testEmitAttrs()...))
+	}
+	require.Eventually(t, func() bool {
+		return store.Len() == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	sizes := store.sizes()
+	assert.Len(t, sizes, n, "one inline UPDATE per delivered event when coalescing is disabled")
+	for _, s := range sizes {
+		assert.Equal(t, 1, s, "inline marks must be single-id UPDATEs")
+	}
 }
 
 func TestDurableEmitter_HooksBatchPublishPath(t *testing.T) {


### PR DESCRIPTION
Batches marking events delivered to reduce DB contention. 