### PR TITLE
[CRE][DonTime] Move request expiry outside the OCR plugin

### DIFF
--- a/pkg/workflows/dontime/plugin.go
+++ b/pkg/workflows/dontime/plugin.go
@@ -113,15 +113,7 @@ func (p *Plugin) Observation(_ context.Context, outctx ocr3types.OutcomeContext,
 	}
 
 	requests := map[string]int64{} // Maps executionID --> seqNum
-	timeoutCheck := time.Now()
 	for _, req := range p.store.GetRequests() {
-		if req.ExpiryTime().Before(timeoutCheck) {
-			// Request has been sitting in queue too long
-			p.store.RemoveRequest(req.WorkflowExecutionID)
-			req.SendTimeout(nil)
-			continue
-		}
-
 		// Validate request sequence number
 		numObservedDonTimes := 0
 		times, ok := previousOutcome.ObservedDonTimes[req.WorkflowExecutionID]
@@ -132,14 +124,13 @@ func (p *Plugin) Observation(_ context.Context, outctx ocr3types.OutcomeContext,
 
 		if req.SeqNum > numObservedDonTimes {
 			p.store.RemoveRequest(req.WorkflowExecutionID)
-			req.SendResponse(nil,
-				Response{
-					WorkflowExecutionID: req.WorkflowExecutionID,
-					SeqNum:              req.SeqNum,
-					Timestamp:           0,
-					Err: fmt.Errorf("requested seqNum %d for executionID %s is greater than the number of observed don times %d",
-						req.SeqNum, req.WorkflowExecutionID, numObservedDonTimes),
-				})
+			req.SendResponse(Response{
+				WorkflowExecutionID: req.WorkflowExecutionID,
+				SeqNum:              req.SeqNum,
+				Timestamp:           0,
+				Err: fmt.Errorf("requested seqNum %d for executionID %s is greater than the number of observed don times %d",
+					req.SeqNum, req.WorkflowExecutionID, numObservedDonTimes),
+			})
 			continue
 		}
 

--- a/pkg/workflows/dontime/request.go
+++ b/pkg/workflows/dontime/request.go
@@ -1,8 +1,8 @@
 package dontime
 
 import (
-	"context"
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -15,42 +15,39 @@ type Request struct {
 
 	WorkflowExecutionID string
 	SeqNum              int
+
+	expiryTimer *time.Timer
+	respondOnce sync.Once
 }
 
 func (r *Request) ID() string {
 	return r.WorkflowExecutionID
 }
 
-func (r *Request) ExpiryTime() time.Time {
-	return r.ExpiresAt
-}
-
-func (r *Request) SendResponse(_ context.Context, resp Response) {
-	select {
-	case r.CallbackCh <- resp:
-		close(r.CallbackCh)
-	default: // Don't block trying to send
+func (r *Request) stopExpiry() {
+	if r.expiryTimer != nil {
+		r.expiryTimer.Stop()
 	}
 }
 
-func (r *Request) SendTimeout(_ context.Context) {
+func (r *Request) SendResponse(resp Response) {
+	r.respondOnce.Do(func() {
+		r.stopExpiry()
+		select {
+		case r.CallbackCh <- resp:
+		default: // Don't block trying to send
+		}
+		close(r.CallbackCh)
+	})
+}
+
+func (r *Request) SendTimeout() {
 	timeoutResponse := Response{
 		WorkflowExecutionID: r.WorkflowExecutionID,
 		SeqNum:              r.SeqNum,
 		Err:                 fmt.Errorf("timeout exceeded: could not process request before expiry, workflowExecutionID %s", r.WorkflowExecutionID),
 	}
-	r.SendResponse(nil, timeoutResponse)
-}
-
-func (r *Request) Copy() *Request {
-	return &Request{
-		ExpiresAt:           r.ExpiresAt,
-		WorkflowExecutionID: r.WorkflowExecutionID,
-		SeqNum:              r.SeqNum,
-
-		// Intentionally not copied, but are thread-safe.
-		CallbackCh: r.CallbackCh,
-	}
+	r.SendResponse(timeoutResponse)
 }
 
 type Response struct {

--- a/pkg/workflows/dontime/request_test.go
+++ b/pkg/workflows/dontime/request_test.go
@@ -1,0 +1,37 @@
+package dontime
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequest_SendResponseAndTimeoutOnce(t *testing.T) {
+	ch := make(chan Response, 1)
+	req := &Request{
+		CallbackCh:          ch,
+		WorkflowExecutionID: "exec-1",
+		SeqNum:              0,
+	}
+	resp := Response{WorkflowExecutionID: "exec-1", SeqNum: 0, Timestamp: 123}
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			req.SendResponse(resp)
+		})
+		wg.Go(func() {
+			req.SendTimeout()
+		})
+	}
+	wg.Wait()
+
+	got, ok := <-ch
+	require.True(t, ok)
+	require.Equal(t, "exec-1", got.WorkflowExecutionID)
+	require.Equal(t, 0, got.SeqNum)
+
+	_, ok = <-ch
+	require.False(t, ok, "channel should be closed after first response")
+}

--- a/pkg/workflows/dontime/store.go
+++ b/pkg/workflows/dontime/store.go
@@ -7,7 +7,12 @@ import (
 	"time"
 )
 
-var DefaultRequestTimeout = 20 * time.Minute
+// This timeout is used to remove the request from the pending queue inside the Store object.
+// Having a short timeout here comes with a risk of affecting all future sequence numbers
+// for the same executionID, if the plugin is not able to process the request fast enough.
+// For that reason, we keep this timeout relatively long but allow the Engine to time out
+// much faster when waiting on the response channel.
+var DefaultRequestTimeout = 10 * time.Minute
 
 type Store struct {
 	requests       map[string]*Request // Maps workflow execution ID to request
@@ -75,19 +80,43 @@ func (s *Store) RequestDonTime(executionID string, seqNum int) <-chan Response {
 		return ch
 	}
 
+	expiresAt := time.Now().Add(s.requestTimeout)
 	s.requests[executionID] = &Request{
-		ExpiresAt:           time.Now().Add(s.requestTimeout),
+		ExpiresAt:           expiresAt,
 		CallbackCh:          ch,
 		WorkflowExecutionID: executionID,
 		SeqNum:              seqNum,
+		expiryTimer: time.AfterFunc(time.Until(expiresAt), func() {
+			s.expireRequest(executionID)
+		}),
 	}
 	return ch
 }
 
+func (s *Store) expireRequest(executionID string) {
+	s.mu.Lock()
+	req := s.removeRequestLocked(executionID)
+	s.mu.Unlock()
+	if req == nil {
+		return
+	}
+	req.SendTimeout()
+}
+
+func (s *Store) removeRequestLocked(executionID string) *Request {
+	req, ok := s.requests[executionID]
+	if !ok {
+		return nil
+	}
+	delete(s.requests, executionID)
+	req.stopExpiry()
+	return req
+}
+
 func (s *Store) RemoveRequest(executionID string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	delete(s.requests, executionID)
+	s.removeRequestLocked(executionID)
+	s.mu.Unlock()
 }
 
 func (s *Store) GetDonTimeForSeqNum(executionID string, seqNum int) *int64 {
@@ -128,7 +157,7 @@ func (s *Store) replaceDonTimes(donTimes map[string][]int64) {
 	for executionID := range s.donTimes {
 		if _, ok := donTimes[executionID]; !ok {
 			delete(s.donTimes, executionID)
-			delete(s.requests, executionID)
+			s.removeRequestLocked(executionID)
 		}
 	}
 }
@@ -149,5 +178,5 @@ func (s *Store) deleteExecutionID(executionID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.donTimes, executionID)
-	delete(s.requests, executionID)
+	s.removeRequestLocked(executionID)
 }

--- a/pkg/workflows/dontime/store_test.go
+++ b/pkg/workflows/dontime/store_test.go
@@ -1,0 +1,26 @@
+package dontime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_RequestExpiresWithoutPlugin(t *testing.T) {
+	store := NewStore(50 * time.Millisecond)
+	executionID := "workflow-123"
+
+	timeRequest := store.RequestDonTime(executionID, 0)
+
+	select {
+	case resp := <-timeRequest:
+		require.Equal(t, executionID, resp.WorkflowExecutionID)
+		require.Equal(t, 0, resp.SeqNum)
+		require.ErrorContains(t, resp.Err, "timeout exceeded: could not process request before expiry")
+	case <-time.After(time.Second):
+		t.Fatal("request did not expire")
+	}
+
+	require.Nil(t, store.GetRequest(executionID))
+}

--- a/pkg/workflows/dontime/transmitter.go
+++ b/pkg/workflows/dontime/transmitter.go
@@ -53,7 +53,7 @@ func (t *Transmitter) Transmit(_ context.Context, _ types.ConfigDigest, _ uint64
 		if len(donTimes.Timestamps) > request.SeqNum {
 			donTime := donTimes.Timestamps[request.SeqNum]
 			t.store.RemoveRequest(executionID) // Make space for next request before delivering
-			request.SendResponse(nil, Response{
+			request.SendResponse(Response{
 				WorkflowExecutionID: executionID,
 				SeqNum:              request.SeqNum,
 				Timestamp:           donTime,


### PR DESCRIPTION
[CRE-5067] Handling expiry inside the plugin comes with a risk of accumulating pending requests indefinitely when OCR is not progressing.

[CRE-5067]: https://smartcontract-it.atlassian.net/browse/CRE-5067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

1. Make Request SendResponse/SendTimeout thread safe and at-most-once.
2. Add timer to each request.
3. Remove expiry from the OCR plugin.
4. Remove unused Copy() method.
5. Remove unused context params.
