### PR TITLE
Add WithClientName

### DIFF
--- a/pkg/chipingress/batch/chip_client.go
+++ b/pkg/chipingress/batch/chip_client.go
@@ -1,8 +1,0 @@
-package batch
-
-// Well-known chip_client metric label values for batch client metrics.
-// Pass to WithChipClient when wiring batch.NewBatchClient.
-const (
-	ChipClientBeholder       = "beholder"
-	ChipClientDurableEmitter = "durable_emitter"
-)

--- a/pkg/chipingress/batch/chip_client.go
+++ b/pkg/chipingress/batch/chip_client.go
@@ -1,0 +1,8 @@
+package batch
+
+// Well-known chip_client metric label values for batch client metrics.
+// Pass to WithChipClient when wiring batch.NewBatchClient.
+const (
+	ChipClientBeholder       = "beholder"
+	ChipClientDurableEmitter = "durable_emitter"
+)

--- a/pkg/chipingress/batch/client.go
+++ b/pkg/chipingress/batch/client.go
@@ -70,6 +70,7 @@ type Client struct {
 	batcherDone             chan struct{}
 	started                 bool
 	counters                sync.Map // map[seqnumKey]*atomic.Uint64 for per-(source,type) seqnum, cleared on Stop()
+	chipClient              string
 
 	metrics batchClientMetrics
 
@@ -88,6 +89,7 @@ type batchClientMetrics struct {
 	maxGRPCReqSizeAttr   otelmetric.MeasurementOption
 	successStatusAttr    otelmetric.MeasurementOption
 	failureStatusAttr    otelmetric.MeasurementOption
+	chipClientAttr       otelmetric.MeasurementOption
 }
 
 // Opt is a functional option for configuring the batch Client.
@@ -118,7 +120,7 @@ func NewBatchClient(client chipingress.Client, opts ...Opt) (*Client, error) {
 	}
 
 	var err error
-	c.metrics, err = newBatchClientMetrics()
+	c.metrics, err = newBatchClientMetrics(c.chipClient)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +293,7 @@ func (b *Client) sendBatch(ctx context.Context, messages []*messageWithCallback)
 
 		splitBatches := splitMessagesByRequestSize(messages, b.effectiveMaxRequestSize, b.transactionEnabled)
 		if len(splitBatches) > 1 {
-			b.metrics.batchSplitsTotal.Add(ctx, 1)
+			b.metrics.batchSplitsTotal.Add(ctx, 1, b.metrics.chipClientAddOpts()...)
 		}
 		for _, batchMessages := range splitBatches {
 			batchReq, batchBytes := newBatchRequest(batchMessages, b.transactionEnabled)
@@ -350,7 +352,7 @@ func (b *Client) completeBatchCallbacksFromResults(messages []*messageWithCallba
 			"results", len(results),
 			"messages", len(messages),
 		)
-		b.metrics.resultsMismatchTotal.Add(context.Background(), 1)
+		b.metrics.resultsMismatchTotal.Add(context.Background(), 1, b.metrics.chipClientAddOpts()...)
 	}
 
 	b.callbackWg.Go(func() {
@@ -377,7 +379,7 @@ func (b *Client) completeBatchCallbacksFromResults(messages []*messageWithCallba
 					"expected", msg.event.Id,
 					"got", result.EventId,
 				)
-				b.metrics.resultsMismatchTotal.Add(context.Background(), 1)
+				b.metrics.resultsMismatchTotal.Add(context.Background(), 1, b.metrics.chipClientAddOpts()...)
 			}
 			if result.Error != nil {
 				msg.callback(&PublishError{
@@ -511,6 +513,13 @@ func WithLogger(log *zap.SugaredLogger) Opt {
 	}
 }
 
+// WithChipClient sets chip_client on batch client metrics. Omitted when unset.
+func WithChipClient(name string) Opt {
+	return func(c *Client) {
+		c.chipClient = name
+	}
+}
+
 // WithTransactionEnabled sets PublishOptions.transaction_enabled on every
 // batch request. The option is always emitted on the wire so client intent
 // is explicit in traces/logs; the server treats unset and explicit false
@@ -525,7 +534,14 @@ func WithTransactionEnabled(transactionEnabled bool) Opt {
 	}
 }
 
-func newBatchClientMetrics() (batchClientMetrics, error) {
+func batchMetricAttributeSet(chipClient string, kvs ...attribute.KeyValue) attribute.Set {
+	if chipClient != "" {
+		kvs = append(kvs, attribute.String("chip_client", chipClient))
+	}
+	return attribute.NewSet(kvs...)
+}
+
+func newBatchClientMetrics(chipClient string) (batchClientMetrics, error) {
 	meter := otel.Meter("chipingress/batch_client")
 	sendRequestsTotal, err := meter.Int64Counter(
 		"chip_ingress.batch.send_requests_total",
@@ -590,6 +606,13 @@ func newBatchClientMetrics() (batchClientMetrics, error) {
 		return batchClientMetrics{}, err
 	}
 
+	var chipClientAttr otelmetric.MeasurementOption
+	if chipClient != "" {
+		chipClientAttr = otelmetric.WithAttributeSet(attribute.NewSet(
+			attribute.String("chip_client", chipClient),
+		))
+	}
+
 	return batchClientMetrics{
 		sendRequestsTotal:    sendRequestsTotal,
 		requestSizeMessages:  requestSizeMessages,
@@ -598,23 +621,32 @@ func newBatchClientMetrics() (batchClientMetrics, error) {
 		configInfo:           configInfo,
 		batchSplitsTotal:     batchSplitsTotal,
 		resultsMismatchTotal: resultsMismatchTotal,
-		successStatusAttr: otelmetric.WithAttributeSet(attribute.NewSet(
+		chipClientAttr:       chipClientAttr,
+		successStatusAttr: otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
 			attribute.String("status", "success"),
 		)),
-		failureStatusAttr: otelmetric.WithAttributeSet(attribute.NewSet(
+		failureStatusAttr: otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
 			attribute.String("status", "failure"),
 		)),
 	}, nil
 }
 
+func (m *batchClientMetrics) chipClientAddOpts() []otelmetric.AddOption {
+	if m.chipClientAttr != nil {
+		return []otelmetric.AddOption{m.chipClientAttr}
+	}
+	return nil
+}
+
 func (m *batchClientMetrics) recordConfig(ctx context.Context, c *Client) {
-	m.batchSizeAttr = otelmetric.WithAttributeSet(attribute.NewSet(
+	chipClient := c.chipClient
+	m.batchSizeAttr = otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
 		attribute.Int("max_batch_size", c.batchSize),
 	))
-	m.maxGRPCReqSizeAttr = otelmetric.WithAttributeSet(attribute.NewSet(
+	m.maxGRPCReqSizeAttr = otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
 		attribute.Int("max_grpc_request_size_bytes", c.maxGRPCRequestSize),
 	))
-	m.configInfo.Record(ctx, 1, otelmetric.WithAttributes(
+	m.configInfo.Record(ctx, 1, otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
 		attribute.Int("max_batch_size", c.batchSize),
 		attribute.Int("message_buffer_size", cap(c.messageBuffer)),
 		attribute.Int("max_concurrent_sends", cap(c.maxConcurrentSends)),
@@ -624,7 +656,7 @@ func (m *batchClientMetrics) recordConfig(ctx context.Context, c *Client) {
 		attribute.Bool("clone_event", c.cloneEvent),
 		attribute.Bool("transaction_enabled", c.transactionEnabled),
 		attribute.Int("max_grpc_request_size_bytes", c.maxGRPCRequestSize),
-	))
+	)))
 }
 
 func (m *batchClientMetrics) recordSend(ctx context.Context, messageCount int, requestBytes int, latency time.Duration, success bool) {

--- a/pkg/chipingress/batch/client.go
+++ b/pkg/chipingress/batch/client.go
@@ -70,7 +70,7 @@ type Client struct {
 	batcherDone             chan struct{}
 	started                 bool
 	counters                sync.Map // map[seqnumKey]*atomic.Uint64 for per-(source,type) seqnum, cleared on Stop()
-	chipClient              string
+	clientName              string
 
 	metrics batchClientMetrics
 
@@ -89,7 +89,7 @@ type batchClientMetrics struct {
 	maxGRPCReqSizeAttr   otelmetric.MeasurementOption
 	successStatusAttr    otelmetric.MeasurementOption
 	failureStatusAttr    otelmetric.MeasurementOption
-	chipClientAttr       otelmetric.MeasurementOption
+	clientNameAttr       otelmetric.MeasurementOption
 }
 
 // Opt is a functional option for configuring the batch Client.
@@ -120,7 +120,7 @@ func NewBatchClient(client chipingress.Client, opts ...Opt) (*Client, error) {
 	}
 
 	var err error
-	c.metrics, err = newBatchClientMetrics(c.chipClient)
+	c.metrics, err = newBatchClientMetrics(c.clientName)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func (b *Client) sendBatch(ctx context.Context, messages []*messageWithCallback)
 
 		splitBatches := splitMessagesByRequestSize(messages, b.effectiveMaxRequestSize, b.transactionEnabled)
 		if len(splitBatches) > 1 {
-			b.metrics.batchSplitsTotal.Add(ctx, 1, b.metrics.chipClientAddOpts()...)
+			b.metrics.batchSplitsTotal.Add(ctx, 1, b.metrics.clientNameAddOpts()...)
 		}
 		for _, batchMessages := range splitBatches {
 			batchReq, batchBytes := newBatchRequest(batchMessages, b.transactionEnabled)
@@ -352,7 +352,7 @@ func (b *Client) completeBatchCallbacksFromResults(messages []*messageWithCallba
 			"results", len(results),
 			"messages", len(messages),
 		)
-		b.metrics.resultsMismatchTotal.Add(context.Background(), 1, b.metrics.chipClientAddOpts()...)
+		b.metrics.resultsMismatchTotal.Add(context.Background(), 1, b.metrics.clientNameAddOpts()...)
 	}
 
 	b.callbackWg.Go(func() {
@@ -379,7 +379,7 @@ func (b *Client) completeBatchCallbacksFromResults(messages []*messageWithCallba
 					"expected", msg.event.Id,
 					"got", result.EventId,
 				)
-				b.metrics.resultsMismatchTotal.Add(context.Background(), 1, b.metrics.chipClientAddOpts()...)
+				b.metrics.resultsMismatchTotal.Add(context.Background(), 1, b.metrics.clientNameAddOpts()...)
 			}
 			if result.Error != nil {
 				msg.callback(&PublishError{
@@ -513,10 +513,17 @@ func WithLogger(log *zap.SugaredLogger) Opt {
 	}
 }
 
-// WithChipClient sets chip_client on batch client metrics. Omitted when unset.
-func WithChipClient(name string) Opt {
+// Well-known client_name metric label values for batch client metrics.
+// Pass to WithClientName when wiring batch.NewBatchClient.
+const (
+	ClientNameBeholder       = "beholder"
+	ClientNameDurableEmitter = "durable_emitter"
+)
+
+// WithClientName sets client_name on batch client metrics. Omitted when unset.
+func WithClientName(name string) Opt {
 	return func(c *Client) {
-		c.chipClient = name
+		c.clientName = name
 	}
 }
 
@@ -534,14 +541,14 @@ func WithTransactionEnabled(transactionEnabled bool) Opt {
 	}
 }
 
-func batchMetricAttributeSet(chipClient string, kvs ...attribute.KeyValue) attribute.Set {
-	if chipClient != "" {
-		kvs = append(kvs, attribute.String("chip_client", chipClient))
+func batchMetricAttributeSet(clientName string, kvs ...attribute.KeyValue) attribute.Set {
+	if clientName != "" {
+		kvs = append(kvs, attribute.String("client_name", clientName))
 	}
 	return attribute.NewSet(kvs...)
 }
 
-func newBatchClientMetrics(chipClient string) (batchClientMetrics, error) {
+func newBatchClientMetrics(clientName string) (batchClientMetrics, error) {
 	meter := otel.Meter("chipingress/batch_client")
 	sendRequestsTotal, err := meter.Int64Counter(
 		"chip_ingress.batch.send_requests_total",
@@ -606,10 +613,10 @@ func newBatchClientMetrics(chipClient string) (batchClientMetrics, error) {
 		return batchClientMetrics{}, err
 	}
 
-	var chipClientAttr otelmetric.MeasurementOption
-	if chipClient != "" {
-		chipClientAttr = otelmetric.WithAttributeSet(attribute.NewSet(
-			attribute.String("chip_client", chipClient),
+	var clientNameAttr otelmetric.MeasurementOption
+	if clientName != "" {
+		clientNameAttr = otelmetric.WithAttributeSet(attribute.NewSet(
+			attribute.String("client_name", clientName),
 		))
 	}
 
@@ -621,32 +628,32 @@ func newBatchClientMetrics(chipClient string) (batchClientMetrics, error) {
 		configInfo:           configInfo,
 		batchSplitsTotal:     batchSplitsTotal,
 		resultsMismatchTotal: resultsMismatchTotal,
-		chipClientAttr:       chipClientAttr,
-		successStatusAttr: otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
+		clientNameAttr:       clientNameAttr,
+		successStatusAttr: otelmetric.WithAttributeSet(batchMetricAttributeSet(clientName,
 			attribute.String("status", "success"),
 		)),
-		failureStatusAttr: otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
+		failureStatusAttr: otelmetric.WithAttributeSet(batchMetricAttributeSet(clientName,
 			attribute.String("status", "failure"),
 		)),
 	}, nil
 }
 
-func (m *batchClientMetrics) chipClientAddOpts() []otelmetric.AddOption {
-	if m.chipClientAttr != nil {
-		return []otelmetric.AddOption{m.chipClientAttr}
+func (m *batchClientMetrics) clientNameAddOpts() []otelmetric.AddOption {
+	if m.clientNameAttr != nil {
+		return []otelmetric.AddOption{m.clientNameAttr}
 	}
 	return nil
 }
 
 func (m *batchClientMetrics) recordConfig(ctx context.Context, c *Client) {
-	chipClient := c.chipClient
-	m.batchSizeAttr = otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
+	clientName := c.clientName
+	m.batchSizeAttr = otelmetric.WithAttributeSet(batchMetricAttributeSet(clientName,
 		attribute.Int("max_batch_size", c.batchSize),
 	))
-	m.maxGRPCReqSizeAttr = otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
+	m.maxGRPCReqSizeAttr = otelmetric.WithAttributeSet(batchMetricAttributeSet(clientName,
 		attribute.Int("max_grpc_request_size_bytes", c.maxGRPCRequestSize),
 	))
-	m.configInfo.Record(ctx, 1, otelmetric.WithAttributeSet(batchMetricAttributeSet(chipClient,
+	m.configInfo.Record(ctx, 1, otelmetric.WithAttributeSet(batchMetricAttributeSet(clientName,
 		attribute.Int("max_batch_size", c.batchSize),
 		attribute.Int("message_buffer_size", cap(c.messageBuffer)),
 		attribute.Int("max_concurrent_sends", cap(c.maxConcurrentSends)),

--- a/pkg/chipingress/batch/client_test.go
+++ b/pkg/chipingress/batch/client_test.go
@@ -1566,8 +1566,8 @@ func TestBatchClient_Metrics(t *testing.T) {
 	})
 }
 
-func TestBatchClient_ChipClientMetricAttribute(t *testing.T) {
-	const chipClient = "test_client"
+func TestBatchClient_ClientNameMetricAttribute(t *testing.T) {
+	const clientName = "test_client"
 
 	batchMetricNames := []string{
 		"chip_ingress.batch.send_requests_total",
@@ -1579,7 +1579,7 @@ func TestBatchClient_ChipClientMetricAttribute(t *testing.T) {
 		"chip_ingress.batch.results_mismatch_total",
 	}
 
-	t.Run("with WithChipClient sets chip_client on all batch metrics", func(t *testing.T) {
+	t.Run("with WithClientName sets client_name on all batch metrics", func(t *testing.T) {
 		reader, restore := useTestMeterProvider(t)
 		defer restore()
 
@@ -1609,7 +1609,7 @@ func TestBatchClient_ChipClientMetricAttribute(t *testing.T) {
 
 		client, err := NewBatchClient(
 			mockClient,
-			WithChipClient(chipClient),
+			WithClientName(clientName),
 			WithBatchSize(1),
 			WithBatchInterval(time.Second),
 			WithMessageBuffer(10),
@@ -1649,11 +1649,11 @@ func TestBatchClient_ChipClientMetricAttribute(t *testing.T) {
 		rm := collectResourceMetrics(t, reader)
 		for _, name := range batchMetricNames {
 			metric := mustMetric(t, rm, name)
-			assertMetricHasChipClient(t, metric, chipClient)
+			assertMetricHasClientName(t, metric, clientName)
 		}
 	})
 
-	t.Run("without WithChipClient omits chip_client", func(t *testing.T) {
+	t.Run("without WithClientName omits client_name", func(t *testing.T) {
 		reader, restore := useTestMeterProvider(t)
 		defer restore()
 
@@ -1692,25 +1692,25 @@ func TestBatchClient_ChipClientMetricAttribute(t *testing.T) {
 				if !strings.HasPrefix(metric.Name, "chip_ingress.batch.") {
 					continue
 				}
-				assertMetricOmitsChipClient(t, metric)
+				assertMetricOmitsClientName(t, metric)
 			}
 		}
 	})
 }
 
-func assertMetricHasChipClient(t *testing.T, metric metricdata.Metrics, chipClient string) {
+func assertMetricHasClientName(t *testing.T, metric metricdata.Metrics, clientName string) {
 	t.Helper()
 	forEachMetricAttrSet(t, metric, func(attrs attribute.Set) {
-		assert.True(t, hasStringAttr(attrs, "chip_client", chipClient),
-			"metric %s missing chip_client=%q", metric.Name, chipClient)
+		assert.True(t, hasStringAttr(attrs, "client_name", clientName),
+			"metric %s missing client_name=%q", metric.Name, clientName)
 	})
 }
 
-func assertMetricOmitsChipClient(t *testing.T, metric metricdata.Metrics) {
+func assertMetricOmitsClientName(t *testing.T, metric metricdata.Metrics) {
 	t.Helper()
 	forEachMetricAttrSet(t, metric, func(attrs attribute.Set) {
 		for _, kv := range attrs.ToSlice() {
-			assert.NotEqual(t, "chip_client", string(kv.Key), "metric %s should not have chip_client", metric.Name)
+			assert.NotEqual(t, "client_name", string(kv.Key), "metric %s should not have client_name", metric.Name)
 		}
 	})
 }

--- a/pkg/chipingress/batch/client_test.go
+++ b/pkg/chipingress/batch/client_test.go
@@ -1566,6 +1566,185 @@ func TestBatchClient_Metrics(t *testing.T) {
 	})
 }
 
+func TestBatchClient_ChipClientMetricAttribute(t *testing.T) {
+	const chipClient = "test_client"
+
+	batchMetricNames := []string{
+		"chip_ingress.batch.send_requests_total",
+		"chip_ingress.batch.request_size_messages",
+		"chip_ingress.batch.request_size_bytes",
+		"chip_ingress.batch.request_latency_ms",
+		"chip_ingress.batch.config.info",
+		"chip_ingress.batch.batch_splits_total",
+		"chip_ingress.batch.results_mismatch_total",
+	}
+
+	t.Run("with WithChipClient sets chip_client on all batch metrics", func(t *testing.T) {
+		reader, restore := useTestMeterProvider(t)
+		defer restore()
+
+		events := []*chipingress.CloudEventPb{
+			largeTestEvent("chip-client-1"),
+			largeTestEvent("chip-client-2"),
+			largeTestEvent("chip-client-3"),
+		}
+		msgs2 := []*messageWithCallback{{event: events[0]}, {event: events[1]}}
+		_, maxRequestSize := newBatchRequest(msgs2, false)
+
+		mockClient := mocks.NewClient(t)
+		done := make(chan struct{})
+		var mu sync.Mutex
+		var publishCount int
+		mockClient.
+			On("PublishBatch", mock.Anything, mock.Anything).
+			Return(&chipingress.PublishResponse{}, nil).
+			Run(func(_ mock.Arguments) {
+				mu.Lock()
+				publishCount++
+				if publishCount == 2 {
+					close(done)
+				}
+				mu.Unlock()
+			})
+
+		client, err := NewBatchClient(
+			mockClient,
+			WithChipClient(chipClient),
+			WithBatchSize(1),
+			WithBatchInterval(time.Second),
+			WithMessageBuffer(10),
+			WithMaxGRPCRequestSize(minMaxGRPCRequestSize),
+		)
+		require.NoError(t, err)
+		client.maxGRPCRequestSize = maxRequestSize
+		client.effectiveMaxRequestSize = maxRequestSize
+		client.metrics.recordConfig(t.Context(), client)
+
+		messages := make([]*messageWithCallback, 0, len(events))
+		for _, event := range events {
+			messages = append(messages, &messageWithCallback{event: event})
+		}
+		client.sendBatch(t.Context(), messages)
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for split batches")
+		}
+
+		client.completeBatchCallbacksFromResults(
+			[]*messageWithCallback{
+				{event: &chipingress.CloudEventPb{Id: "m1", Source: "s", Type: "t"}},
+				{event: &chipingress.CloudEventPb{Id: "m2", Source: "s", Type: "t"}},
+			},
+			[]*chipingress.PublishResult{{EventId: "m1"}},
+		)
+		client.completeBatchCallbacksFromResults(
+			[]*messageWithCallback{
+				{event: &chipingress.CloudEventPb{Id: "m1", Source: "s", Type: "t"}},
+			},
+			[]*chipingress.PublishResult{{EventId: "wrong-id"}},
+		)
+
+		rm := collectResourceMetrics(t, reader)
+		for _, name := range batchMetricNames {
+			metric := mustMetric(t, rm, name)
+			assertMetricHasChipClient(t, metric, chipClient)
+		}
+	})
+
+	t.Run("without WithChipClient omits chip_client", func(t *testing.T) {
+		reader, restore := useTestMeterProvider(t)
+		defer restore()
+
+		mockClient := mocks.NewClient(t)
+		mockClient.EXPECT().Close().Return(nil).Maybe()
+		done := make(chan struct{})
+		mockClient.
+			On("PublishBatch", mock.Anything, mock.Anything).
+			Return(&chipingress.PublishResponse{}, nil).
+			Run(func(_ mock.Arguments) { close(done) }).
+			Once()
+
+		client, err := NewBatchClient(
+			mockClient,
+			WithBatchSize(1),
+			WithBatchInterval(time.Second),
+			WithMessageBuffer(10),
+		)
+		require.NoError(t, err)
+		client.Start(t.Context())
+
+		require.NoError(t, client.QueueMessage(&chipingress.CloudEventPb{
+			Id: "no-chip-client", Source: "platform", Type: "Test",
+		}, nil))
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for PublishBatch")
+		}
+		client.Stop()
+
+		rm := collectResourceMetrics(t, reader)
+		for _, sm := range rm.ScopeMetrics {
+			for _, metric := range sm.Metrics {
+				if !strings.HasPrefix(metric.Name, "chip_ingress.batch.") {
+					continue
+				}
+				assertMetricOmitsChipClient(t, metric)
+			}
+		}
+	})
+}
+
+func assertMetricHasChipClient(t *testing.T, metric metricdata.Metrics, chipClient string) {
+	t.Helper()
+	forEachMetricAttrSet(t, metric, func(attrs attribute.Set) {
+		assert.True(t, hasStringAttr(attrs, "chip_client", chipClient),
+			"metric %s missing chip_client=%q", metric.Name, chipClient)
+	})
+}
+
+func assertMetricOmitsChipClient(t *testing.T, metric metricdata.Metrics) {
+	t.Helper()
+	forEachMetricAttrSet(t, metric, func(attrs attribute.Set) {
+		for _, kv := range attrs.ToSlice() {
+			assert.NotEqual(t, "chip_client", string(kv.Key), "metric %s should not have chip_client", metric.Name)
+		}
+	})
+}
+
+func forEachMetricAttrSet(t *testing.T, metric metricdata.Metrics, fn func(attribute.Set)) {
+	t.Helper()
+	var count int
+	record := func(attrs attribute.Set) {
+		count++
+		fn(attrs)
+	}
+	switch data := metric.Data.(type) {
+	case metricdata.Sum[int64]:
+		for _, dp := range data.DataPoints {
+			record(dp.Attributes)
+		}
+	case metricdata.Histogram[int64]:
+		for _, dp := range data.DataPoints {
+			record(dp.Attributes)
+		}
+	case metricdata.Histogram[float64]:
+		for _, dp := range data.DataPoints {
+			record(dp.Attributes)
+		}
+	case metricdata.Gauge[int64]:
+		for _, dp := range data.DataPoints {
+			record(dp.Attributes)
+		}
+	default:
+		t.Fatalf("metric %s has unsupported type %T", metric.Name, metric.Data)
+	}
+	require.NotZero(t, count, "metric %s has no datapoints", metric.Name)
+}
+
 func TestSplitMessagesByRequestSize(t *testing.T) {
 	t.Run("empty messages returns nil", func(t *testing.T) {
 		result := splitMessagesByRequestSize(nil, 1024, false)


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/INFOPLAT-14703
This PR adds a client_name field in chip ingress, so that it can be used later in metrics.
Current possible values are:
"beholder" & "durable_emitter"

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
https://github.com/smartcontractkit/chainlink-common/pull/2228/
