### PR TITLE
DurableEmitter: Default idempotency key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -158,3 +158,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/smartcontractkit/chainlink-common/pkg/chipingress => ./pkg/chipingress

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.100
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260528204832-58c7145c53f8
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b
@@ -158,5 +158,3 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/smartcontractkit/chainlink-common/pkg/chipingress => ./pkg/chipingress

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/smartcontractkit/chain-selectors v1.0.100 h1:wpiSpmI/eFjY+wx/nPr5VuNF4hki0prIBMKEaQWn3g4=
 github.com/smartcontractkit/chain-selectors v1.0.100/go.mod h1:qy7whtgG5g+7z0jt0nRyii9bLND9m15NZTzuQPkMZ5w=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260528204832-58c7145c53f8 h1:5O2qAtvBLzTHBeSIPcxt9i9BCqqOyeroVxN0xbXwoS0=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260528204832-58c7145c53f8/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4 h1:GCzrxDWn3b7jFfEA+WiYRi8CKoegsayiDoJBCjYkneE=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4/go.mod h1:HHGeDUpAsPa0pmOx7wrByCitjQ0mbUxf0R9v+g67uCA=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b h1:VDgJWDipihV9f7M5+d21d1RzSsg5rEv+iI12oN1VQbo=

--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -3,6 +3,7 @@ package durableemitter
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -372,16 +373,16 @@ func (d *DurableEmitter) Emit(ctx context.Context, body []byte, attrKVs ...any) 
 		}
 
 		attrs := parseAttrs(attrKVs...)
-        if key, _ := attrs[chipingress.IdempotencyKeyAttr].(string); key == "" {
-            h := sha256.New()
-            for _, s := range []string{sourceDomain, entityType} {
-                h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(s))))
-                h.Write([]byte(s))
-            }
-            h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(body))))
-            h.Write(body)
-            attrs[chipingress.IdempotencyKeyAttr] = hex.EncodeToString(h.Sum(nil))
-        }
+		if key, _ := attrs[chipingress.IdempotencyKeyAttr].(string); key == "" {
+			h := sha256.New()
+			for _, s := range []string{sourceDomain, entityType} {
+				h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(s))))
+				h.Write([]byte(s))
+			}
+			h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(body))))
+			h.Write(body)
+			attrs[chipingress.IdempotencyKeyAttr] = hex.EncodeToString(h.Sum(nil))
+		}
 
 		event, err := chipingress.NewEvent(sourceDomain, entityType, body, attrs)
 		if err != nil {

--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -373,24 +373,7 @@ func (d *DurableEmitter) Emit(ctx context.Context, body []byte, attrKVs ...any) 
 		}
 
 		attrs := parseAttrs(attrKVs...)
-		if key, _ := attrs[chipingress.IdempotencyKeyAttr].(string); key == "" {
-				h := sha256.New()
-				var lenBuf [4]byte
-				writeString := func(s string) {
-					binary.BigEndian.PutUint32(lenBuf[:], uint32(len(s)))
-					_, _ = h.Write(lenBuf[:])
-					_, _ = io.WriteString(h, s)
-				}
-				writeBytes := func(b []byte) {
-					binary.BigEndian.PutUint32(lenBuf[:], uint32(len(b)))
-					_, _ = h.Write(lenBuf[:])
-					_, _ = h.Write(b)
-				}
-				writeString(sourceDomain)
-				writeString(entityType)
-				writeBytes(body)
-				attrs[chipingress.IdempotencyKeyAttr] = hex.EncodeToString(h.Sum(nil))
-		}
+		ensureIdempotencyKey(attrs, sourceDomain, entityType, body)
 
 		event, err := chipingress.NewEvent(sourceDomain, entityType, body, attrs)
 		if err != nil {
@@ -971,6 +954,26 @@ func (d *DurableEmitter) metricsLoop() {
 			d.metrics.pollProcessGauges(ctx)
 		}
 	}
+}
+
+// ensureIdempotencyKey sets attrs[IdempotencyKeyAttr] to a deterministic hash
+// of source, type, and body when the caller did not supply a non-empty key.
+func ensureIdempotencyKey(attrs map[string]any, sourceDomain, entityType string, body []byte) {
+	if val, ok := attrs[chipingress.IdempotencyKeyAttr].(string); ok && val != "" {
+		return
+	}
+	attrs[chipingress.IdempotencyKeyAttr] = defaultIdempotencyKey(sourceDomain, entityType, body)
+}
+
+func defaultIdempotencyKey(sourceDomain, entityType string, body []byte) string {
+	h := sha256.New()
+	for _, s := range []string{sourceDomain, entityType} {
+		h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(s))))
+		h.Write([]byte(s))
+	}
+	h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(body))))
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // parseAttrs converts a variadic slice of (key, value) pairs (with optional

--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -2,6 +2,8 @@ package durableemitter
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -369,7 +371,13 @@ func (d *DurableEmitter) Emit(ctx context.Context, body []byte, attrKVs ...any) 
 			return err
 		}
 
-		event, err := chipingress.NewEvent(sourceDomain, entityType, body, parseAttrs(attrKVs...))
+		attrs := parseAttrs(attrKVs...)
+		if key, _ := attrs[chipingress.IdempotencyKeyAttr].(string); key == "" {
+			sum := sha256.Sum256(body)
+			attrs[chipingress.IdempotencyKeyAttr] = hex.EncodeToString(sum[:])
+		}
+
+		event, err := chipingress.NewEvent(sourceDomain, entityType, body, attrs)
 		if err != nil {
 			emitFail()
 			return err

--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -374,14 +374,22 @@ func (d *DurableEmitter) Emit(ctx context.Context, body []byte, attrKVs ...any) 
 
 		attrs := parseAttrs(attrKVs...)
 		if key, _ := attrs[chipingress.IdempotencyKeyAttr].(string); key == "" {
-			h := sha256.New()
-			for _, s := range []string{sourceDomain, entityType} {
-				h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(s))))
-				h.Write([]byte(s))
-			}
-			h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(body))))
-			h.Write(body)
-			attrs[chipingress.IdempotencyKeyAttr] = hex.EncodeToString(h.Sum(nil))
+				h := sha256.New()
+				var lenBuf [4]byte
+				writeString := func(s string) {
+					binary.BigEndian.PutUint32(lenBuf[:], uint32(len(s)))
+					_, _ = h.Write(lenBuf[:])
+					_, _ = io.WriteString(h, s)
+				}
+				writeBytes := func(b []byte) {
+					binary.BigEndian.PutUint32(lenBuf[:], uint32(len(b)))
+					_, _ = h.Write(lenBuf[:])
+					_, _ = h.Write(b)
+				}
+				writeString(sourceDomain)
+				writeString(entityType)
+				writeBytes(body)
+				attrs[chipingress.IdempotencyKeyAttr] = hex.EncodeToString(h.Sum(nil))
 		}
 
 		event, err := chipingress.NewEvent(sourceDomain, entityType, body, attrs)

--- a/pkg/durableemitter/durable_emitter.go
+++ b/pkg/durableemitter/durable_emitter.go
@@ -372,10 +372,16 @@ func (d *DurableEmitter) Emit(ctx context.Context, body []byte, attrKVs ...any) 
 		}
 
 		attrs := parseAttrs(attrKVs...)
-		if key, _ := attrs[chipingress.IdempotencyKeyAttr].(string); key == "" {
-			sum := sha256.Sum256(body)
-			attrs[chipingress.IdempotencyKeyAttr] = hex.EncodeToString(sum[:])
-		}
+        if key, _ := attrs[chipingress.IdempotencyKeyAttr].(string); key == "" {
+            h := sha256.New()
+            for _, s := range []string{sourceDomain, entityType} {
+                h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(s))))
+                h.Write([]byte(s))
+            }
+            h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(body))))
+            h.Write(body)
+            attrs[chipingress.IdempotencyKeyAttr] = hex.EncodeToString(h.Sum(nil))
+        }
 
 		event, err := chipingress.NewEvent(sourceDomain, entityType, body, attrs)
 		if err != nil {

--- a/pkg/durableemitter/durable_emitter_test.go
+++ b/pkg/durableemitter/durable_emitter_test.go
@@ -2,6 +2,8 @@ package durableemitter
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"net"
 	"sort"
@@ -1141,6 +1143,76 @@ func TestIntegration_GRPCConnection(t *testing.T) {
 
 	assert.Equal(t, "test-domain", received.Source)
 	assert.Equal(t, "test-entity", received.Type)
+}
+
+func TestDurableEmitter_IdempotencyKeyDefaultsToBodyHash(t *testing.T) {
+	store := NewMemDurableEventStore()
+	be := newTestBatchEmitter()
+	be.setPublishErr(errors.New("hold"))
+	cfg := DefaultConfig()
+	cfg.RetransmitInterval = 10 * time.Minute // no retransmit during test
+	em, err := NewDurableEmitter(store, be, nil, true, cfg, logger.Test(t), nil)
+	require.NoError(t, err)
+	servicetest.Run(t, em)
+	ctx := t.Context()
+
+	body := []byte("deterministic-body")
+	require.NoError(t, em.Emit(ctx, body, testEmitAttrs()...))
+	require.Eventually(t, func() bool { return be.callCount.Load() == 1 }, 2*time.Second, 10*time.Millisecond)
+
+	// Event stays in store (publish failed). Unmarshal stored proto and check attribute.
+	store.mu.Lock()
+	var stored []byte
+	for _, e := range store.events {
+		stored = append([]byte(nil), e.Payload...)
+		break
+	}
+	store.mu.Unlock()
+	require.NotNil(t, stored, "event should still be in store")
+
+	var eventPb cepb.CloudEvent
+	require.NoError(t, proto.Unmarshal(stored, &eventPb))
+
+	attr, ok := eventPb.Attributes[chipingress.IdempotencyKeyAttr]
+	require.True(t, ok, "idempotencykey attribute must be set")
+	expectedSum := sha256.Sum256(body)
+	expectedKey := hex.EncodeToString(expectedSum[:])
+	require.Equal(t, expectedKey, attr.GetCeString())
+}
+
+func TestDurableEmitter_IdempotencyKeyCallerSupplied(t *testing.T) {
+	store := NewMemDurableEventStore()
+	be := newTestBatchEmitter()
+	be.setPublishErr(errors.New("hold"))
+	cfg := DefaultConfig()
+	cfg.RetransmitInterval = 10 * time.Minute
+	em, err := NewDurableEmitter(store, be, nil, true, cfg, logger.Test(t), nil)
+	require.NoError(t, err)
+	servicetest.Run(t, em)
+	ctx := t.Context()
+
+	callerKey := "my-idempotency-key-abc123"
+	body := []byte("some-body")
+	attrs := append(testEmitAttrs(), chipingress.IdempotencyKeyAttr, callerKey)
+	require.NoError(t, em.Emit(ctx, body, attrs...))
+
+	require.Eventually(t, func() bool { return be.callCount.Load() == 1 }, 2*time.Second, 10*time.Millisecond)
+
+	store.mu.Lock()
+	var stored []byte
+	for _, e := range store.events {
+		stored = append([]byte(nil), e.Payload...)
+		break
+	}
+	store.mu.Unlock()
+	require.NotNil(t, stored)
+
+	var eventPb cepb.CloudEvent
+	require.NoError(t, proto.Unmarshal(stored, &eventPb))
+
+	attr, ok := eventPb.Attributes[chipingress.IdempotencyKeyAttr]
+	require.True(t, ok, "idempotencykey attribute must be present")
+	require.Equal(t, callerKey, attr.GetCeString(), "caller-supplied key must be preserved")
 }
 
 // MemDurableEventStore is an in-memory DurableEventStore for unit tests.

--- a/pkg/durableemitter/durable_emitter_test.go
+++ b/pkg/durableemitter/durable_emitter_test.go
@@ -1225,6 +1225,47 @@ func TestDurableEmitter_IdempotencyKeyCallerSupplied(t *testing.T) {
 	require.Equal(t, callerKey, attr.GetCeString(), "caller-supplied key must be preserved")
 }
 
+func BenchmarkDefaultIdempotencyKey(b *testing.B) {
+	const sourceDomain = "test-source"
+	const entityType = "test-type"
+
+	for name, size := range map[string]int{"64B": 64, "1KB": 1024, "4KB": 4096} {
+		body := make([]byte, size)
+		for i := range body {
+			body[i] = byte(i)
+		}
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			for i := 0; i < b.N; i++ {
+				defaultIdempotencyKey(sourceDomain, entityType, body)
+			}
+		})
+	}
+}
+
+func BenchmarkEnsureIdempotencyKey(b *testing.B) {
+	const sourceDomain = "test-source"
+	const entityType = "test-type"
+	body := []byte("deterministic-body")
+
+	b.Run("DefaultHash", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			attrs := make(map[string]any)
+			ensureIdempotencyKey(attrs, sourceDomain, entityType, body)
+		}
+	})
+
+	b.Run("CallerSupplied", func(b *testing.B) {
+		attrs := map[string]any{chipingress.IdempotencyKeyAttr: "my-idempotency-key-abc123"}
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ensureIdempotencyKey(attrs, sourceDomain, entityType, body)
+		}
+	})
+}
+
 // MemDurableEventStore is an in-memory DurableEventStore for unit tests.
 type MemDurableEventStore struct {
 	mu     sync.Mutex

--- a/pkg/durableemitter/durable_emitter_test.go
+++ b/pkg/durableemitter/durable_emitter_test.go
@@ -1146,7 +1146,7 @@ func TestIntegration_GRPCConnection(t *testing.T) {
 	assert.Equal(t, "test-entity", received.Type)
 }
 
-func TestDurableEmitter_IdempotencyKeyDefaultsToBodyHash(t *testing.T) {
+func TestDurableEmitter_IdempotencyKeyDefaultsToEventHash(t *testing.T) {
 	store := NewMemDurableEventStore()
 	be := newTestBatchEmitter()
 	be.setPublishErr(errors.New("hold"))

--- a/pkg/durableemitter/durable_emitter_test.go
+++ b/pkg/durableemitter/durable_emitter_test.go
@@ -3,6 +3,7 @@ package durableemitter
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"net"
@@ -1175,8 +1176,17 @@ func TestDurableEmitter_IdempotencyKeyDefaultsToBodyHash(t *testing.T) {
 
 	attr, ok := eventPb.Attributes[chipingress.IdempotencyKeyAttr]
 	require.True(t, ok, "idempotencykey attribute must be set")
-	expectedSum := sha256.Sum256(body)
-	expectedKey := hex.EncodeToString(expectedSum[:])
+
+	// The idempotency key is computed as a SHA256 hash of:
+	// source domain (with 4-byte big-endian length) + entity type (with 4-byte big-endian length) + body (with 4-byte big-endian length)
+	h := sha256.New()
+	for _, s := range []string{"test-source", "test-type"} {
+		h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(s))))
+		h.Write([]byte(s))
+	}
+	h.Write(binary.BigEndian.AppendUint32(nil, uint32(len(body))))
+	h.Write(body)
+	expectedKey := hex.EncodeToString(h.Sum(nil))
 	require.Equal(t, expectedKey, attr.GetCeString())
 }
 


### PR DESCRIPTION
This pull request enhances the idempotency handling in the `DurableEmitter` by automatically generating a deterministic idempotency key when one is not supplied.

**Idempotency Key Generation and Testing Improvements:**

* [`pkg/durableemitter/durable_emitter.go`](diffhunk://#diff-bf5153785824bcce4dd2d71df28ee6391f3def652716abe5a72a4c365ffb4b74L372-R387): The `Emit` method now generates a SHA256-based idempotency key from the source domain, entity type, and event body if the caller does not provide one. This ensures event deduplication and deterministic key generation.
* [`pkg/durableemitter/durable_emitter_test.go`](diffhunk://#diff-5009cdc79211faa205b9d43a36002ba14c78c42aa8a630571128d7e84d3ebc5fR1149-R1227): Added tests to verify that the idempotency key is correctly generated by default and that a caller-supplied key is preserved. These tests confirm the robustness of the new idempotency logic.