### PR TITLE
Doc: fix utils.StartStopOnce Deprecation notice

### DIFF
--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -221,7 +221,7 @@ type service struct {
 	subs []Service
 }
 
-// Ready implements [HealthReporter.Ready] and overrides and extends [utils.StartStopOnce.Ready()] to include [Config.SubServices]
+// Ready implements [HealthReporter.Ready] and overrides and extends [services.StateMachine.Ready()] to include [Config.SubServices]
 // readiness as well.
 func (s *service) Ready() (err error) {
 	err = s.StateMachine.Ready()

--- a/pkg/utils/start_stop_once.go
+++ b/pkg/utils/start_stop_once.go
@@ -7,4 +7,6 @@ import (
 // StartStopOnce can be embedded in a struct to help implement types.Service.
 //
 // Deprecated: use services.StateMachine
+//
+//go:fix inline
 type StartStopOnce = services.StateMachine

--- a/pkg/utils/start_stop_once.go
+++ b/pkg/utils/start_stop_once.go
@@ -5,5 +5,6 @@ import (
 )
 
 // StartStopOnce can be embedded in a struct to help implement types.Service.
+//
 // Deprecated: use services.StateMachine
 type StartStopOnce = services.StateMachine


### PR DESCRIPTION
🥜 Update [utils.StartStopOnce](https://github.com/smartcontractkit/chainlink-common/tree/main/pkg/utils/start_stop_once.go#L12)'s deprecation notice so that linter picks up it is deprecated, with quick autofix for replacing it with `services.StateMachine`. See https://go.dev/wiki/Deprecated .
