### PR TITLE
beholder: apply 1s MetricReaderInterval default when config field is zero

### DIFF
--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -434,7 +434,7 @@ func createConfigMetric(meter otelmetric.Meter, cfg Config) (otelmetric.Int64Gau
 
 		// Metrics config
 		attribute.String(
-			"metric_reader_interval", cfg.MetricReaderInterval.String()),
+			"metric_reader_interval", metricReaderInterval(cfg).String()),
 		attribute.String(
 			"metric_compressor", cfg.MetricCompressor),
 	}
@@ -544,7 +544,7 @@ func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, cre
 	}
 
 	readerOpts := []sdkmetric.PeriodicReaderOption{
-		sdkmetric.WithInterval(cfg.MetricReaderInterval), // Default is 10s
+		sdkmetric.WithInterval(metricReaderInterval(cfg)), // Zero uses Beholder default (1s)
 	}
 	for _, p := range cfg.MetricProducers {
 		readerOpts = append(readerOpts, sdkmetric.WithProducer(p))

--- a/pkg/beholder/config.go
+++ b/pkg/beholder/config.go
@@ -163,6 +163,13 @@ func DefaultConfig() Config {
 	}
 }
 
+func metricReaderInterval(cfg Config) time.Duration {
+	if cfg.MetricReaderInterval > 0 {
+		return cfg.MetricReaderInterval
+	}
+	return DefaultConfig().MetricReaderInterval
+}
+
 func TestDefaultConfig() Config {
 	config := DefaultConfig()
 	// Should be only disabled for testing

--- a/pkg/beholder/config_defaults_test.go
+++ b/pkg/beholder/config_defaults_test.go
@@ -1,0 +1,15 @@
+package beholder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricReaderInterval_zeroUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, time.Second, metricReaderInterval(Config{}))
+	assert.Equal(t, 5*time.Second, metricReaderInterval(Config{MetricReaderInterval: 5 * time.Second}))
+}

--- a/pkg/beholder/httpclient.go
+++ b/pkg/beholder/httpclient.go
@@ -289,7 +289,7 @@ func newHTTPMeterProvider(config Config, resource *sdkresource.Resource, tlsConf
 		sdkmetric.WithReader(
 			sdkmetric.NewPeriodicReader(
 				exporter,
-				sdkmetric.WithInterval(config.MetricReaderInterval), // Default is 10s
+				sdkmetric.WithInterval(metricReaderInterval(config)), // Zero uses Beholder default (1s)
 			)),
 		sdkmetric.WithResource(resource),
 		sdkmetric.WithView(config.MetricViews...),


### PR DESCRIPTION
## Summary

- Add `metricReaderInterval()` so partial `beholder.Config` literals get Beholder's 1s default instead of OTel's 60s fallback when `MetricReaderInterval` is zero
- Use the effective interval in gRPC + HTTP `PeriodicReader` and in the `beholder.config.info` gauge attribute
- Add unit test for zero → 1s and explicit override
- No caller changes required (`chainlink/core/cmd/shell.go`, `pkg/loop/server.go`)

## Test plan

- [x] `go test ./pkg/beholder/...`
- [ ] Verify `beholder.config.info{metric_reader_interval="1s"}` on a node using partial config literals after deploy


Made with [Cursor](https://cursor.com)