### PR TITLE
settings: add Confidential Compute enclave request timeouts (PRIV-504)

### DIFF
--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -267,6 +267,8 @@ flowchart
         ConfidentialCompute.MaxRetries{{ConfidentialCompute.MaxRetries}}:::bound
         ConfidentialCompute.RetryBackoff>ConfidentialCompute.RetryBackoff]:::time
         ConfidentialCompute.SecretsCacheEnabled[/ConfidentialCompute.SecretsCacheEnabled\]:::gate
+        ConfidentialCompute.EnclaveRequestTimeout>ConfidentialCompute.EnclaveRequestTimeout]:::time
+        ConfidentialCompute.PublicKeyRequestTimeout>ConfidentialCompute.PublicKeyRequestTimeout]:::time
     end
 
     handleRequest-->Store.FetchWorkflowArtifacts-->host.NewModule-->Engine.init-->Engine.runTriggerSubscriptionPhase-->triggers-->Engine.handleAllTriggerEvents-->Engine.startExecution

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -45,7 +45,9 @@
 		"GlobalRate": "1000rps:1000",
 		"MaxRetries": "3",
 		"RetryBackoff": "2s",
-		"SecretsCacheEnabled": "false"
+		"SecretsCacheEnabled": "false",
+		"EnclaveRequestTimeout": "30s",
+		"PublicKeyRequestTimeout": "5s"
 	},
 	"PerOrg": {
 		"BaseTriggerRetransmitEnabled": "false",

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -46,6 +46,8 @@ GlobalRate = '1000rps:1000'
 MaxRetries = '3'
 RetryBackoff = '2s'
 SecretsCacheEnabled = 'false'
+EnclaveRequestTimeout = '30s'
+PublicKeyRequestTimeout = '5s'
 
 [PerOrg]
 BaseTriggerRetransmitEnabled = 'false'

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -137,10 +137,12 @@ var Default = Schema{
 	// mirror the previous hardcoded executor defaults so behavior is unchanged
 	// until explicitly overridden.
 	ConfidentialCompute: confidentialCompute{
-		GlobalRate:          Rate(rate.Limit(1000), 1000),
-		MaxRetries:          Int(3),
-		RetryBackoff:        Duration(2 * time.Second),
-		SecretsCacheEnabled: Bool(false),
+		GlobalRate:              Rate(rate.Limit(1000), 1000),
+		MaxRetries:              Int(3),
+		RetryBackoff:            Duration(2 * time.Second),
+		SecretsCacheEnabled:     Bool(false),
+		EnclaveRequestTimeout:   Duration(30 * time.Second),
+		PublicKeyRequestTimeout: Duration(5 * time.Second),
 	},
 
 	PerOrg: Orgs{
@@ -476,10 +478,12 @@ type confidentialHTTP struct {
 // framework) settings. These are global scope (no scope tag), like the other
 // top-level settings.
 type confidentialCompute struct {
-	GlobalRate          Setting[config.Rate]
-	MaxRetries          Setting[int] `unit:"{attempt}"`
-	RetryBackoff        Setting[time.Duration]
-	SecretsCacheEnabled Setting[bool]
+	GlobalRate              Setting[config.Rate]
+	MaxRetries              Setting[int] `unit:"{attempt}"`
+	RetryBackoff            Setting[time.Duration]
+	SecretsCacheEnabled     Setting[bool]
+	EnclaveRequestTimeout   Setting[time.Duration]
+	PublicKeyRequestTimeout Setting[time.Duration]
 }
 
 // ownerConfidentialCompute holds the per-workflow-owner Confidential Compute settings.


### PR DESCRIPTION
## What

Adds two node-level settings to the `ConfidentialCompute` block of the CRE limits framework:

- `ConfidentialCompute.EnclaveRequestTimeout` (`Setting[time.Duration]`, default **30s**)
- `ConfidentialCompute.PublicKeyRequestTimeout` (`Setting[time.Duration]`, default **5s**)

Regenerates the golden `defaults.json` / `defaults.toml` (`go test . -update`) and adds the two keys to the README flowchart so `TestFlowchartComplete` passes.