### PR TITLE
adding label to durable emitter emit latency metric

### DIFF
--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -428,7 +428,7 @@ func (d *DurableEmitter) Emit(ctx context.Context, body []byte, attrKVs ...any) 
 				h.OnEmitInsert(insElapsed, res.err)
 			}
 			if d.metrics != nil {
-				d.metrics.emitDuration.Record(ctx, insElapsed.Seconds())
+				d.metrics.recordEmitDuration(ctx, insElapsed, res.err)
 				if res.err != nil {
 					d.metrics.emitFail.Add(ctx, 1)
 				} else {
@@ -447,7 +447,7 @@ func (d *DurableEmitter) Emit(ctx context.Context, body []byte, attrKVs ...any) 
 				h.OnEmitInsert(insElapsed, err)
 			}
 			if d.metrics != nil {
-				d.metrics.emitDuration.Record(ctx, insElapsed.Seconds())
+				d.metrics.recordEmitDuration(ctx, insElapsed, err)
 				if err != nil {
 					d.metrics.emitFail.Add(ctx, 1)
 				} else {

--- a/pkg/durableemitter/durable_emitter_metrics.go
+++ b/pkg/durableemitter/durable_emitter_metrics.go
@@ -101,7 +101,7 @@ func newDurableEmitterMetrics(meter metric.Meter) (*durableEmitterMetrics, error
 	if m.emitDuration, err = meter.Float64Histogram(
 		"durable_emitter.emit.duration",
 		metric.WithUnit("s"),
-		metric.WithDescription("Emit insert path duration (seconds, fractional; aligns with Prometheus _duration_seconds)"),
+		metric.WithDescription("Emit insert path duration (seconds, fractional; aligns with Prometheus _duration_seconds); labels: error={true,false}"),
 		durationBuckets,
 	); err != nil {
 		return nil, err
@@ -317,6 +317,15 @@ func (m *durableEmitterMetrics) recordQueueStats(ctx context.Context, st Durable
 	if maxBytes > 0 {
 		m.queueCapacityRatio.Record(ctx, float64(st.PayloadBytes)/float64(maxBytes))
 	}
+}
+
+func (m *durableEmitterMetrics) recordEmitDuration(ctx context.Context, elapsed time.Duration, err error) {
+	if m == nil {
+		return
+	}
+	m.emitDuration.Record(ctx, elapsed.Seconds(),
+		metric.WithAttributes(attribute.Bool("error", err != nil)),
+	)
 }
 
 func (m *durableEmitterMetrics) recordPublish(ctx context.Context, elapsed time.Duration, phase string, err error) {


### PR DESCRIPTION
Adding the status of the call to emit will help us identify the source of high p99 latencies.
