### PR TITLE
Default Grafana alert RuleQuery interval to 30s

### DIFF
--- a/observability-lib/grafana/alerts.go
+++ b/observability-lib/grafana/alerts.go
@@ -1,6 +1,7 @@
 package grafana
 
 import (
+	"fmt"
 	"maps"
 
 	"github.com/grafana/grafana-foundation-sdk/go/alerting"
@@ -14,10 +15,11 @@ type RuleQueryType string
 const (
 	RuleQueryTypeInstant RuleQueryType = "instant"
 
-	// DefaultRuleQueryInterval is the default Prometheus query interval for alert rule models.
-	DefaultRuleQueryInterval = "30s"
-	defaultRuleQueryIntervalMs = 30 * 1000
+	defaultRuleQueryIntervalSeconds = 30
 )
+
+// DefaultRuleQueryInterval is the default Prometheus query interval for alert rule models.
+var DefaultRuleQueryInterval = fmt.Sprintf("%ds", defaultRuleQueryIntervalSeconds)
 
 type RuleQuery struct {
 	Expr         string
@@ -138,7 +140,7 @@ func newReduceSettingsOptions(options expr.ExprTypeReduceSettings) cog.Builder[e
 func newConditionQuery(options ConditionQuery) *alerting.QueryBuilder {
 	if options.IntervalMs == nil {
 		// Recommended value for intervalMs is 30s
-		options.IntervalMs = Pointer[float64](defaultRuleQueryIntervalMs)
+		options.IntervalMs = Pointer[float64](float64(defaultRuleQueryIntervalSeconds * 1000))
 	}
 
 	if options.MaxDataPoints == nil {

--- a/observability-lib/grafana/alerts.go
+++ b/observability-lib/grafana/alerts.go
@@ -13,6 +13,10 @@ type RuleQueryType string
 
 const (
 	RuleQueryTypeInstant RuleQueryType = "instant"
+
+	// DefaultRuleQueryInterval is the default Prometheus query interval for alert rule models.
+	DefaultRuleQueryInterval = "30s"
+	defaultRuleQueryIntervalMs = 30 * 1000
 )
 
 type RuleQuery struct {
@@ -23,6 +27,9 @@ type RuleQuery struct {
 	TimeRange    int64
 	Instant      bool
 	QueryType    RuleQueryType
+	// Interval sets the Prometheus query interval in the alert rule model (e.g. "30s").
+	// When empty, DefaultRuleQueryInterval is used.
+	Interval string
 }
 
 func newRuleQuery(query RuleQuery) *alerting.QueryBuilder {
@@ -50,6 +57,12 @@ func newRuleQuery(query RuleQuery) *alerting.QueryBuilder {
 	if query.QueryType != "" {
 		model.QueryType(string(query.QueryType))
 	}
+
+	interval := query.Interval
+	if interval == "" {
+		interval = DefaultRuleQueryInterval
+	}
+	model.Interval(interval)
 
 	return res.Model(model)
 }
@@ -125,7 +138,7 @@ func newReduceSettingsOptions(options expr.ExprTypeReduceSettings) cog.Builder[e
 func newConditionQuery(options ConditionQuery) *alerting.QueryBuilder {
 	if options.IntervalMs == nil {
 		// Recommended value for intervalMs is 30s
-		options.IntervalMs = Pointer[float64](30 * 1000)
+		options.IntervalMs = Pointer[float64](defaultRuleQueryIntervalMs)
 	}
 
 	if options.MaxDataPoints == nil {

--- a/observability-lib/grafana/builder_test.go
+++ b/observability-lib/grafana/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana-foundation-sdk/go/alerting"
 	"github.com/grafana/grafana-foundation-sdk/go/expr"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
@@ -545,4 +546,21 @@ func TestBuilder_AddTimeSeriesPanelWithAlert(t *testing.T) {
 		// RuleGroup defaults to Panel Title
 		require.Equal(t, "Panel Title", o.Alerts[0].RuleGroup)
 	})
+}
+
+func TestNewAlertRule_DefaultRuleQueryInterval(t *testing.T) {
+	rule, err := grafana.NewAlertRule(&grafana.AlertOptions{
+		Title: "CPU High",
+		Query: []grafana.RuleQuery{{
+			Expr:       "up",
+			RefID:      "A",
+			Datasource: "prometheus-uid",
+		}},
+	}).Build()
+	require.NoError(t, err)
+	require.Len(t, rule.Data, 1)
+	model, ok := rule.Data[0].Model.(prometheus.Dataquery)
+	require.True(t, ok)
+	require.NotNil(t, model.Interval)
+	require.Equal(t, grafana.DefaultRuleQueryInterval, *model.Interval)
 }


### PR DESCRIPTION
## Summary
- Add `RuleQuery.Interval` to observability-lib with a default of `"30s"`.
- Set `interval` on Prometheus datasource query models (refId `A`) in `newRuleQuery`, so deployed Grafana alert rules no longer show 1s on the datasource step.
- Reuse a shared `defaultRuleQueryIntervalMs` constant for condition query defaults.
- Add `TestNewAlertRule_DefaultRuleQueryInterval`.

Companion to [chainlink-observability#467](https://github.com/smartcontractkit/chainlink-observability/pull/467), which sets rule group evaluation intervals and condition `intervalMs` in chainlink-observability. This PR covers the remaining alert rule model layer: the Prometheus query step (refId `A`).

## Coverage
| Layer | Owner |
|---|---|
| Rule group evaluation (`Evaluate every`) | chainlink-observability #467 |
| Condition step `intervalMs` (B/C) | observability-lib + chainlink-observability #467 |
| Datasource query model interval (ref A) | **This PR** |

## Test plan
- [x] `go test ./observability-lib/grafana/...`
- [ ] After merge: bump `observability-lib` in chainlink-observability and verify ref `A` shows `"interval": "30s"` in generated alert JSON