### PR TITLE
require both flag and endpoint to enable ChipIngress dual emitter

### DIFF
--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -189,7 +189,7 @@ func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (*Client, erro
 	}
 	// if chip ingress is enabled, create dual source emitter that sends to both otel collector and chip ingress
 	// eventually we will remove the dual source emitter and just use chip ingress
-	if cfg.ChipIngressEmitterEnabled || cfg.ChipIngressEmitterGRPCEndpoint != "" {
+	if cfg.ChipIngressEmitterEnabled && cfg.ChipIngressEmitterGRPCEndpoint != "" {
 		var opts []chipingress.Opt
 
 		if cfg.ChipIngressInsecureConnection {

--- a/pkg/beholder/client_test.go
+++ b/pkg/beholder/client_test.go
@@ -304,6 +304,7 @@ func TestNewClient(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 		assert.IsType(t, &chipingress.NoopClient{}, client.Chip)
+		require.NotNil(t, client.Emitter)
 		_, ok := client.Emitter.(*beholder.DualSourceEmitter)
 		assert.False(t, ok)
 	})

--- a/pkg/beholder/client_test.go
+++ b/pkg/beholder/client_test.go
@@ -426,6 +426,7 @@ func TestNewClientWithInvalidChipIngressConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 		assert.IsType(t, &chipingress.NoopClient{}, client.Chip)
+		require.NotNil(t, client.Emitter)
 		_, ok := client.Emitter.(*beholder.DualSourceEmitter)
 		assert.False(t, ok)
 	})

--- a/pkg/beholder/client_test.go
+++ b/pkg/beholder/client_test.go
@@ -534,6 +534,7 @@ func TestNewClient_Chip(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 		assert.IsType(t, &chipingress.NoopClient{}, client.Chip)
+		require.NotNil(t, client.Emitter)
 		_, ok := client.Emitter.(*beholder.DualSourceEmitter)
 		assert.False(t, ok)
 	})

--- a/pkg/beholder/client_test.go
+++ b/pkg/beholder/client_test.go
@@ -296,14 +296,16 @@ func TestNewClient(t *testing.T) {
 		assert.IsType(t, &beholder.DualSourceEmitter{}, client.Emitter)
 	})
 
-	t.Run("errors when ChipIngress is enabled but no endpoint is set", func(t *testing.T) {
+	t.Run("does not enable chip ingress when enabled but endpoint is missing", func(t *testing.T) {
 		client, err := beholder.NewClient(beholder.Config{
 			OtelExporterGRPCEndpoint:  "grpc-endpoint",
 			ChipIngressEmitterEnabled: true,
 		})
-		require.Error(t, err)
-		assert.Nil(t, client)
-		assert.Equal(t, "invalid address format: missing port in address", err.Error())
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		assert.IsType(t, &chipingress.NoopClient{}, client.Chip)
+		_, ok := client.Emitter.(*beholder.DualSourceEmitter)
+		assert.False(t, ok)
 	})
 }
 
@@ -414,15 +416,17 @@ func TestNewClientWithInvalidChipIngressConfig(t *testing.T) {
 		assert.Nil(t, client)
 	})
 
-	t.Run("errors when ChipIngress enabled with empty endpoint", func(t *testing.T) {
+	t.Run("does not enable ChipIngress when enabled with empty endpoint", func(t *testing.T) {
 		client, err := beholder.NewClient(beholder.Config{
 			OtelExporterGRPCEndpoint:       "grpc-endpoint",
 			ChipIngressEmitterEnabled:      true,
 			ChipIngressEmitterGRPCEndpoint: "",
 		})
-		require.Error(t, err)
-		assert.Nil(t, client)
-		assert.Contains(t, err.Error(), "invalid address format: missing port in address")
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		assert.IsType(t, &chipingress.NoopClient{}, client.Chip)
+		_, ok := client.Emitter.(*beholder.DualSourceEmitter)
+		assert.False(t, ok)
 	})
 
 	t.Run("errors when ChipIngress enabled with whitespace-only endpoint", func(t *testing.T) {
@@ -503,7 +507,7 @@ func TestNewClient_Chip(t *testing.T) {
 		assert.IsType(t, &beholder.DualSourceEmitter{}, client.Emitter)
 	})
 
-	t.Run("chip interface can be enabled when chip ingress dual emitter is not enabled ", func(t *testing.T) {
+	t.Run("chip interface remains noop when endpoint is set but dual emitter is disabled", func(t *testing.T) {
 		client, err := beholder.NewClient(beholder.Config{
 			OtelExporterGRPCEndpoint:       "grpc-endpoint",
 			ChipIngressEmitterEnabled:      false,
@@ -512,19 +516,24 @@ func TestNewClient_Chip(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.NotNil(t, client)
-		assert.NotNil(t, client.Chip)
+		assert.IsType(t, &chipingress.NoopClient{}, client.Chip)
 
-		// Verify emitter is not dual source when dual emitter is disabled
+		// Verify emitter is not dual source when dual emitter is disabled.
 		assert.NotNil(t, client.Emitter)
+		_, ok := client.Emitter.(*beholder.DualSourceEmitter)
+		assert.False(t, ok)
 	})
 
-	t.Run("chip interface is nil when chip ingress config is missing", func(t *testing.T) {
+	t.Run("chip interface remains noop when chip ingress endpoint is missing", func(t *testing.T) {
 		client, err := beholder.NewClient(beholder.Config{
 			OtelExporterGRPCEndpoint:  "grpc-endpoint",
 			ChipIngressEmitterEnabled: true,
 		})
-		require.Error(t, err)
-		assert.Nil(t, client)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		assert.IsType(t, &chipingress.NoopClient{}, client.Chip)
+		_, ok := client.Emitter.(*beholder.DualSourceEmitter)
+		assert.False(t, ok)
 	})
 }
 


### PR DESCRIPTION
This pull request refines the logic for enabling the Chip Ingress dual source emitter in the `beholder` client, ensuring it is only activated when both the feature flag and a valid endpoint are set. Corresponding unit tests are updated to reflect the new behavior, verifying that the system gracefully falls back to a no-op client when configuration is incomplete.

**Configuration logic improvements:**

* The condition for enabling the Chip Ingress dual source emitter in `pkg/beholder/client.go` now requires both `ChipIngressEmitterEnabled` to be true and `ChipIngressEmitterGRPCEndpoint` to be non-empty, preventing accidental activation with incomplete configuration.
