### PR TITLE
Handle nil pointer error

### DIFF
--- a/observability-lib/api/dashboard.go
+++ b/observability-lib/api/dashboard.go
@@ -50,7 +50,8 @@ func (c *Client) GetDashboardByNameFolderUID(name string, folderUID string) (Get
 
 type PostDashboardRequest struct {
 	Dashboard interface{} `json:"dashboard"`
-	FolderID  int         `json:"folderId"`
+	FolderID  int         `json:"folderId,omitempty"`
+	FolderUID string      `json:"folderUid,omitempty"`
 	Overwrite bool        `json:"overwrite"`
 }
 

--- a/observability-lib/api/dashboard.go
+++ b/observability-lib/api/dashboard.go
@@ -36,6 +36,9 @@ func (c *Client) GetDashboardByNameFolderUID(name string, folderUID string) (Get
 
 	if len(grafanaResp) > 0 {
 		for _, dashboard := range grafanaResp {
+			if dashboard.Title == nil || dashboard.FolderUID == nil {
+				continue
+			}
 			if strings.EqualFold(*dashboard.Title, name) && strings.EqualFold(*dashboard.FolderUID, folderUID) {
 				return dashboard, resp, nil
 			}

--- a/observability-lib/api/dashboard.go
+++ b/observability-lib/api/dashboard.go
@@ -36,7 +36,7 @@ func (c *Client) GetDashboardByNameFolderUID(name string, folderUID string) (Get
 
 	if len(grafanaResp) > 0 {
 		for _, dashboard := range grafanaResp {
-			if dashboard.Title == nil || dashboard.FolderUID == nil {
+			if dashboard.Title == nil || dashboard.FolderUID == nil || dashboard.UID == nil {
 				continue
 			}
 			if strings.EqualFold(*dashboard.Title, name) && strings.EqualFold(*dashboard.FolderUID, folderUID) {

--- a/observability-lib/api/folder.go
+++ b/observability-lib/api/folder.go
@@ -35,7 +35,7 @@ func (c *Client) GetFolderByUID(uid string) (*Folder, error) {
 	resp, err := c.resty.R().
 		SetHeader("Accept", "application/json").
 		SetResult(&folder).
-		Get(fmt.Sprintf("/api/folders/%s", uid))
+		Get("/api/folders/" + uid)
 
 	if err != nil {
 		return nil, fmt.Errorf("error making API request: %w", err)

--- a/observability-lib/api/folder.go
+++ b/observability-lib/api/folder.go
@@ -28,6 +28,30 @@ func (c *Client) FindOrCreateFolder(name string) (*Folder, error) {
 	return folder, nil
 }
 
+// GetFolderByUID returns a folder by UID.
+func (c *Client) GetFolderByUID(uid string) (*Folder, error) {
+	var folder Folder
+
+	resp, err := c.resty.R().
+		SetHeader("Accept", "application/json").
+		SetResult(&folder).
+		Get(fmt.Sprintf("/api/folders/%s", uid))
+
+	if err != nil {
+		return nil, fmt.Errorf("error making API request: %w", err)
+	}
+
+	statusCode := resp.StatusCode()
+	if statusCode == 404 {
+		return nil, nil
+	}
+	if statusCode != 200 {
+		return nil, fmt.Errorf("error fetching folder %q, received unexpected status code %d: %s", uid, statusCode, resp.String())
+	}
+
+	return &folder, nil
+}
+
 // GetFolderByTitle Get a folder by title
 func (c *Client) GetFolderByTitle(title string) (*Folder, error) {
 	folders, _, err := c.GetFolders()

--- a/observability-lib/grafana/dashboard.go
+++ b/observability-lib/grafana/dashboard.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 
 	"github.com/grafana/grafana-foundation-sdk/go/alerting"
@@ -39,9 +40,27 @@ type DeployOptions struct {
 	GrafanaURL             string
 	GrafanaToken           string
 	FolderName             string
+	FolderUID              string // when set, deploy to this folder instead of resolving FolderName by title
 	EnableAlerts           bool
 	RuleGroupFromDashboard bool // if true, set the alert rule group to the dashboard title on all alerts
 	NotificationTemplates  string
+}
+
+func resolveDeployFolder(client *api.Client, options *DeployOptions) (*api.Folder, error) {
+	if options.FolderUID != "" {
+		folder, err := client.GetFolderByUID(options.FolderUID)
+		if err != nil {
+			return nil, err
+		}
+		if folder == nil {
+			return nil, fmt.Errorf("folder with UID %q not found", options.FolderUID)
+		}
+		return folder, nil
+	}
+	if options.FolderName != "" {
+		return client.FindOrCreateFolder(options.FolderName)
+	}
+	return nil, nil
 }
 
 func alertRuleExist(alerts []alerting.Rule, alert alerting.Rule) bool {
@@ -95,13 +114,9 @@ func (o *Observability) DeployToGrafana(options *DeployOptions) error {
 	)
 
 	// Create or update folder
-	var folder *api.Folder
-	var errFolder error
-	if options.FolderName != "" {
-		folder, errFolder = grafanaClient.FindOrCreateFolder(options.FolderName)
-		if errFolder != nil {
-			return errFolder
-		}
+	folder, errFolder := resolveDeployFolder(grafanaClient, options)
+	if errFolder != nil {
+		return errFolder
 	}
 
 	// Create or update dashboard
@@ -123,11 +138,13 @@ func (o *Observability) DeployToGrafana(options *DeployOptions) error {
 			newDashboard, _, errPostDashboard = grafanaClient.PostDashboard(api.PostDashboardRequest{
 				Dashboard: o.Dashboard,
 				Overwrite: true,
-				//nolint:gosec // disable G115
-				FolderID: int(folder.ID),
+				FolderUID: folder.UID,
 			})
 			if errPostDashboard != nil {
 				return errPostDashboard
+			}
+			if newDashboard.URL != nil && o.Dashboard.Title != nil {
+				fmt.Fprintf(os.Stderr, "deployed dashboard %q to folder uid=%s: %s\n", *o.Dashboard.Title, folder.UID, *newDashboard.URL)
 			}
 		}
 	}


### PR DESCRIPTION
- Handle nil pointer error when fetching dashboards.
- Add option to deploy using folder UID. Generally the folder UID resolves properly but I hit a case when it did not and as a result I had missing dashboards. This is an additive change which does not hurt in case we run into the same issue again.
