### PR TITLE
[CRE] Add new DONTime settings

### DIFF
--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -151,6 +151,7 @@ flowchart
         PerWorkflow.ExecutionTimestampsEnabled[/PerWorkflow.ExecutionTimestampsEnabled\]:::gate
         PerWorkflow.FeatureMultiTriggerExecutionIDsActiveAt[/PerWorkflow.FeatureMultiTriggerExecutionIDsActiveAt\]:::gate
         PerWorkflow.FeatureMultiTriggerExecutionIDsActivePeriod[/PerWorkflow.FeatureMultiTriggerExecutionIDsActivePeriod\]:::gate
+        PerWorkflow.FeatureUseSingleDONTimeProviderPerExecutionActivePeriod[/PerWorkflow.FeatureUseSingleDONTimeProviderPerExecutionActivePeriod\]:::gate
         PerWorkflow.FeatureChainCapabilityHashBasedOCRActivePeriod[/PerWorkflow.FeatureChainCapabilityHashBasedOCRActivePeriod\]:::gate
         PerWorkflow.FeatureEVMWriteReportL1FeeActivePeriod[/PerWorkflow.FeatureEVMWriteReportL1FeeActivePeriod\]:::gate
         PerWorkflow.FeatureAptosWriteReportBlockTimestampActivePeriod[/PerWorkflow.FeatureAptosWriteReportBlockTimestampActivePeriod\]:::gate
@@ -225,6 +226,9 @@ flowchart
         end
         subgraph PerWorkflow.Secrets
             PerWorkflow.Secrets.CallLimit{{CallLimit}}:::bound
+        end
+        subgraph PerWorkflow.DONTime
+            PerWorkflow.DONTime.RequestTimeout{{RequestTimeout}}:::time
         end
         subgraph PerOrg.HTTPAction
             PerOrg.HTTPAction.MtlsRateLimit{{PerOrg.HTTPAction.MtlsRateLimit}}:::bound

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -154,8 +154,12 @@
 		"Secrets": {
 			"CallLimit": "5"
 		},
+		"DONTime": {
+			"RequestTimeout": "30s"
+		},
 		"FeatureMultiTriggerExecutionIDsActiveAt": "2100-01-01 00:00:00 +0000 UTC",
 		"FeatureMultiTriggerExecutionIDsActivePeriod": "[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]",
+		"FeatureUseSingleDONTimeProviderPerExecutionActivePeriod": "[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]",
 		"FeatureChainCapabilityHashBasedOCRActivePeriod": "[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]",
 		"FeatureEVMWriteReportL1FeeActivePeriod": "[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]",
 		"FeatureAptosWriteReportBlockTimestampActivePeriod": "[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]"

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -81,6 +81,7 @@ UserMetricLabelsPerMetric = '10'
 UserMetricLabelValueLength = '256'
 FeatureMultiTriggerExecutionIDsActiveAt = '2100-01-01 00:00:00 +0000 UTC'
 FeatureMultiTriggerExecutionIDsActivePeriod = '[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]'
+FeatureUseSingleDONTimeProviderPerExecutionActivePeriod = '[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]'
 FeatureChainCapabilityHashBasedOCRActivePeriod = '[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]'
 FeatureEVMWriteReportL1FeeActivePeriod = '[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]'
 FeatureAptosWriteReportBlockTimestampActivePeriod = '[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]'
@@ -161,3 +162,6 @@ ResponseSizeLimit = '100kb'
 
 [PerWorkflow.Secrets]
 CallLimit = '5'
+
+[PerWorkflow.DONTime]
+RequestTimeout = '30s'

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -58,24 +58,24 @@ var Default = Schema{
 	GatewayVaultManagementEnabled:     Bool(true),
 	VaultJWTAuthEnabled:               Bool(false),
 	// Deprecated: retained for backwards compatibility; workflow owner identifies secret ownership.
-	VaultOrgIdAsSecretOwnerEnabled:         Bool(false),
-	PropagateOrgIDInRequestMetadata:        Bool(false),
-	VaultBase64EncodingEnabled:             Bool(false),
-	VaultForceEmptyOCRRounds:               Bool(false),
-	VaultOptimizationsEnabled:                      Bool(false),
-	VaultOwnerAddressCanonicalizationEnabled:       Bool(false),
-	VaultSignedResponseRequestIDEnabled:            Bool(false),
-	GatewayHTTPGlobalRate:                  Rate(rate.Limit(500), 500),
-	GatewayHTTPPerNodeRate:                 Rate(rate.Limit(100), 100),
-	GatewayConfidentialRelayGlobalRate:     Rate(rate.Limit(50), 10),
-	GatewayConfidentialRelayPerNodeRate:    Rate(rate.Limit(10), 10),
-	GatewayHTTPActionMtlsRequestRate:       Rate(rate.Every(30*time.Second), 0),
-	GatewayHTTPActionMtlsConcurrencyLimit:  Int(50),
-	TriggerRegistrationStatusUpdateTimeout: Duration(0 * time.Second),
-	BaseTriggerRetryInterval:               Duration(30 * time.Second),
-	BaseTriggerMaxRetries:                  Int(20),
-	BaseTriggerPruneAge:                    Duration(24 * time.Hour),
-	BaseTriggerMaxSendsPerTick:             Int(20),
+	VaultOrgIdAsSecretOwnerEnabled:           Bool(false),
+	PropagateOrgIDInRequestMetadata:          Bool(false),
+	VaultBase64EncodingEnabled:               Bool(false),
+	VaultForceEmptyOCRRounds:                 Bool(false),
+	VaultOptimizationsEnabled:                Bool(false),
+	VaultOwnerAddressCanonicalizationEnabled: Bool(false),
+	VaultSignedResponseRequestIDEnabled:      Bool(false),
+	GatewayHTTPGlobalRate:                    Rate(rate.Limit(500), 500),
+	GatewayHTTPPerNodeRate:                   Rate(rate.Limit(100), 100),
+	GatewayConfidentialRelayGlobalRate:       Rate(rate.Limit(50), 10),
+	GatewayConfidentialRelayPerNodeRate:      Rate(rate.Limit(10), 10),
+	GatewayHTTPActionMtlsRequestRate:         Rate(rate.Every(30*time.Second), 0),
+	GatewayHTTPActionMtlsConcurrencyLimit:    Int(50),
+	TriggerRegistrationStatusUpdateTimeout:   Duration(0 * time.Second),
+	BaseTriggerRetryInterval:                 Duration(30 * time.Second),
+	BaseTriggerMaxRetries:                    Int(20),
+	BaseTriggerPruneAge:                      Duration(24 * time.Hour),
+	BaseTriggerMaxSendsPerTick:               Int(20),
 
 	// DANGER(cedric): Be extremely careful changing these vault limits below as they act as a default value
 	// used by the Vault OCR plugin -- changing these values could cause issues with the plugin during an image
@@ -230,12 +230,12 @@ var Default = Schema{
 			CallLimit:            Int(20),
 		},
 		HTTPAction: httpAction{
-			CallLimit:           Int(5),
-			CacheAgeLimit:       Duration(10 * time.Minute),
-			ConnectionTimeout:   Duration(10 * time.Second),
-			RequestSizeLimit:    Size(10 * config.KByte),
-			ResponseSizeLimit:   Size(100 * config.KByte),
-			GatewayProxyDonID:   String(""),
+			CallLimit:         Int(5),
+			CacheAgeLimit:     Duration(10 * time.Minute),
+			ConnectionTimeout: Duration(10 * time.Second),
+			RequestSizeLimit:  Size(10 * config.KByte),
+			ResponseSizeLimit: Size(100 * config.KByte),
+			GatewayProxyDonID: String(""),
 		},
 		ConfidentialHTTP: confidentialHTTP{
 			CallLimit:         Int(5),
@@ -246,9 +246,15 @@ var Default = Schema{
 		Secrets: secrets{
 			CallLimit: Int(5),
 		},
+		DONTime: donTime{
+			RequestTimeout: Duration(30 * time.Second),
+		},
 
 		FeatureMultiTriggerExecutionIDsActiveAt: Time(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)),
 		FeatureMultiTriggerExecutionIDsActivePeriod: TimeRange(
+			time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2101, 1, 1, 0, 0, 0, 0, time.UTC)),
+		FeatureUseSingleDONTimeProviderPerExecutionActivePeriod: TimeRange(
 			time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC),
 			time.Date(2101, 1, 1, 0, 0, 0, 0, time.UTC)),
 		FeatureChainCapabilityHashBasedOCRActivePeriod: TimeRange(
@@ -264,25 +270,25 @@ var Default = Schema{
 }
 
 type Schema struct {
-	WorkflowLimit                          Setting[int] `unit:"{workflow}"`
-	WorkflowExecutionConcurrencyLimit      Setting[int] `unit:"{workflow}"`
-	GatewayIncomingPayloadSizeLimit        Setting[config.Size]
-	GatewayVaultManagementEnabled          Setting[bool]
-	VaultJWTAuthEnabled                    Setting[bool]
-	VaultOrgIdAsSecretOwnerEnabled         Setting[bool] // Deprecated
-	PropagateOrgIDInRequestMetadata        Setting[bool]
-	VaultBase64EncodingEnabled             Setting[bool]
-	VaultForceEmptyOCRRounds               Setting[bool]
-	VaultOptimizationsEnabled                    Setting[bool]
-	VaultOwnerAddressCanonicalizationEnabled     Setting[bool]
-	VaultSignedResponseRequestIDEnabled          Setting[bool]
-	GatewayHTTPGlobalRate                  Setting[config.Rate]
-	GatewayHTTPPerNodeRate                 Setting[config.Rate]
-	GatewayConfidentialRelayGlobalRate     Setting[config.Rate]
-	GatewayConfidentialRelayPerNodeRate    Setting[config.Rate]
-	GatewayHTTPActionMtlsRequestRate       Setting[config.Rate]
-	GatewayHTTPActionMtlsConcurrencyLimit  Setting[int] `unit:"{request}"`
-	TriggerRegistrationStatusUpdateTimeout Setting[time.Duration]
+	WorkflowLimit                            Setting[int] `unit:"{workflow}"`
+	WorkflowExecutionConcurrencyLimit        Setting[int] `unit:"{workflow}"`
+	GatewayIncomingPayloadSizeLimit          Setting[config.Size]
+	GatewayVaultManagementEnabled            Setting[bool]
+	VaultJWTAuthEnabled                      Setting[bool]
+	VaultOrgIdAsSecretOwnerEnabled           Setting[bool] // Deprecated
+	PropagateOrgIDInRequestMetadata          Setting[bool]
+	VaultBase64EncodingEnabled               Setting[bool]
+	VaultForceEmptyOCRRounds                 Setting[bool]
+	VaultOptimizationsEnabled                Setting[bool]
+	VaultOwnerAddressCanonicalizationEnabled Setting[bool]
+	VaultSignedResponseRequestIDEnabled      Setting[bool]
+	GatewayHTTPGlobalRate                    Setting[config.Rate]
+	GatewayHTTPPerNodeRate                   Setting[config.Rate]
+	GatewayConfidentialRelayGlobalRate       Setting[config.Rate]
+	GatewayConfidentialRelayPerNodeRate      Setting[config.Rate]
+	GatewayHTTPActionMtlsRequestRate         Setting[config.Rate]
+	GatewayHTTPActionMtlsConcurrencyLimit    Setting[int] `unit:"{request}"`
+	TriggerRegistrationStatusUpdateTimeout   Setting[time.Duration]
 
 	BaseTriggerRetryInterval   Setting[time.Duration]
 	BaseTriggerMaxRetries      Setting[int] `unit:"{attempt}"`
@@ -372,11 +378,13 @@ type Workflows struct {
 	HTTPAction       httpAction
 	ConfidentialHTTP confidentialHTTP
 	Secrets          secrets
+	DONTime          donTime
 
-	FeatureMultiTriggerExecutionIDsActiveAt        Setting[config.Timestamp] // Deprecated
-	FeatureMultiTriggerExecutionIDsActivePeriod    Setting[Range[config.Timestamp]]
-	FeatureChainCapabilityHashBasedOCRActivePeriod Setting[Range[config.Timestamp]]
-	FeatureEVMWriteReportL1FeeActivePeriod         Setting[Range[config.Timestamp]]
+	FeatureMultiTriggerExecutionIDsActiveAt           Setting[config.Timestamp] // Deprecated
+	FeatureMultiTriggerExecutionIDsActivePeriod       Setting[Range[config.Timestamp]]
+	FeatureUseSingleDONTimeProviderPerExecutionActivePeriod Setting[Range[config.Timestamp]]
+	FeatureChainCapabilityHashBasedOCRActivePeriod    Setting[Range[config.Timestamp]]
+	FeatureEVMWriteReportL1FeeActivePeriod            Setting[Range[config.Timestamp]]
 	FeatureAptosWriteReportBlockTimestampActivePeriod Setting[Range[config.Timestamp]]
 }
 
@@ -419,12 +427,12 @@ type chainRead struct {
 	PayloadSizeLimit   Setting[config.Size]
 }
 type httpAction struct {
-	CallLimit           Setting[int] `unit:"{call}"`
-	CacheAgeLimit       Setting[time.Duration]
-	ConnectionTimeout   Setting[time.Duration]
-	RequestSizeLimit    Setting[config.Size]
-	ResponseSizeLimit   Setting[config.Size]
-	GatewayProxyDonID   Setting[string]
+	CallLimit         Setting[int] `unit:"{call}"`
+	CacheAgeLimit     Setting[time.Duration]
+	ConnectionTimeout Setting[time.Duration]
+	RequestSizeLimit  Setting[config.Size]
+	ResponseSizeLimit Setting[config.Size]
+	GatewayProxyDonID Setting[string]
 }
 type perOrgHTTPAction struct {
 	MtlsRateLimit Setting[config.Rate]
@@ -441,4 +449,8 @@ type secrets struct {
 type consensus struct {
 	ObservationSizeLimit Setting[config.Size]
 	CallLimit            Setting[int] `unit:"{call}"`
+}
+
+type donTime struct {
+	RequestTimeout Setting[time.Duration]
 }

--- a/pkg/settings/cresettings/settings_test.go
+++ b/pkg/settings/cresettings/settings_test.go
@@ -109,6 +109,9 @@ func TestSchema_Unmarshal(t *testing.T) {
 		"Secrets": {
 			"CallLimit": "5"
 		},
+		"DONTime": {
+			"RequestTimeout": "45s"
+		},
 		"ChainWrite": {
 			"EVM": {
 				"TransactionGasLimit": "500000"
@@ -118,6 +121,7 @@ func TestSchema_Unmarshal(t *testing.T) {
 			"CallLimit": "3"
 		},
 		"FeatureMultiTriggerExecutionIDsActiveAt": "2025-06-15 00:00:00 +0000 UTC",
+		"FeatureUseSingleDONTimeProviderPerExecutionActivePeriod": "[2025-08-15 00:00:00 +0000 UTC,2025-09-15 00:00:00 +0000 UTC]",
 		"FeatureChainCapabilityHashBasedOCRActivePeriod": "[2025-07-15 00:00:00 +0000 UTC,2025-08-15 00:00:00 +0000 UTC]",
 		"FeatureEVMWriteReportL1FeeActivePeriod": "[2025-09-15 00:00:00 +0000 UTC,2025-10-15 00:00:00 +0000 UTC]",
 		"FeatureAptosWriteReportBlockTimestampActivePeriod": "[2025-11-15 00:00:00 +0000 UTC,2025-12-15 00:00:00 +0000 UTC]"
@@ -149,9 +153,14 @@ func TestSchema_Unmarshal(t *testing.T) {
 	assert.Equal(t, 5, cfg.PerWorkflow.ConfidentialHTTP.CallLimit.DefaultValue)
 	assert.Equal(t, 10*config.KByte, cfg.PerWorkflow.ConfidentialHTTP.RequestSizeLimit.DefaultValue)
 	assert.Equal(t, 5, cfg.PerWorkflow.Secrets.CallLimit.DefaultValue)
+	assert.Equal(t, 45*time.Second, cfg.PerWorkflow.DONTime.RequestTimeout.DefaultValue)
 	assert.Equal(t, uint64(500000), cfg.PerWorkflow.ChainWrite.EVM.TransactionGasLimit.DefaultValue)
 	assert.Equal(t, 3, cfg.PerWorkflow.ChainRead.CallLimit.DefaultValue)
 	assert.Equal(t, config.Timestamp(time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC).Unix()), cfg.PerWorkflow.FeatureMultiTriggerExecutionIDsActiveAt.DefaultValue)
+	assert.Equal(t, settings.Range[config.Timestamp]{
+		Lower: config.Timestamp(time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC).Unix()),
+		Upper: config.Timestamp(time.Date(2025, 9, 15, 0, 0, 0, 0, time.UTC).Unix()),
+	}, cfg.PerWorkflow.FeatureUseSingleDONTimeProviderPerExecutionActivePeriod.DefaultValue)
 	assert.Equal(t, settings.Range[config.Timestamp]{
 		Lower: config.Timestamp(time.Date(2025, 7, 15, 0, 0, 0, 0, time.UTC).Unix()),
 		Upper: config.Timestamp(time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC).Unix()),
@@ -164,6 +173,67 @@ func TestSchema_Unmarshal(t *testing.T) {
 		Lower: config.Timestamp(time.Date(2025, 11, 15, 0, 0, 0, 0, time.UTC).Unix()),
 		Upper: config.Timestamp(time.Date(2025, 12, 15, 0, 0, 0, 0, time.UTC).Unix()),
 	}, cfg.PerWorkflow.FeatureAptosWriteReportBlockTimestampActivePeriod.DefaultValue)
+}
+
+func TestDONTimeRequestTimeoutKeyInit(t *testing.T) {
+	s := Default.PerWorkflow.DONTime.RequestTimeout
+
+	assert.Equal(t, "PerWorkflow.DONTime.RequestTimeout", s.GetKey())
+	assert.Equal(t, settings.ScopeWorkflow, s.Scope)
+	assert.NotNil(t, s.Parse)
+	assert.Equal(t, 30*time.Second, s.DefaultValue)
+
+	got, err := s.Parse("1m")
+	require.NoError(t, err)
+	assert.Equal(t, time.Minute, got)
+}
+
+func TestDONTimeRequestTimeoutGetOrDefault(t *testing.T) {
+	setting := Default.PerWorkflow.DONTime.RequestTimeout
+	ctx := contexts.WithCRE(t.Context(), contexts.CRE{Org: "test-org", Owner: "test-owner", Workflow: "test-wf"})
+	overrideCtx := contexts.WithCRE(t.Context(), contexts.CRE{Owner: "owner-id", Workflow: "test-wf-id"})
+
+	got, err := setting.GetOrDefault(ctx, DefaultGetter)
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, got)
+
+	got, err = setting.GetOrDefault(overrideCtx, DefaultGetter)
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, got)
+
+	t.Cleanup(reinit)
+	t.Setenv(EnvNameSettings, `{
+	"workflow": {
+		"test-wf-id": {
+			"PerWorkflow": {
+				"DONTime": {
+					"RequestTimeout": "1m"
+				}
+			}
+		}
+	}
+}`)
+	reinit()
+
+	got, err = setting.GetOrDefault(ctx, DefaultGetter)
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, got)
+
+	got, err = setting.GetOrDefault(overrideCtx, DefaultGetter)
+	require.NoError(t, err)
+	assert.Equal(t, time.Minute, got)
+}
+
+func TestFeatureUseSingleDONTimeProviderPerExecutionActivePeriodKeyInit(t *testing.T) {
+	s := Default.PerWorkflow.FeatureUseSingleDONTimeProviderPerExecutionActivePeriod
+
+	assert.Equal(t, "PerWorkflow.FeatureUseSingleDONTimeProviderPerExecutionActivePeriod", s.GetKey())
+	assert.Equal(t, settings.ScopeWorkflow, s.Scope)
+	assert.NotNil(t, s.Parse)
+	assert.Equal(t, settings.Range[config.Timestamp]{
+		Lower: config.Timestamp(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
+		Upper: config.Timestamp(time.Date(2101, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
+	}, s.DefaultValue)
 }
 
 func TestGatewayProxyDonIDKeyInit(t *testing.T) {


### PR DESCRIPTION
1. Timeout to be used by the Engine when waiting for DONTime response.
2. Flag to refactor Engine to use a single instance of TimeProvider for the whole execution.

Core counterpart: https://github.com/smartcontractkit/chainlink/pull/22919