### PR TITLE
Add Beholder OTel SDK metric cardinality limit

### DIFF
--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -549,11 +549,11 @@ func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, cre
 	for _, p := range cfg.MetricProducers {
 		readerOpts = append(readerOpts, sdkmetric.WithProducer(p))
 	}
-	return sdkmetric.NewMeterProvider(
+	mpOpts := cfg.metricOptions(
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, readerOpts...)),
 		sdkmetric.WithResource(resource),
-		sdkmetric.WithView(cfg.MetricViews...),
-	), nil
+	)
+	return sdkmetric.NewMeterProvider(mpOpts...), nil
 }
 
 // newLoggerOpts creates options for a logger exporter

--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -549,7 +549,7 @@ func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, cre
 	for _, p := range cfg.MetricProducers {
 		readerOpts = append(readerOpts, sdkmetric.WithProducer(p))
 	}
-	mpOpts := cfg.metricOptions(
+	mpOpts := append(cfg.metricOptions(),
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, readerOpts...)),
 		sdkmetric.WithResource(resource),
 	)

--- a/pkg/beholder/config.go
+++ b/pkg/beholder/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	MetricRetryConfig    *RetryConfig
 	MetricViews []metric.View
 	// MetricCardinalityLimit sets the SDK per-instrument attribute-set limit (0 = disabled).
-	// DefaultConfig uses 100000 as a production safety valve for high-cardinality workloads.
+	// DefaultConfig uses DefaultMetricCardinalityLimit as a production safety valve for high-cardinality workloads.
 	MetricCardinalityLimit int
 	// MetricCompressor sets the gRPC compressor for metrics. Valid values: "gzip" (default), "none".
 	MetricCompressor string
@@ -111,6 +111,9 @@ var defaultRetryConfig = RetryConfig{
 const (
 	defaultPackageName        = "beholder"
 	defaultMaxConcurrentSends = 10
+
+	// DefaultMetricCardinalityLimit is the production safety valve for high-cardinality workloads.
+	DefaultMetricCardinalityLimit = 100000
 )
 
 var defaultOtelAttributes = []attribute.KeyValue{
@@ -142,7 +145,7 @@ func DefaultConfig() Config {
 		// Metric
 		MetricReaderInterval:   1 * time.Second,
 		MetricCompressor:       "gzip",
-		MetricCardinalityLimit: 100000,
+		MetricCardinalityLimit: DefaultMetricCardinalityLimit,
 		// OTel metric exporter retry config
 		MetricRetryConfig: defaultRetryConfig.Copy(),
 		// Log

--- a/pkg/beholder/config.go
+++ b/pkg/beholder/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	EmitterMaxQueueSize       int
 	// EmitterBatchProcessor controls custom-message export mode:
 	// true = batched async export; false = immediate per-record export.
-	EmitterBatchProcessor     bool
+	EmitterBatchProcessor bool
 
 	// OTel Trace
 	TraceSampleRatio  float64
@@ -39,7 +39,10 @@ type Config struct {
 	// OTel Metric
 	MetricReaderInterval time.Duration
 	MetricRetryConfig    *RetryConfig
-	MetricViews          []metric.View
+	MetricViews []metric.View
+	// MetricCardinalityLimit sets the SDK per-instrument attribute-set limit (0 = disabled).
+	// DefaultConfig uses 100000 as a production safety valve for high-cardinality workloads.
+	MetricCardinalityLimit int
 	// MetricCompressor sets the gRPC compressor for metrics. Valid values: "gzip" (default), "none".
 	MetricCompressor string
 	MetricProducers  []metric.Producer // For example, a prometheus bridge
@@ -127,7 +130,7 @@ func DefaultConfig() Config {
 		EmitterExportInterval:     1 * time.Second,
 		EmitterMaxQueueSize:       2048,
 		// Keep batched export enabled by default for throughput.
-		EmitterBatchProcessor:     true,
+		EmitterBatchProcessor: true,
 		// OTel message log exporter retry config
 		LogRetryConfig: defaultRetryConfig.Copy(),
 		// Trace
@@ -137,8 +140,9 @@ func DefaultConfig() Config {
 		// OTel trace exporter retry config
 		TraceRetryConfig: defaultRetryConfig.Copy(),
 		// Metric
-		MetricReaderInterval: 1 * time.Second,
-		MetricCompressor:     "gzip",
+		MetricReaderInterval:   1 * time.Second,
+		MetricCompressor:       "gzip",
+		MetricCardinalityLimit: 100000,
 		// OTel metric exporter retry config
 		MetricRetryConfig: defaultRetryConfig.Copy(),
 		// Log
@@ -148,8 +152,8 @@ func DefaultConfig() Config {
 		LogMaxQueueSize:       2048,
 		LogBatchProcessor:     true,
 		LogStreamingEnabled:   true, // Enable logs streaming by default
-		LogLevel:      zapcore.InfoLevel,
-		LogCompressor: "gzip",
+		LogLevel:              zapcore.InfoLevel,
+		LogCompressor:         "gzip",
 		// Chip Ingress Batch Emitter
 		ChipIngressBatchEmitterEnabled: false,
 		ChipIngressBufferSize:          1000,
@@ -173,6 +177,7 @@ func TestDefaultConfig() Config {
 	config.LogRetryConfig.MaxElapsedTime = 0    // Retry is disabled
 	config.TraceRetryConfig.MaxElapsedTime = 0  // Retry is disabled
 	config.MetricRetryConfig.MaxElapsedTime = 0 // Retry is disabled
+	config.MetricCardinalityLimit = 0           // Disable overflow aggregation in unit tests
 	// Auth disabled for testing (TTL=0 means static auth mode)
 	config.AuthHeadersTTL = 0
 	return config
@@ -186,6 +191,7 @@ func TestDefaultConfigHTTPClient() Config {
 	config.LogBatchProcessor = false
 	config.OtelExporterGRPCEndpoint = ""
 	config.OtelExporterHTTPEndpoint = "localhost:4318"
+	config.MetricCardinalityLimit = 0
 	// Auth disabled for testing (TTL=0 means static auth mode)
 	config.AuthHeadersTTL = 0
 	return config

--- a/pkg/beholder/config_test.go
+++ b/pkg/beholder/config_test.go
@@ -53,8 +53,9 @@ func TestConfig(t *testing.T) {
 		// OTel trace exporter retry config
 		TraceRetryConfig: nil,
 		// Metric
-		MetricReaderInterval: 1 * time.Second,
-		MetricCompressor:     "gzip",
+		MetricReaderInterval:   1 * time.Second,
+		MetricCompressor:       "gzip",
+		MetricCardinalityLimit: 0,
 		// OTel metric exporter retry config
 		MetricRetryConfig: nil,
 		// Log

--- a/pkg/beholder/httpclient.go
+++ b/pkg/beholder/httpclient.go
@@ -285,7 +285,7 @@ func newHTTPMeterProvider(config Config, resource *sdkresource.Resource, tlsConf
 		return nil, err
 	}
 
-	mpOpts := config.metricOptions(
+	mpOpts := append(config.metricOptions(),
 		sdkmetric.WithReader(
 			sdkmetric.NewPeriodicReader(
 				exporter,

--- a/pkg/beholder/httpclient.go
+++ b/pkg/beholder/httpclient.go
@@ -285,14 +285,13 @@ func newHTTPMeterProvider(config Config, resource *sdkresource.Resource, tlsConf
 		return nil, err
 	}
 
-	mp := sdkmetric.NewMeterProvider(
+	mpOpts := config.metricOptions(
 		sdkmetric.WithReader(
 			sdkmetric.NewPeriodicReader(
 				exporter,
 				sdkmetric.WithInterval(config.MetricReaderInterval), // Default is 10s
 			)),
 		sdkmetric.WithResource(resource),
-		sdkmetric.WithView(config.MetricViews...),
 	)
-	return mp, nil
+	return sdkmetric.NewMeterProvider(mpOpts...), nil
 }

--- a/pkg/beholder/meter_provider.go
+++ b/pkg/beholder/meter_provider.go
@@ -4,9 +4,11 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
-// metricOptions returns sdkmetric.Option values for caller MetricViews and the
-// SDK per-instrument cardinality limit.
-func (cfg Config) metricOptions(opts ...sdkmetric.Option) []sdkmetric.Option {
+// metricOptions returns cfg-derived sdkmetric.Option values (caller MetricViews
+// and the SDK per-instrument cardinality limit). Callers append reader/resource
+// options at the call site.
+func (cfg Config) metricOptions() []sdkmetric.Option {
+	var opts []sdkmetric.Option
 	if len(cfg.MetricViews) > 0 {
 		opts = append(opts, sdkmetric.WithView(cfg.MetricViews...))
 	}

--- a/pkg/beholder/meter_provider.go
+++ b/pkg/beholder/meter_provider.go
@@ -1,0 +1,17 @@
+package beholder
+
+import (
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// metricOptions returns sdkmetric.Option values for caller MetricViews and the
+// SDK per-instrument cardinality limit.
+func (cfg Config) metricOptions(opts ...sdkmetric.Option) []sdkmetric.Option {
+	if len(cfg.MetricViews) > 0 {
+		opts = append(opts, sdkmetric.WithView(cfg.MetricViews...))
+	}
+	if cfg.MetricCardinalityLimit > 0 {
+		opts = append(opts, sdkmetric.WithCardinalityLimit(cfg.MetricCardinalityLimit))
+	}
+	return opts
+}

--- a/pkg/beholder/meter_provider_test.go
+++ b/pkg/beholder/meter_provider_test.go
@@ -1,0 +1,50 @@
+package beholder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestConfig_metricOptions_cardinalityLimit(t *testing.T) {
+	t.Parallel()
+
+	const (
+		uniqueAttributes = 10
+		limit            = 5
+	)
+
+	reader := sdkmetric.NewManualReader()
+	cfg := DefaultConfig()
+	cfg.MetricCardinalityLimit = limit
+
+	mpOpts := cfg.metricOptions(sdkmetric.WithReader(reader))
+	mp := sdkmetric.NewMeterProvider(mpOpts...)
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	meter := mp.Meter("test")
+	counter, err := meter.Int64Counter("overflow_test_total")
+	require.NoError(t, err)
+
+	for i := range uniqueAttributes {
+		counter.Add(context.Background(), 1, metric.WithAttributes(attribute.Int("key", i)))
+	}
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	sum := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64])
+	assert.Len(t, sum.DataPoints, limit)
+
+	var total int64
+	for _, dp := range sum.DataPoints {
+		total += dp.Value
+	}
+	assert.Equal(t, int64(uniqueAttributes), total)
+}

--- a/pkg/beholder/meter_provider_test.go
+++ b/pkg/beholder/meter_provider_test.go
@@ -24,7 +24,7 @@ func TestConfig_metricOptions_cardinalityLimit(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.MetricCardinalityLimit = limit
 
-	mpOpts := cfg.metricOptions(sdkmetric.WithReader(reader))
+	mpOpts := append(cfg.metricOptions(), sdkmetric.WithReader(reader))
 	mp := sdkmetric.NewMeterProvider(mpOpts...)
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
 

--- a/pkg/beholder/noop.go
+++ b/pkg/beholder/noop.go
@@ -109,7 +109,7 @@ func NewWriterClient(w io.Writer) (*Client, error) {
 	if err != nil {
 		return NewNoopClient(), err
 	}
-	mpOpts := cfg.Config.metricOptions(
+	mpOpts := append(cfg.Config.metricOptions(),
 		sdkmetric.WithReader(
 			sdkmetric.NewPeriodicReader(
 				metricExporter,

--- a/pkg/beholder/noop.go
+++ b/pkg/beholder/noop.go
@@ -109,13 +109,14 @@ func NewWriterClient(w io.Writer) (*Client, error) {
 	if err != nil {
 		return NewNoopClient(), err
 	}
-	meterProvider := sdkmetric.NewMeterProvider(
+	mpOpts := cfg.Config.metricOptions(
 		sdkmetric.WithReader(
 			sdkmetric.NewPeriodicReader(
 				metricExporter,
 				sdkmetric.WithInterval(100*time.Millisecond), // Default is 10s
 			)),
 	)
+	meterProvider := sdkmetric.NewMeterProvider(mpOpts...)
 	meter := meterProvider.Meter(defaultPackageName)
 
 	// MessageEmitter

--- a/pkg/beholder/testdata/config-example.json
+++ b/pkg/beholder/testdata/config-example.json
@@ -32,6 +32,7 @@
   "MetricReaderInterval": 1000000000,
   "MetricRetryConfig": null,
   "MetricViews": null,
+  "MetricCardinalityLimit": 0,
   "MetricCompressor": "gzip",
   "MetricProducers": null,
   "ChipIngressEmitterEnabled": false,

--- a/pkg/loop/config.go
+++ b/pkg/loop/config.go
@@ -82,6 +82,7 @@ const (
 	envTelemetryLogMaxQueueSize           = "CL_TELEMETRY_LOG_MAX_QUEUE_SIZE"
 	envTelemetryTraceCompressor           = "CL_TELEMETRY_TRACE_COMPRESSOR"
 	envTelemetryMetricCompressor          = "CL_TELEMETRY_METRIC_COMPRESSOR"
+	envTelemetryMetricCardinalityLimit    = "CL_TELEMETRY_METRIC_CARDINALITY_LIMIT"
 	envTelemetryPrometheusBridgeEnabled   = "CL_TELEMETRY_PROMETHEUS_BRIDGE_ENABLED"
 	envTelemetryPrometheusBridgePrefixes  = "CL_TELEMETRY_PROMETHEUS_BRIDGE_PREFIXES"
 	envTelemetryLogCompressor             = "CL_TELEMETRY_LOG_COMPRESSOR"
@@ -176,11 +177,15 @@ type EnvConfig struct {
 	TelemetryLogMaxQueueSize           int
 	TelemetryTraceCompressor           string
 	TelemetryMetricCompressor          string
-	TelemetryPrometheusBridgeEnabled   bool
-	TelemetryPrometheusBridgePrefixes  []string
-	TelemetryLogCompressor             string
-	MeterRecordsEnabled                bool
-	MeterSnapshotsEnabled              bool
+	// TelemetryMetricCardinalityLimit is nil when unset, so AsCmdEnv can
+	// distinguish "no opinion" (child applies its own default) from an
+	// explicit 0, which disables the limit.
+	TelemetryMetricCardinalityLimit   *int
+	TelemetryPrometheusBridgeEnabled  bool
+	TelemetryPrometheusBridgePrefixes []string
+	TelemetryLogCompressor            string
+	MeterRecordsEnabled               bool
+	MeterSnapshotsEnabled             bool
 
 	// MeterProduct / MeterTenant / MeterNumericTenantID / MeterEnvironment /
 	// MeterZone / MeterNodeID are
@@ -290,6 +295,9 @@ func (e *EnvConfig) AsCmdEnv() (env []string) {
 	add(envTelemetryLogMaxQueueSize, strconv.Itoa(e.TelemetryLogMaxQueueSize))
 	add(envTelemetryTraceCompressor, e.TelemetryTraceCompressor)
 	add(envTelemetryMetricCompressor, e.TelemetryMetricCompressor)
+	if e.TelemetryMetricCardinalityLimit != nil {
+		add(envTelemetryMetricCardinalityLimit, strconv.Itoa(*e.TelemetryMetricCardinalityLimit))
+	}
 	add(envTelemetryPrometheusBridgeEnabled, strconv.FormatBool(e.TelemetryPrometheusBridgeEnabled))
 	add(envTelemetryPrometheusBridgePrefixes, strings.Join(e.TelemetryPrometheusBridgePrefixes, ","))
 	add(envTelemetryLogCompressor, e.TelemetryLogCompressor)
@@ -530,6 +538,19 @@ func (e *EnvConfig) parse() error {
 		}
 		e.TelemetryTraceCompressor = os.Getenv(envTelemetryTraceCompressor)
 		e.TelemetryMetricCompressor = os.Getenv(envTelemetryMetricCompressor)
+		if v, ok := os.LookupEnv(envTelemetryMetricCardinalityLimit); ok {
+			limit, err := strconv.Atoi(v)
+			if err != nil {
+				return fmt.Errorf("failed to parse %s: %w", envTelemetryMetricCardinalityLimit, err)
+			}
+			if limit < 0 {
+				return fmt.Errorf("failed to parse %s: value %d must not be negative (0 disables the limit)", envTelemetryMetricCardinalityLimit, limit)
+			}
+			e.TelemetryMetricCardinalityLimit = &limit
+		} else {
+			defaultLimit := 100000
+			e.TelemetryMetricCardinalityLimit = &defaultLimit
+		}
 		e.TelemetryPrometheusBridgeEnabled, err = getBool(envTelemetryPrometheusBridgeEnabled)
 		if err != nil {
 			return fmt.Errorf("failed to parse %s: %w", envTelemetryPrometheusBridgeEnabled, err)

--- a/pkg/loop/config.go
+++ b/pkg/loop/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
 )
@@ -548,7 +549,7 @@ func (e *EnvConfig) parse() error {
 			}
 			e.TelemetryMetricCardinalityLimit = &limit
 		} else {
-			defaultLimit := 100000
+			defaultLimit := beholder.DefaultMetricCardinalityLimit
 			e.TelemetryMetricCardinalityLimit = &defaultLimit
 		}
 		e.TelemetryPrometheusBridgeEnabled, err = getBool(envTelemetryPrometheusBridgeEnabled)

--- a/pkg/loop/config_test.go
+++ b/pkg/loop/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -214,7 +215,7 @@ var envCfgFull = EnvConfig{
 	TelemetryEmitterExportMaxBatchSize: 100,
 	TelemetryEmitterMaxQueueSize:       1000,
 	TelemetryLogStreamingEnabled:       false,
-	TelemetryMetricCardinalityLimit:    new(100000),
+	TelemetryMetricCardinalityLimit:    new(beholder.DefaultMetricCardinalityLimit),
 	TelemetryPrometheusBridgeEnabled:   true,
 	TelemetryPrometheusBridgePrefixes:  []string{"foo", "bar"},
 	MeterRecordsEnabled:                true,
@@ -288,7 +289,7 @@ func TestEnvConfig_AsCmdEnv(t *testing.T) {
 	assert.Equal(t, "100", got[envTelemetryEmitterExportMaxBatchSize])
 	assert.Equal(t, "1000", got[envTelemetryEmitterMaxQueueSize])
 	assert.Equal(t, "false", got[envTelemetryLogStreamingEnabled])
-	assert.Equal(t, "100000", got[envTelemetryMetricCardinalityLimit])
+	assert.Equal(t, strconv.Itoa(beholder.DefaultMetricCardinalityLimit), got[envTelemetryMetricCardinalityLimit])
 	assert.Equal(t, "true", got[envTelemetryPrometheusBridgeEnabled])
 	assert.Equal(t, "foo,bar", got[envTelemetryPrometheusBridgePrefixes])
 	assert.Equal(t, "true", got[envMeterRecordsEnabled])

--- a/pkg/loop/config_test.go
+++ b/pkg/loop/config_test.go
@@ -126,6 +126,15 @@ func TestEnvConfig_parse(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "CL_TELEMETRY_METRIC_CARDINALITY_LIMIT negative value rejected",
+			envVars: map[string]string{
+				envPromPort:                        "8080",
+				envTelemetryEnabled:                "true",
+				envTelemetryMetricCardinalityLimit: "-1",
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -146,6 +155,8 @@ func TestEnvConfig_parse(t *testing.T) {
 		})
 	}
 }
+
+func ptr[T any](v T) *T { return &v }
 
 var envCfgFull = EnvConfig{
 	AppID: "app-id",
@@ -205,6 +216,7 @@ var envCfgFull = EnvConfig{
 	TelemetryEmitterExportMaxBatchSize: 100,
 	TelemetryEmitterMaxQueueSize:       1000,
 	TelemetryLogStreamingEnabled:       false,
+	TelemetryMetricCardinalityLimit:    ptr(100000),
 	TelemetryPrometheusBridgeEnabled:   true,
 	TelemetryPrometheusBridgePrefixes:  []string{"foo", "bar"},
 	MeterRecordsEnabled:                true,
@@ -278,6 +290,7 @@ func TestEnvConfig_AsCmdEnv(t *testing.T) {
 	assert.Equal(t, "100", got[envTelemetryEmitterExportMaxBatchSize])
 	assert.Equal(t, "1000", got[envTelemetryEmitterMaxQueueSize])
 	assert.Equal(t, "false", got[envTelemetryLogStreamingEnabled])
+	assert.Equal(t, "100000", got[envTelemetryMetricCardinalityLimit])
 	assert.Equal(t, "true", got[envTelemetryPrometheusBridgeEnabled])
 	assert.Equal(t, "foo,bar", got[envTelemetryPrometheusBridgePrefixes])
 	assert.Equal(t, "true", got[envMeterRecordsEnabled])
@@ -296,6 +309,58 @@ func TestEnvConfig_AsCmdEnv(t *testing.T) {
 
 	assert.JSONEq(t, `{"global":{}}`, got[envCRESettings])
 	assert.JSONEq(t, `{"foo":"bar"}`, got[envCRESettingsDefault])
+}
+
+// TestEnvConfig_MetricCardinalityLimit_RoundTrip verifies that an explicit
+// disable (0) survives a AsCmdEnv -> parse round trip the same way an
+// explicit positive limit does, and that leaving the field unset lets the
+// child apply its own default instead of forcing a value.
+func TestEnvConfig_MetricCardinalityLimit_RoundTrip(t *testing.T) {
+	setEnvFromCmdEnv := func(t *testing.T, env []string) {
+		t.Helper()
+		for _, kv := range env {
+			pair := strings.SplitN(kv, "=", 2)
+			require.Len(t, pair, 2)
+			t.Setenv(pair[0], pair[1])
+		}
+	}
+
+	t.Run("explicit disable propagates as 0", func(t *testing.T) {
+		cfg := envCfgFull
+		cfg.TelemetryMetricCardinalityLimit = ptr(0)
+		setEnvFromCmdEnv(t, cfg.AsCmdEnv())
+
+		var parsed EnvConfig
+		require.NoError(t, parsed.parse())
+		require.NotNil(t, parsed.TelemetryMetricCardinalityLimit)
+		assert.Equal(t, 0, *parsed.TelemetryMetricCardinalityLimit)
+	})
+
+	t.Run("explicit positive limit propagates", func(t *testing.T) {
+		cfg := envCfgFull
+		cfg.TelemetryMetricCardinalityLimit = ptr(500)
+		setEnvFromCmdEnv(t, cfg.AsCmdEnv())
+
+		var parsed EnvConfig
+		require.NoError(t, parsed.parse())
+		require.NotNil(t, parsed.TelemetryMetricCardinalityLimit)
+		assert.Equal(t, 500, *parsed.TelemetryMetricCardinalityLimit)
+	})
+
+	t.Run("unset falls back to child default", func(t *testing.T) {
+		cfg := envCfgFull
+		cfg.TelemetryMetricCardinalityLimit = nil
+		env := cfg.AsCmdEnv()
+		for _, kv := range env {
+			require.NotContains(t, kv, envTelemetryMetricCardinalityLimit+"=", "unset limit must not be emitted")
+		}
+		setEnvFromCmdEnv(t, env)
+
+		var parsed EnvConfig
+		require.NoError(t, parsed.parse())
+		require.NotNil(t, parsed.TelemetryMetricCardinalityLimit)
+		assert.Equal(t, 100000, *parsed.TelemetryMetricCardinalityLimit)
+	})
 }
 
 func TestGetMap(t *testing.T) {

--- a/pkg/loop/config_test.go
+++ b/pkg/loop/config_test.go
@@ -156,8 +156,6 @@ func TestEnvConfig_parse(t *testing.T) {
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
-
 var envCfgFull = EnvConfig{
 	AppID: "app-id",
 
@@ -216,7 +214,7 @@ var envCfgFull = EnvConfig{
 	TelemetryEmitterExportMaxBatchSize: 100,
 	TelemetryEmitterMaxQueueSize:       1000,
 	TelemetryLogStreamingEnabled:       false,
-	TelemetryMetricCardinalityLimit:    ptr(100000),
+	TelemetryMetricCardinalityLimit:    new(100000),
 	TelemetryPrometheusBridgeEnabled:   true,
 	TelemetryPrometheusBridgePrefixes:  []string{"foo", "bar"},
 	MeterRecordsEnabled:                true,
@@ -327,7 +325,7 @@ func TestEnvConfig_MetricCardinalityLimit_RoundTrip(t *testing.T) {
 
 	t.Run("explicit disable propagates as 0", func(t *testing.T) {
 		cfg := envCfgFull
-		cfg.TelemetryMetricCardinalityLimit = ptr(0)
+		cfg.TelemetryMetricCardinalityLimit = new(0)
 		setEnvFromCmdEnv(t, cfg.AsCmdEnv())
 
 		var parsed EnvConfig
@@ -338,7 +336,7 @@ func TestEnvConfig_MetricCardinalityLimit_RoundTrip(t *testing.T) {
 
 	t.Run("explicit positive limit propagates", func(t *testing.T) {
 		cfg := envCfgFull
-		cfg.TelemetryMetricCardinalityLimit = ptr(500)
+		cfg.TelemetryMetricCardinalityLimit = new(500)
 		setEnvFromCmdEnv(t, cfg.AsCmdEnv())
 
 		var parsed EnvConfig

--- a/pkg/loop/server.go
+++ b/pkg/loop/server.go
@@ -191,6 +191,7 @@ func (s *Server) start(opts ...ServerOpt) error {
 			ChipIngressBatchEmitterEnabled: s.EnvConfig.ChipIngressBatchEmitterEnabled,
 			ChipIngressLogger:              s.Logger,
 			MetricCompressor:               s.EnvConfig.TelemetryMetricCompressor,
+			MetricCardinalityLimit:         *s.EnvConfig.TelemetryMetricCardinalityLimit,
 		}
 
 		if s.EnvConfig.TelemetryPrometheusBridgeEnabled {


### PR DESCRIPTION
This PR adds a configurable cardinality limit to the Beholder OTel SDK metric provider. It prevents unbounded memory growth when high-cardinality labels (e.g., `event_id`, `workflow_execution_id`) are accidentally attached to metrics.

### How `sdkmetric.WithCardinalityLimit` works

`WithCardinalityLimit(n)` sets a **hard limit on distinct attribute sets (time series) per metric instrument**. Each unique combination of attributes creates a separate aggregation state in the SDK.

**Example:**

```go
requestsTotal.Add(ctx, 1,
    attribute.String("method", method),
    attribute.String("status", status),
)
```

Creates series:
- `(method=GET, status=200)`
- `(method=GET, status=500)`
- `(method=POST, status=200)`

If someone adds `user_id` (unbounded), series explode. The limit prevents this.

**What happens when the limit is reached?**

When the (n+1)th unique attribute set arrives, it does **not** create a new aggregation. Instead, it is recorded into an **overflow bucket** with attribute `otel.metric.overflow=true`:

```
http_requests_total{method=GET,status=200}     15231
http_requests_total{method=POST,status=500}    183
...
http_requests_total{otel.metric.overflow=true} 428912
```

The total count remains correct, but per-identity of overflowed combinations is lost.

**Important:** This does **not** drop the metric or fail exports. It is a safety net, not a substitute for good metric design.

### Scope

- `pkg/beholder/config.go`: Add `MetricCardinalityLimit` field
- `pkg/beholder/meter_provider.go`: Wire `sdkmetric.WithCardinalityLimit`
- `pkg/loop/config.go`: Propagate limit via env var `CL_TELEMETRY_METRIC_CARDINALITY_LIMIT`

### Limitations

This limit is **per instrument**, not global across the application. Unbounded labels should still be avoided or filtered via views; the cardinality limit exists as a last-resort memory guard.
