### PR TITLE
cresettings: add Confidential Compute node and per-owner limits

### DIFF
--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -261,6 +261,14 @@ flowchart
         PerOwner.VaultSecretsLimit{{PerOwner.VaultSecretsLimit}}:::bound
     end
 
+    subgraph ConfidentialCompute[Confidential Compute executor]
+        ConfidentialCompute.GlobalRate[\ConfidentialCompute.GlobalRate/]:::rate
+        PerOwner.ConfidentialCompute.Rate[\PerOwner.ConfidentialCompute.Rate/]:::rate
+        ConfidentialCompute.MaxRetries{{ConfidentialCompute.MaxRetries}}:::bound
+        ConfidentialCompute.RetryBackoff>ConfidentialCompute.RetryBackoff]:::time
+        ConfidentialCompute.SecretsCacheEnabled[/ConfidentialCompute.SecretsCacheEnabled\]:::gate
+    end
+
     handleRequest-->Store.FetchWorkflowArtifacts-->host.NewModule-->Engine.init-->Engine.runTriggerSubscriptionPhase-->triggers-->Engine.handleAllTriggerEvents-->Engine.startExecution
     Engine.startExecution-->ExecutionHelper.CallCapability-->actions
     Engine.startExecution-->PerWorkflow.SecretsConcurrencyLimit-->vault

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -41,6 +41,12 @@
 	"VaultMaxBlobPayloadSizeLimit": "25.6kb",
 	"VaultMaxPerOracleUnexpiredBlobCumulativePayloadSizeLimit": "31.45728mb",
 	"VaultMaxPerOracleUnexpiredBlobCount": "1000",
+	"ConfidentialCompute": {
+		"GlobalRate": "1000rps:1000",
+		"MaxRetries": "3",
+		"RetryBackoff": "2s",
+		"SecretsCacheEnabled": "false"
+	},
 	"PerOrg": {
 		"BaseTriggerRetransmitEnabled": "false",
 		"WorkflowExecutionConcurrencyLimit": "100",
@@ -53,7 +59,10 @@
 		"WorkflowLimit": "1000",
 		"WorkflowExecutionConcurrencyLimit": "5",
 		"VaultCiphertextSizeLimit": "2kb",
-		"VaultSecretsLimit": "100"
+		"VaultSecretsLimit": "100",
+		"ConfidentialCompute": {
+			"Rate": "1000rps:1000"
+		}
 	},
 	"PerWorkflow": {
 		"TriggerRegistrationsTimeout": "10s",

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -41,6 +41,12 @@ VaultMaxBlobPayloadSizeLimit = '25.6kb'
 VaultMaxPerOracleUnexpiredBlobCumulativePayloadSizeLimit = '31.45728mb'
 VaultMaxPerOracleUnexpiredBlobCount = '1000'
 
+[ConfidentialCompute]
+GlobalRate = '1000rps:1000'
+MaxRetries = '3'
+RetryBackoff = '2s'
+SecretsCacheEnabled = 'false'
+
 [PerOrg]
 BaseTriggerRetransmitEnabled = 'false'
 WorkflowExecutionConcurrencyLimit = '100'
@@ -54,6 +60,9 @@ WorkflowLimit = '1000'
 WorkflowExecutionConcurrencyLimit = '5'
 VaultCiphertextSizeLimit = '2kb'
 VaultSecretsLimit = '100'
+
+[PerOwner.ConfidentialCompute]
+Rate = '1000rps:1000'
 
 [PerWorkflow]
 TriggerRegistrationsTimeout = '10s'

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -133,6 +133,16 @@ var Default = Schema{
 	VaultMaxPerOracleUnexpiredBlobCumulativePayloadSizeLimit: Size(31457280 * config.Byte),
 	VaultMaxPerOracleUnexpiredBlobCount:                      Int(1000),
 
+	// Confidential Compute (San Marino framework) node-level settings. Defaults
+	// mirror the previous hardcoded executor defaults so behavior is unchanged
+	// until explicitly overridden.
+	ConfidentialCompute: confidentialCompute{
+		GlobalRate:          Rate(rate.Limit(1000), 1000),
+		MaxRetries:          Int(3),
+		RetryBackoff:        Duration(2 * time.Second),
+		SecretsCacheEnabled: Bool(false),
+	},
+
 	PerOrg: Orgs{
 		BaseTriggerRetransmitEnabled:      Bool(false),
 		WorkflowExecutionConcurrencyLimit: Int(100),
@@ -151,6 +161,12 @@ var Default = Schema{
 		// must ensure that we are overriding the default in the onchain configuration for the contract.
 		VaultCiphertextSizeLimit: Size(2 * config.KByte),
 		VaultSecretsLimit:        Int(100),
+
+		// Confidential Compute per-workflow-owner request rate. Mirrors the
+		// previous hardcoded WorkflowOwner RPS/burst executor defaults.
+		ConfidentialCompute: ownerConfidentialCompute{
+			Rate: Rate(rate.Limit(1000), 1000),
+		},
 	},
 	PerWorkflow: Workflows{
 		TriggerRegistrationsTimeout:   Duration(10 * time.Second),
@@ -321,6 +337,9 @@ type Schema struct {
 	VaultMaxPerOracleUnexpiredBlobCumulativePayloadSizeLimit Setting[config.Size]
 	VaultMaxPerOracleUnexpiredBlobCount                      Setting[int]
 
+	// Confidential Compute (San Marino framework) node-level settings.
+	ConfidentialCompute confidentialCompute
+
 	PerOrg      Orgs      `scope:"org"`
 	PerOwner    Owners    `scope:"owner"`
 	PerWorkflow Workflows `scope:"workflow"`
@@ -337,6 +356,9 @@ type Owners struct {
 	WorkflowExecutionConcurrencyLimit Setting[int] `unit:"{workflow}"`
 	VaultCiphertextSizeLimit          Setting[config.Size]
 	VaultSecretsLimit                 Setting[int] `unit:"{secret}"`
+
+	// ConfidentialCompute holds the per-workflow-owner Confidential Compute settings.
+	ConfidentialCompute ownerConfidentialCompute
 }
 
 type Workflows struct {
@@ -448,6 +470,21 @@ type confidentialHTTP struct {
 	ConnectionTimeout Setting[time.Duration]
 	RequestSizeLimit  Setting[config.Size]
 	ResponseSizeLimit Setting[config.Size]
+}
+
+// confidentialCompute holds node-level Confidential Compute (San Marino
+// framework) settings. These are global scope (no scope tag), like the other
+// top-level settings.
+type confidentialCompute struct {
+	GlobalRate          Setting[config.Rate]
+	MaxRetries          Setting[int] `unit:"{attempt}"`
+	RetryBackoff        Setting[time.Duration]
+	SecretsCacheEnabled Setting[bool]
+}
+
+// ownerConfidentialCompute holds the per-workflow-owner Confidential Compute settings.
+type ownerConfidentialCompute struct {
+	Rate Setting[config.Rate]
 }
 
 type confidentialWorkflows struct {


### PR DESCRIPTION
## Summary
Adds Confidential Compute (San Marino framework) settings to `cresettings` so the executor's rate-limit / retry / secrets-cache configuration can be driven by the CRE limits framework instead of the job spec.

New settings:
- `ConfidentialCompute.GlobalRate` (`config.Rate`, global scope) — node-global request rate; was `GlobalRPS` / `GlobalBurst`
- `ConfidentialCompute.MaxRetries` (`int`) — was `MaxRetries`
- `ConfidentialCompute.RetryBackoff` (`time.Duration`) — was `RetryBackoffSeconds`
- `ConfidentialCompute.SecretsCacheEnabled` (`bool`) — was `EnableSecretsCache`
- `PerOwner.ConfidentialCompute.Rate` (`config.Rate`, owner scope) — per-workflow-owner rate; was `WorkflowOwnerRPS` / `WorkflowOwnerBurst`

Defaults exactly mirror the previous hardcoded executor defaults (`1000rps:1000`, retries `3`, backoff `2s`, cache `false`), so behavior is unchanged until a deployment explicitly overrides them. Regenerated `defaults.json` / `defaults.toml` golden files and updated the `README.md` flowchart with a Confidential Compute subgraph.

## Context (PRIV-504)
First of two PRs migrating Confidential Compute config off the job spec into the limits framework. The consuming change lives in the `confidential-compute` repo (the `RealExecutor`) and depends on this being released and version-bumped there. Migration is staged so nothing changes on deploy: limits become the source of truth, the existing job-spec fields remain as transitional overrides, deployments then move their tuned values into scoped settings overrides, and finally the job-spec fields are removed.

These settings are node-local (rate / retry / cache) and never feed the hashed enclave request, so they carry no DON-to-DON determinism risk.

