### PR TITLE
fix resource conflict error

### DIFF
--- a/observability-lib/grafana/dashboard.go
+++ b/observability-lib/grafana/dashboard.go
@@ -210,9 +210,21 @@ func (o *Observability) DeployToGrafana(options *DeployOptions) error {
 				// update alert rule if it already exists
 				alertToUpdate := getAlertRuleByTitle(alertsRule, alert.Title)
 				if alertToUpdate != nil {
-					_, _, errPutAlertRule := grafanaClient.UpdateAlertRule(*alertToUpdate.Uid, alert)
+					_, updateResp, errPutAlertRule := grafanaClient.UpdateAlertRule(*alertToUpdate.Uid, alert)
 					if errPutAlertRule != nil {
-						return errPutAlertRule
+						// A 409 means a provenance mismatch: the stored rule was created with a
+						// different provenance (e.g. "api") than what we send (""). Migrate by
+						// deleting the old rule and recreating it with the current provenance.
+						if updateResp != nil && updateResp.StatusCode() == 409 {
+							if _, _, errDelete := grafanaClient.DeleteAlertRule(*alertToUpdate.Uid); errDelete != nil {
+								return fmt.Errorf("provenance migration: delete alert rule %q: %w", alert.Title, errDelete)
+							}
+							if _, _, errPost := grafanaClient.PostAlertRule(alert); errPost != nil {
+								return fmt.Errorf("provenance migration: recreate alert rule %q: %w", alert.Title, errPost)
+							}
+						} else {
+							return errPutAlertRule
+						}
 					}
 				}
 			} else {

--- a/observability-lib/grafana/dashboard.go
+++ b/observability-lib/grafana/dashboard.go
@@ -215,15 +215,15 @@ func (o *Observability) DeployToGrafana(options *DeployOptions) error {
 						// A 409 means a provenance mismatch: the stored rule was created with a
 						// different provenance (e.g. "api") than what we send (""). Migrate by
 						// deleting the old rule and recreating it with the current provenance.
-						if updateResp != nil && updateResp.StatusCode() == 409 {
-							if _, _, errDelete := grafanaClient.DeleteAlertRule(*alertToUpdate.Uid); errDelete != nil {
-								return fmt.Errorf("provenance migration: delete alert rule %q: %w", alert.Title, errDelete)
-							}
-							if _, _, errPost := grafanaClient.PostAlertRule(alert); errPost != nil {
-								return fmt.Errorf("provenance migration: recreate alert rule %q: %w", alert.Title, errPost)
-							}
-						} else {
+						if updateResp != nil && updateResp.StatusCode() != 409 {
 							return errPutAlertRule
+						}
+
+						if _, _, errDelete := grafanaClient.DeleteAlertRule(*alertToUpdate.Uid); errDelete != nil {
+							return fmt.Errorf("provenance migration: delete alert rule %q: %w", alert.Title, errDelete)
+						}
+						if _, _, errPost := grafanaClient.PostAlertRule(alert); errPost != nil {
+							return fmt.Errorf("provenance migration: recreate alert rule %q: %w", alert.Title, errPost)
 						}
 					}
 				}

--- a/observability-lib/grafana/dashboard.go
+++ b/observability-lib/grafana/dashboard.go
@@ -215,7 +215,7 @@ func (o *Observability) DeployToGrafana(options *DeployOptions) error {
 						// A 409 means a provenance mismatch: the stored rule was created with a
 						// different provenance (e.g. "api") than what we send (""). Migrate by
 						// deleting the old rule and recreating it with the current provenance.
-						if updateResp != nil && updateResp.StatusCode() != 409 {
+						if updateResp == nil || updateResp.StatusCode() != 409 {
 							return errPutAlertRule
 						}
 


### PR DESCRIPTION
When an UpdateAlertRule call returns 409 with alerting.provenanceMismatch, the code should fall back to deleting the old rule and recreating it (migrating the provenance from "api" to ""). 