### PR TITLE
INFOPLAT-13349: feat(beholder): track beholder.export.* metrics per export via custom gRPC stats handler

### DIFF
--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
@@ -140,21 +139,32 @@ func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (*Client, erro
 	tracer := tracerProvider.Tracer(defaultPackageName)
 
 	// Meter
-	meterProvider, err := newMeterProvider(cfg, baseResource, auth, creds)
+	meterProvider, meteredMetrics, err := newMeterProvider(cfg, baseResource, auth, creds)
 	if err != nil {
 		return nil, err
 	}
 	meter := meterProvider.Meter(defaultPackageName)
 
-	// Shared log exporter for both logger and message emitter
-	logOpts, err := newLoggerOpts(cfg, auth, creds, meterProvider, tracerProvider)
+	// Shared export instruments beholder.export.bytes and
+	// beholder.export.duration, labelled per signal. They live on this
+	// MeterProvider, so the metrics exporter can only be wired up once the
+	// provider and its meter exist.
+	expMetrics, err := newExportMetrics(meter)
 	if err != nil {
 		return nil, err
 	}
-	sharedLogExporter, err := otlploggrpcNew(logOpts...)
+	meteredMetrics.attachMetrics(expMetrics, cfg.AuthPublicKeyHex)
+
+	// Shared log exporter for both logger and message emitter.
+	logOpts, err := newLoggerOpts(cfg, auth, creds)
 	if err != nil {
 		return nil, err
 	}
+	rawLogExporter, err := otlploggrpcNew(logOpts...)
+	if err != nil {
+		return nil, err
+	}
+	sharedLogExporter := newMeteredLogExporter(rawLogExporter, expMetrics, cfg.AuthPublicKeyHex)
 
 	// Logger
 	var loggerProvider *sdklog.LoggerProvider
@@ -505,12 +515,17 @@ func newTracerProvider(config Config, resource *sdkresource.Resource, auth Auth,
 	return sdktrace.NewTracerProvider(opts...), nil
 }
 
-func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, creds credentials.TransportCredentials) (*sdkmetric.MeterProvider, error) {
+func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, creds credentials.TransportCredentials) (*sdkmetric.MeterProvider, *meteredMetricExporter, error) {
 	ctx := context.Background()
 	opts := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithTLSCredentials(creds),
 		otlpmetricgrpc.WithEndpoint(cfg.OtelExporterGRPCEndpoint),
 	}
+
+	dialOpts := []grpc.DialOption{
+		grpc.WithStatsHandler(beholderStatsHandler{}),
+	}
+
 	switch compressor := cfg.MetricCompressor; compressor {
 	case "none":
 	case "":
@@ -522,13 +537,14 @@ func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, cre
 	switch {
 	// Rotating auth
 	case auth != nil:
-		opts = append(opts, otlpmetricgrpc.WithDialOption(authDialOpt(auth)))
+		dialOpts = append(dialOpts, authDialOpt(auth))
 	// Static auth
 	case len(cfg.AuthHeaders) > 0:
 		opts = append(opts, otlpmetricgrpc.WithHeaders(cfg.AuthHeaders))
 	// No auth
 	default:
 	}
+	opts = append(opts, otlpmetricgrpc.WithDialOption(dialOpts...))
 
 	if cfg.MetricRetryConfig != nil {
 		// NOTE: By default, the retry is enabled in the OTel SDK
@@ -542,8 +558,10 @@ func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, cre
 	// note: context is unused internally
 	exporter, err := otlpmetricgrpc.New(ctx, opts...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	metered := newMeteredMetricExporter(exporter)
 
 	readerOpts := []sdkmetric.PeriodicReaderOption{
 		sdkmetric.WithInterval(cfg.MetricReaderInterval), // Default is 10s
@@ -551,22 +569,19 @@ func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, cre
 	for _, p := range cfg.MetricProducers {
 		readerOpts = append(readerOpts, sdkmetric.WithProducer(p))
 	}
+
 	mpOpts := append(cfg.metricOptions(),
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, readerOpts...)),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metered, readerOpts...)),
 		sdkmetric.WithResource(resource),
 	)
-	return sdkmetric.NewMeterProvider(mpOpts...), nil
+	return sdkmetric.NewMeterProvider(mpOpts...), metered, nil
 }
 
 // newLoggerOpts creates options for a logger exporter
-func newLoggerOpts(cfg Config, auth Auth, creds credentials.TransportCredentials, meter *sdkmetric.MeterProvider, tracer *sdktrace.TracerProvider) ([]otlploggrpc.Option, error) {
-	otelOpts := []otelgrpc.Option{
-		otelgrpc.WithMeterProvider(meter),
-		otelgrpc.WithTracerProvider(tracer),
-	}
+func newLoggerOpts(cfg Config, auth Auth, creds credentials.TransportCredentials) ([]otlploggrpc.Option, error) {
 
 	dialOpts := []grpc.DialOption{
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler(otelOpts...)),
+		grpc.WithStatsHandler(beholderStatsHandler{}),
 	}
 
 	opts := []otlploggrpc.Option{

--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -138,25 +138,27 @@ func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (*Client, erro
 	}
 	tracer := tracerProvider.Tracer(defaultPackageName)
 
+	logStatsHandler := newExportStatsHandler("logs", cfg.AuthPublicKeyHex)
+	metricStatsHandler := newExportStatsHandler("metrics", cfg.AuthPublicKeyHex)
+
 	// Meter
-	meterProvider, meteredMetrics, err := newMeterProvider(cfg, baseResource, auth, creds)
+	meterProvider, meteredMetrics, err := newMeterProvider(cfg, baseResource, auth, creds, metricStatsHandler)
 	if err != nil {
 		return nil, err
 	}
 	meter := meterProvider.Meter(defaultPackageName)
 
-	// Shared export instruments beholder.export.bytes and
-	// beholder.export.duration, labelled per signal. They live on this
-	// MeterProvider, so the metrics exporter can only be wired up once the
-	// provider and its meter exist.
+	// Shared export instruments beholder.export.* metrics
 	expMetrics, err := newExportMetrics(meter)
 	if err != nil {
 		return nil, err
 	}
+	logStatsHandler.attachMetrics(expMetrics)
+	metricStatsHandler.attachMetrics(expMetrics)
 	meteredMetrics.attachMetrics(expMetrics, cfg.AuthPublicKeyHex)
 
 	// Shared log exporter for both logger and message emitter.
-	logOpts, err := newLoggerOpts(cfg, auth, creds)
+	logOpts, err := newLoggerOpts(cfg, auth, creds, logStatsHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -515,7 +517,7 @@ func newTracerProvider(config Config, resource *sdkresource.Resource, auth Auth,
 	return sdktrace.NewTracerProvider(opts...), nil
 }
 
-func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, creds credentials.TransportCredentials) (*sdkmetric.MeterProvider, *meteredMetricExporter, error) {
+func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, creds credentials.TransportCredentials, statsHandler *exportStatsHandler) (*sdkmetric.MeterProvider, *meteredMetricExporter, error) {
 	ctx := context.Background()
 	opts := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithTLSCredentials(creds),
@@ -523,7 +525,7 @@ func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, cre
 	}
 
 	dialOpts := []grpc.DialOption{
-		grpc.WithStatsHandler(beholderStatsHandler{}),
+		grpc.WithStatsHandler(statsHandler),
 	}
 
 	switch compressor := cfg.MetricCompressor; compressor {
@@ -578,10 +580,10 @@ func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, cre
 }
 
 // newLoggerOpts creates options for a logger exporter
-func newLoggerOpts(cfg Config, auth Auth, creds credentials.TransportCredentials) ([]otlploggrpc.Option, error) {
+func newLoggerOpts(cfg Config, auth Auth, creds credentials.TransportCredentials, statsHandler *exportStatsHandler) ([]otlploggrpc.Option, error) {
 
 	dialOpts := []grpc.DialOption{
-		grpc.WithStatsHandler(beholderStatsHandler{}),
+		grpc.WithStatsHandler(statsHandler),
 	}
 
 	opts := []otlploggrpc.Option{

--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -131,8 +131,10 @@ func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (_ *Client, er
 		return nil, err
 	}
 
+	traceStatsHandler := newExportStatsHandler(signalTraces, cfg.AuthPublicKeyHex)
+
 	// Tracer
-	tracerProvider, err := newTracerProvider(cfg, baseResource, auth, creds)
+	tracerProvider, meteredTraces, err := newTracerProvider(cfg, baseResource, auth, creds, traceStatsHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +169,9 @@ func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (_ *Client, er
 	}
 	logStatsHandler.attachMetrics(expMetrics)
 	metricStatsHandler.attachMetrics(expMetrics)
+	traceStatsHandler.attachMetrics(expMetrics)
 	meteredMetrics.attachMetrics(expMetrics, cfg.AuthPublicKeyHex)
+	meteredTraces.attachMetrics(expMetrics, cfg.AuthPublicKeyHex)
 
 	// Shared log exporter for both logger and message emitter.
 	logOpts, err := newLoggerOpts(cfg, auth, creds, logStatsHandler)
@@ -472,8 +476,12 @@ type shutdowner interface {
 	Shutdown(ctx context.Context) error
 }
 
-func newTracerProvider(config Config, resource *sdkresource.Resource, auth Auth, creds credentials.TransportCredentials) (*sdktrace.TracerProvider, error) {
+func newTracerProvider(config Config, resource *sdkresource.Resource, auth Auth, creds credentials.TransportCredentials, statsHandler *exportStatsHandler) (*sdktrace.TracerProvider, *meteredTraceExporter, error) {
 	ctx := context.Background()
+
+	dialOpts := []grpc.DialOption{
+		grpc.WithStatsHandler(statsHandler),
+	}
 
 	exporterOpts := []otlptracegrpc.Option{
 		otlptracegrpc.WithTLSCredentials(creds),
@@ -482,13 +490,15 @@ func newTracerProvider(config Config, resource *sdkresource.Resource, auth Auth,
 	switch {
 	// Rotating auth
 	case auth != nil:
-		exporterOpts = append(exporterOpts, otlptracegrpc.WithDialOption(authDialOpt(auth)))
+		dialOpts = append(dialOpts, authDialOpt(auth))
 	// Static auth
 	case len(config.AuthHeaders) > 0:
 		exporterOpts = append(exporterOpts, otlptracegrpc.WithHeaders(config.AuthHeaders))
 	// No auth
 	default:
 	}
+
+	exporterOpts = append(exporterOpts, otlptracegrpc.WithDialOption(dialOpts...))
 	switch compressor := config.TraceCompressor; compressor {
 	case "none":
 	case "":
@@ -508,14 +518,16 @@ func newTracerProvider(config Config, resource *sdkresource.Resource, auth Auth,
 	// note: context is used internally
 	exporter, err := otlptracegrpc.New(ctx, exporterOpts...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	metered := newMeteredTraceExporter(exporter)
+
 	batcherOpts := []sdktrace.BatchSpanProcessorOption{}
 	if config.TraceBatchTimeout > 0 {
 		batcherOpts = append(batcherOpts, sdktrace.WithBatchTimeout(config.TraceBatchTimeout)) // Default is 5s
 	}
 	opts := []sdktrace.TracerProviderOption{
-		sdktrace.WithBatcher(exporter, batcherOpts...),
+		sdktrace.WithBatcher(metered, batcherOpts...),
 		sdktrace.WithResource(resource),
 		sdktrace.WithSampler(
 			sdktrace.ParentBased(
@@ -526,7 +538,7 @@ func newTracerProvider(config Config, resource *sdkresource.Resource, auth Auth,
 	if config.TraceSpanExporter != nil {
 		opts = append(opts, sdktrace.WithBatcher(config.TraceSpanExporter))
 	}
-	return sdktrace.NewTracerProvider(opts...), nil
+	return sdktrace.NewTracerProvider(opts...), metered, nil
 }
 
 func newMeterProvider(cfg Config, resource *sdkresource.Resource, auth Auth, creds credentials.TransportCredentials, statsHandler *exportStatsHandler) (*sdkmetric.MeterProvider, *meteredMetricExporter, error) {

--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -109,7 +109,7 @@ type otlploggrpcFactory func(options ...otlploggrpc.Option) (sdklog.Exporter, er
 
 // NewGRPCClient creates a GRPC based beholder Client. Use NewClient to create a client from a Config which will pick
 // the best client type from the Config.
-func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (*Client, error) {
+func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (_ *Client, err error) {
 	baseResource, err := newOtelResource(cfg)
 	if err != nil {
 		return nil, err
@@ -136,16 +136,28 @@ func NewGRPCClient(cfg Config, otlploggrpcNew otlploggrpcFactory) (*Client, erro
 	if err != nil {
 		return nil, err
 	}
+	// If any later step fails, shut the providers down so their gRPC
+	// connections and the metric periodic-reader goroutine are not leaked.
+	defer func() {
+		if err != nil {
+			_ = tracerProvider.Shutdown(context.Background())
+		}
+	}()
 	tracer := tracerProvider.Tracer(defaultPackageName)
 
-	logStatsHandler := newExportStatsHandler("logs", cfg.AuthPublicKeyHex)
-	metricStatsHandler := newExportStatsHandler("metrics", cfg.AuthPublicKeyHex)
+	logStatsHandler := newExportStatsHandler(signalLogs, cfg.AuthPublicKeyHex)
+	metricStatsHandler := newExportStatsHandler(signalMetrics, cfg.AuthPublicKeyHex)
 
 	// Meter
 	meterProvider, meteredMetrics, err := newMeterProvider(cfg, baseResource, auth, creds, metricStatsHandler)
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			_ = meterProvider.Shutdown(context.Background())
+		}
+	}()
 	meter := meterProvider.Meter(defaultPackageName)
 
 	// Shared export instruments beholder.export.* metrics
@@ -364,7 +376,7 @@ func newOtelResource(cfg Config) (resource *sdkresource.Resource, err error) {
 	}
 
 	// Add csa public key resource attribute
-	csaPublicKeyHex := "not-configured"
+	csaPublicKeyHex := csaPublicKeyNotConfigured
 	if len(cfg.AuthPublicKeyHex) > 0 {
 		csaPublicKeyHex = cfg.AuthPublicKeyHex
 	}

--- a/pkg/beholder/meter_provider_test.go
+++ b/pkg/beholder/meter_provider_test.go
@@ -2,7 +2,9 @@ package beholder
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder/metricviews"
 )
@@ -88,4 +91,95 @@ func TestConfig_metricViews_emptyDenylistOmitsCatchAll(t *testing.T) {
 	views := cfg.metricViews()
 	require.Len(t, views, len(metricviews.Default(nil)))
 	require.NotEmpty(t, views)
+}
+
+// capturingMetricExporter records the ResourceMetrics handed to Export so a test
+// can inspect what a MeterProvider's reader actually collected.
+type capturingMetricExporter struct {
+	mu     sync.Mutex
+	rm     metricdata.ResourceMetrics
+	called bool
+}
+
+func (c *capturingMetricExporter) Temporality(k sdkmetric.InstrumentKind) metricdata.Temporality {
+	return sdkmetric.DefaultTemporalitySelector(k)
+}
+
+func (c *capturingMetricExporter) Aggregation(k sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.DefaultAggregationSelector(k)
+}
+
+func (c *capturingMetricExporter) Export(_ context.Context, rm *metricdata.ResourceMetrics) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rm, c.called = *rm, true
+	return nil
+}
+
+func (c *capturingMetricExporter) ForceFlush(context.Context) error { return nil }
+func (c *capturingMetricExporter) Shutdown(context.Context) error   { return nil }
+
+func (c *capturingMetricExporter) collected() (metricdata.ResourceMetrics, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.rm, c.called
+}
+
+// TestNewMeterProvider_AppliesCardinalityLimit is the regression guard for the
+// gRPC meter provider bypassing Config.metricOptions. Asserting on
+// metricOptions alone cannot catch that, since the bug is the call site not
+// using it.
+func TestNewMeterProvider_AppliesCardinalityLimit(t *testing.T) {
+	t.Parallel()
+
+	const (
+		uniqueAttributes = 10
+		limit            = 5
+	)
+
+	cfg := TestDefaultConfig()
+	cfg.MetricCardinalityLimit = limit
+	// Isolate the assertion from metricviews.Default, same as
+	// TestConfig_metricOptions_cardinalityLimit above.
+	cfg.metricViewsDisabled = true
+	// Long interval so only the explicit ForceFlush below triggers a collection.
+	cfg.MetricReaderInterval = time.Hour
+
+	resource, err := newOtelResource(cfg)
+	require.NoError(t, err)
+
+	mp, metered, err := newMeterProvider(cfg, resource, nil, insecure.NewCredentials())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	// Swap the real OTLP exporter for one we can read. Shut the original down
+	// separately, since mp.Shutdown will now reach the capturing exporter.
+	capture := &capturingMetricExporter{}
+	original := metered.Exporter
+	metered.Exporter = capture
+	t.Cleanup(func() { _ = original.Shutdown(context.Background()) })
+
+	counter, err := mp.Meter("test").Int64Counter("overflow_test_total")
+	require.NoError(t, err)
+	for i := range uniqueAttributes {
+		counter.Add(context.Background(), 1, metric.WithAttributes(attribute.Int("key", i)))
+	}
+
+	require.NoError(t, mp.ForceFlush(context.Background()))
+
+	rm, called := capture.collected()
+	require.True(t, called, "ForceFlush should have exported a batch")
+
+	var sum metricdata.Sum[int64]
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "overflow_test_total" {
+				sum, found = m.Data.(metricdata.Sum[int64]), true
+			}
+		}
+	}
+	require.True(t, found, "expected overflow_test_total in the collected batch")
+	assert.Len(t, sum.DataPoints, limit,
+		"newMeterProvider must honour MetricCardinalityLimit via Config.metricOptions")
 }

--- a/pkg/beholder/meter_provider_test.go
+++ b/pkg/beholder/meter_provider_test.go
@@ -148,7 +148,7 @@ func TestNewMeterProvider_AppliesCardinalityLimit(t *testing.T) {
 	resource, err := newOtelResource(cfg)
 	require.NoError(t, err)
 
-	mp, metered, err := newMeterProvider(cfg, resource, nil, insecure.NewCredentials())
+	mp, metered, err := newMeterProvider(cfg, resource, nil, insecure.NewCredentials(), newExportStatsHandler("metrics", cfg.AuthPublicKeyHex))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
 

--- a/pkg/beholder/meter_provider_test.go
+++ b/pkg/beholder/meter_provider_test.go
@@ -183,3 +183,23 @@ func TestNewMeterProvider_AppliesCardinalityLimit(t *testing.T) {
 	assert.Len(t, sum.DataPoints, limit,
 		"newMeterProvider must honour MetricCardinalityLimit via Config.metricOptions")
 }
+
+func TestNewTracerProvider_WiresMeteredTraceExporter(t *testing.T) {
+	cfg := TestDefaultConfig()
+	resource, err := newOtelResource(cfg)
+	require.NoError(t, err)
+
+	tp, metered, err := newTracerProvider(cfg, resource, nil, insecure.NewCredentials(), newExportStatsHandler("traces", cfg.AuthPublicKeyHex))
+	require.NoError(t, err)
+	require.NotNil(t, tp)
+	require.NotNil(t, metered, "the trace exporter must be wrapped so beholder.export.duration is emitted for traces")
+
+	inst, collect := newTestMetrics(t)
+	metered.attachMetrics(inst, cfg.AuthPublicKeyHex)
+	require.NoError(t, metered.ExportSpans(context.Background(), nil))
+
+	_, ok := histForSignal(t, collect(), "traces", false)
+	assert.True(t, ok, "expected a traces duration datapoint")
+
+	require.NoError(t, tp.Shutdown(context.Background()))
+}

--- a/pkg/beholder/metered_exporter.go
+++ b/pkg/beholder/metered_exporter.go
@@ -19,6 +19,14 @@ const (
 	exportDurationMetric = "beholder.export.duration"
 )
 
+const (
+	signalLogs    = "logs"
+	signalMetrics = "metrics"
+	signalTraces  = "traces"
+)
+
+const csaPublicKeyNotConfigured = "not-configured"
+
 // exportMetrics holds the instruments shared by the export stats handler and
 // the metered exporters. They live on the beholder MeterProvider and are
 // distinguished per signal.
@@ -56,6 +64,9 @@ func newExportMetrics(meter otelmetric.Meter) (exportMetrics, error) {
 // exportAttrs builds the attribute set identifying one signal's exports, plus
 // any per-measurement extras.
 func exportAttrs(signal, csaPublicKeyHex string, extra ...attribute.KeyValue) otelmetric.MeasurementOption {
+	if csaPublicKeyHex == "" {
+		csaPublicKeyHex = csaPublicKeyNotConfigured
+	}
 	attrs := make([]attribute.KeyValue, 0, 2+len(extra))
 	attrs = append(attrs,
 		attribute.String("otel_signal", signal),
@@ -104,7 +115,7 @@ type meteredLogExporter struct {
 
 func newMeteredLogExporter(inner sdklog.Exporter, metrics exportMetrics, csaPublicKeyHex string) *meteredLogExporter {
 	return &meteredLogExporter{
-		meteredExporter: newBaseExporter(metrics, "logs", csaPublicKeyHex),
+		meteredExporter: newBaseExporter(metrics, signalLogs, csaPublicKeyHex),
 		inner:           inner,
 	}
 }
@@ -147,7 +158,7 @@ type meteredMetricExporter struct {
 }
 
 func newMeteredMetricExporter(inner sdkmetric.Exporter) *meteredMetricExporter {
-	return &meteredMetricExporter{Exporter: inner, lazyMetered: lazyMetered{signal: "metrics"}}
+	return &meteredMetricExporter{Exporter: inner, lazyMetered: lazyMetered{signal: signalMetrics}}
 }
 
 func (e *meteredMetricExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
@@ -160,7 +171,7 @@ type meteredTraceExporter struct {
 }
 
 func newMeteredTraceExporter(inner sdktrace.SpanExporter) *meteredTraceExporter {
-	return &meteredTraceExporter{SpanExporter: inner, lazyMetered: lazyMetered{signal: "traces"}}
+	return &meteredTraceExporter{SpanExporter: inner, lazyMetered: lazyMetered{signal: signalTraces}}
 }
 
 func (e *meteredTraceExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {

--- a/pkg/beholder/metered_exporter.go
+++ b/pkg/beholder/metered_exporter.go
@@ -1,0 +1,208 @@
+package beholder
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/grpc/stats"
+)
+
+// exportBytesKey is the context key under which a metered exporter stashes a
+// per-export byte holder for beholderStatsHandler to fill in.
+type exportBytesKey struct{}
+
+// beholderStatsHandler is a minimal, stateless gRPC stats.Handler that records the
+// uncompressed proto size of each outbound message.
+type beholderStatsHandler struct{}
+
+func (beholderStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (beholderStatsHandler) HandleConn(context.Context, stats.ConnStats) {}
+
+func (beholderStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+// HandleRPC fires on every gRPC stats event. On OutPayload it stores the
+// uncompressed message length, the same field otelgrpc used for
+// rpc.client.request.size
+func (beholderStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	op, ok := rs.(*stats.OutPayload)
+	if !ok {
+		return
+	}
+	if holder, ok := ctx.Value(exportBytesKey{}).(*atomic.Int64); ok {
+		holder.Store(int64(op.Length))
+	}
+}
+
+const (
+	exportBytesMetric    = "beholder.export.bytes"
+	exportDurationMetric = "beholder.export.duration"
+)
+
+// exportMetrics holds the instruments shared by all metered exporters. They live
+// on the beholder MeterProvider and are distinguished per exporter only by
+// attributes, so one set covers every signal.
+type exportMetrics struct {
+	bytes    otelmetric.Int64Counter
+	duration otelmetric.Float64Histogram
+}
+
+// newExportMetrics creates the instruments shared by all metered exporters.
+func newExportMetrics(meter otelmetric.Meter) (exportMetrics, error) {
+	bytes, err := meter.Int64Counter(
+		exportBytesMetric,
+		otelmetric.WithDescription("Uncompressed OTLP proto size in bytes of each export batch. Recorded once per batch, on success only; retry attempts are not summed."),
+		otelmetric.WithUnit("By"),
+	)
+	if err != nil {
+		return exportMetrics{}, err
+	}
+	duration, err := meter.Float64Histogram(
+		exportDurationMetric,
+		otelmetric.WithDescription("Wall-clock duration in seconds of each OTLP export batch, covering all retry attempts and backoff. Recorded once per batch, on both success and failure."),
+		otelmetric.WithUnit("s"),
+		// Sized for network exports: sub-10ms to a 60s deadline. The SDK defaults
+		// are millisecond-scaled, so nearly every export would land in bucket one.
+		otelmetric.WithExplicitBucketBoundaries(
+			0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60,
+		),
+	)
+	if err != nil {
+		return exportMetrics{}, err
+	}
+	return exportMetrics{bytes: bytes, duration: duration}, nil
+}
+
+// exportAttrs builds the attribute set identifying one signal's exports, plus
+// any per-measurement extras.
+func exportAttrs(signal, csaPublicKeyHex string, extra ...attribute.KeyValue) otelmetric.MeasurementOption {
+	attrs := make([]attribute.KeyValue, 0, 2+len(extra))
+	attrs = append(attrs,
+		attribute.String("otel_signal", signal),
+		attribute.String("csa_public_key", csaPublicKeyHex),
+	)
+	return otelmetric.WithAttributes(append(attrs, extra...)...)
+}
+
+// meteredExporter holds the shared metering logic: run an export with a per-call
+// size holder in the context, then record the captured OutPayload size on
+// success and the duration either way. Attribute options are
+// precomputed so the export path allocates nothing per call.
+type meteredExporter struct {
+	metrics exportMetrics
+
+	byteAttrs otelmetric.MeasurementOption // otel_signal, csa_public_key
+	okAttrs   otelmetric.MeasurementOption // + error=false
+	errAttrs  otelmetric.MeasurementOption // + error=true
+}
+
+func newBaseExporter(metrics exportMetrics, signal, csaPublicKeyHex string) meteredExporter {
+	return meteredExporter{
+		metrics:   metrics,
+		byteAttrs: exportAttrs(signal, csaPublicKeyHex),
+		okAttrs:   exportAttrs(signal, csaPublicKeyHex, attribute.Bool("error", false)),
+		errAttrs:  exportAttrs(signal, csaPublicKeyHex, attribute.Bool("error", true)),
+	}
+}
+
+func (m meteredExporter) record(ctx context.Context, export func(context.Context) error) error {
+	var size atomic.Int64
+	start := time.Now()
+	err := export(context.WithValue(ctx, exportBytesKey{}, &size))
+	elapsed := time.Since(start).Seconds()
+
+	// Bytes are only meaningful for a batch that landed; duration is recorded
+	// either way
+	if err == nil {
+		m.metrics.bytes.Add(ctx, size.Load(), m.byteAttrs)
+		m.metrics.duration.Record(ctx, elapsed, m.okAttrs)
+	} else {
+		m.metrics.duration.Record(ctx, elapsed, m.errAttrs)
+	}
+	return err
+}
+
+// meteredLogExporter wraps an sdklog.Exporter and records each export batch's
+// uncompressed proto size and duration. It sits above the otlploggrpc retry
+// loop, so Export is called once per logical batch: bytes are counted only on
+// success, and the duration covers the whole retry sequence.
+type meteredLogExporter struct {
+	meteredExporter
+	inner sdklog.Exporter
+}
+
+func newMeteredLogExporter(inner sdklog.Exporter, metrics exportMetrics, csaPublicKeyHex string) *meteredLogExporter {
+	return &meteredLogExporter{
+		meteredExporter: newBaseExporter(metrics, "logs", csaPublicKeyHex),
+		inner:           inner,
+	}
+}
+
+func (e *meteredLogExporter) Export(ctx context.Context, records []sdklog.Record) error {
+	return e.record(ctx, func(c context.Context) error { return e.inner.Export(c, records) })
+}
+
+func (e *meteredLogExporter) Shutdown(ctx context.Context) error { return e.inner.Shutdown(ctx) }
+
+func (e *meteredLogExporter) ForceFlush(ctx context.Context) error { return e.inner.ForceFlush(ctx) }
+
+// lazyMetered defers instrument wiring for exporters constructed before
+// beholder MeterProvider exist
+type lazyMetered struct {
+	signal string
+	base   atomic.Pointer[meteredExporter]
+}
+
+// attachMetrics wires the export instruments once the MeterProvider exists.
+func (l *lazyMetered) attachMetrics(metrics exportMetrics, csaPublicKeyHex string) {
+	base := newBaseExporter(metrics, l.signal, csaPublicKeyHex)
+	l.base.Store(&base)
+}
+
+func (l *lazyMetered) record(ctx context.Context, export func(context.Context) error) error {
+	base := l.base.Load()
+	if base == nil {
+		return export(ctx)
+	}
+	return base.record(ctx, export)
+}
+
+// meteredMetricExporter wraps an sdkmetric.Exporter.
+// It is created by the MeterProvider and has no access to the instruments until
+// the MeterProvider exists and calls attachMetrics.
+type meteredMetricExporter struct {
+	sdkmetric.Exporter
+	lazyMetered
+}
+
+func newMeteredMetricExporter(inner sdkmetric.Exporter) *meteredMetricExporter {
+	return &meteredMetricExporter{Exporter: inner, lazyMetered: lazyMetered{signal: "metrics"}}
+}
+
+func (e *meteredMetricExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
+	return e.record(ctx, func(c context.Context) error { return e.Exporter.Export(c, rm) })
+}
+
+type meteredTraceExporter struct {
+	sdktrace.SpanExporter
+	lazyMetered
+}
+
+func newMeteredTraceExporter(inner sdktrace.SpanExporter) *meteredTraceExporter {
+	return &meteredTraceExporter{SpanExporter: inner, lazyMetered: lazyMetered{signal: "traces"}}
+}
+
+func (e *meteredTraceExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	return e.record(ctx, func(c context.Context) error { return e.SpanExporter.ExportSpans(c, spans) })
+}

--- a/pkg/beholder/metered_exporter.go
+++ b/pkg/beholder/metered_exporter.go
@@ -92,6 +92,11 @@ func newBaseExporter(metrics exportMetrics, signal, csaPublicKeyHex string) mete
 }
 
 func (m meteredExporter) record(ctx context.Context, export func() error) error {
+	// A zero-value exportMetrics (no instruments) degrades to passthrough,
+	// matching lazyMetered's unattached behavior.
+	if m.metrics.duration == nil {
+		return export()
+	}
 	start := time.Now()
 	err := export()
 	elapsed := time.Since(start).Seconds()

--- a/pkg/beholder/metered_exporter.go
+++ b/pkg/beholder/metered_exporter.go
@@ -14,45 +14,14 @@ import (
 	"google.golang.org/grpc/stats"
 )
 
-// exportBytesKey is the context key under which a metered exporter stashes a
-// per-export byte holder for beholderStatsHandler to fill in.
-type exportBytesKey struct{}
-
-// beholderStatsHandler is a minimal, stateless gRPC stats.Handler that records the
-// uncompressed proto size of each outbound message.
-type beholderStatsHandler struct{}
-
-func (beholderStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
-	return ctx
-}
-
-func (beholderStatsHandler) HandleConn(context.Context, stats.ConnStats) {}
-
-func (beholderStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
-	return ctx
-}
-
-// HandleRPC fires on every gRPC stats event. On OutPayload it stores the
-// uncompressed message length, the same field otelgrpc used for
-// rpc.client.request.size
-func (beholderStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
-	op, ok := rs.(*stats.OutPayload)
-	if !ok {
-		return
-	}
-	if holder, ok := ctx.Value(exportBytesKey{}).(*atomic.Int64); ok {
-		holder.Store(int64(op.Length))
-	}
-}
-
 const (
 	exportBytesMetric    = "beholder.export.bytes"
 	exportDurationMetric = "beholder.export.duration"
 )
 
-// exportMetrics holds the instruments shared by all metered exporters. They live
-// on the beholder MeterProvider and are distinguished per exporter only by
-// attributes, so one set covers every signal.
+// exportMetrics holds the instruments shared by the export stats handler and
+// the metered exporters. They live on the beholder MeterProvider and are
+// distinguished per signal.
 type exportMetrics struct {
 	bytes    otelmetric.Int64Counter
 	duration otelmetric.Float64Histogram
@@ -95,37 +64,28 @@ func exportAttrs(signal, csaPublicKeyHex string, extra ...attribute.KeyValue) ot
 	return otelmetric.WithAttributes(append(attrs, extra...)...)
 }
 
-// meteredExporter holds the shared metering logic: run an export with a per-call
-// size holder in the context, then record the captured OutPayload size on
-// success and the duration either way. Attribute options are
-// precomputed so the export path allocates nothing per call.
+// meteredExporter holds the shared metering logic for all signals.
 type meteredExporter struct {
 	metrics exportMetrics
 
-	byteAttrs otelmetric.MeasurementOption // otel_signal, csa_public_key
-	okAttrs   otelmetric.MeasurementOption // + error=false
-	errAttrs  otelmetric.MeasurementOption // + error=true
+	okAttrs  otelmetric.MeasurementOption // otel_signal, csa_public_key, error=false
+	errAttrs otelmetric.MeasurementOption // otel_signal, csa_public_key, error=true
 }
 
 func newBaseExporter(metrics exportMetrics, signal, csaPublicKeyHex string) meteredExporter {
 	return meteredExporter{
-		metrics:   metrics,
-		byteAttrs: exportAttrs(signal, csaPublicKeyHex),
-		okAttrs:   exportAttrs(signal, csaPublicKeyHex, attribute.Bool("error", false)),
-		errAttrs:  exportAttrs(signal, csaPublicKeyHex, attribute.Bool("error", true)),
+		metrics:  metrics,
+		okAttrs:  exportAttrs(signal, csaPublicKeyHex, attribute.Bool("error", false)),
+		errAttrs: exportAttrs(signal, csaPublicKeyHex, attribute.Bool("error", true)),
 	}
 }
 
-func (m meteredExporter) record(ctx context.Context, export func(context.Context) error) error {
-	var size atomic.Int64
+func (m meteredExporter) record(ctx context.Context, export func() error) error {
 	start := time.Now()
-	err := export(context.WithValue(ctx, exportBytesKey{}, &size))
+	err := export()
 	elapsed := time.Since(start).Seconds()
 
-	// Bytes are only meaningful for a batch that landed; duration is recorded
-	// either way
 	if err == nil {
-		m.metrics.bytes.Add(ctx, size.Load(), m.byteAttrs)
 		m.metrics.duration.Record(ctx, elapsed, m.okAttrs)
 	} else {
 		m.metrics.duration.Record(ctx, elapsed, m.errAttrs)
@@ -134,9 +94,9 @@ func (m meteredExporter) record(ctx context.Context, export func(context.Context
 }
 
 // meteredLogExporter wraps an sdklog.Exporter and records each export batch's
-// uncompressed proto size and duration. It sits above the otlploggrpc retry
-// loop, so Export is called once per logical batch: bytes are counted only on
-// success, and the duration covers the whole retry sequence.
+// duration. It sits above the otlploggrpc retry loop, so Export is called once
+// per logical batch and the duration covers the whole retry sequence. Bytes are
+// recorded by exportStatsHandler inside the gRPC stack.
 type meteredLogExporter struct {
 	meteredExporter
 	inner sdklog.Exporter
@@ -150,15 +110,15 @@ func newMeteredLogExporter(inner sdklog.Exporter, metrics exportMetrics, csaPubl
 }
 
 func (e *meteredLogExporter) Export(ctx context.Context, records []sdklog.Record) error {
-	return e.record(ctx, func(c context.Context) error { return e.inner.Export(c, records) })
+	return e.record(ctx, func() error { return e.inner.Export(ctx, records) })
 }
 
 func (e *meteredLogExporter) Shutdown(ctx context.Context) error { return e.inner.Shutdown(ctx) }
 
 func (e *meteredLogExporter) ForceFlush(ctx context.Context) error { return e.inner.ForceFlush(ctx) }
 
-// lazyMetered defers instrument wiring for exporters constructed before
-// beholder MeterProvider exist
+// lazyMetered defers duration instrument wiring for exporters constructed
+// before the beholder MeterProvider exists
 type lazyMetered struct {
 	signal string
 	base   atomic.Pointer[meteredExporter]
@@ -170,10 +130,10 @@ func (l *lazyMetered) attachMetrics(metrics exportMetrics, csaPublicKeyHex strin
 	l.base.Store(&base)
 }
 
-func (l *lazyMetered) record(ctx context.Context, export func(context.Context) error) error {
+func (l *lazyMetered) record(ctx context.Context, export func() error) error {
 	base := l.base.Load()
 	if base == nil {
-		return export(ctx)
+		return export()
 	}
 	return base.record(ctx, export)
 }
@@ -191,7 +151,7 @@ func newMeteredMetricExporter(inner sdkmetric.Exporter) *meteredMetricExporter {
 }
 
 func (e *meteredMetricExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
-	return e.record(ctx, func(c context.Context) error { return e.Exporter.Export(c, rm) })
+	return e.record(ctx, func() error { return e.Exporter.Export(ctx, rm) })
 }
 
 type meteredTraceExporter struct {
@@ -204,5 +164,75 @@ func newMeteredTraceExporter(inner sdktrace.SpanExporter) *meteredTraceExporter 
 }
 
 func (e *meteredTraceExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
-	return e.record(ctx, func(c context.Context) error { return e.SpanExporter.ExportSpans(c, spans) })
+	return e.record(ctx, func() error { return e.SpanExporter.ExportSpans(ctx, spans) })
 }
+
+// rpcStateKey is the handler's private context key.
+type rpcStateKey struct{}
+
+// rpcState accumulates one RPC's outbound bytes.
+type rpcState struct {
+	outBytes atomic.Int64
+}
+
+// boundInstruments is the handler's metric wiring.
+type boundInstruments struct {
+	bytes otelmetric.Int64Counter
+	attrs otelmetric.MeasurementOption
+}
+
+type exportStatsHandler struct {
+	signal          string
+	csaPublicKeyHex string
+
+	// nil until attachMetrics; the handler is registered at dial time but the
+	// instruments only exist once the beholder MeterProvider does.
+	instruments atomic.Pointer[boundInstruments]
+}
+
+func newExportStatsHandler(signal, csaPublicKeyHex string) *exportStatsHandler {
+	return &exportStatsHandler{signal: signal, csaPublicKeyHex: csaPublicKeyHex}
+}
+
+// attachMetrics wires the bytes instrument once the MeterProvider exists. Until
+// it is called the handler is an inert no-op.
+func (h *exportStatsHandler) attachMetrics(metrics exportMetrics) {
+	h.instruments.Store(&boundInstruments{
+		bytes: metrics.bytes,
+		attrs: exportAttrs(h.signal, h.csaPublicKeyHex),
+	})
+}
+
+// TagRPC allocates this RPC's byte accumulator. grpc-go threads the returned
+// context through every subsequent HandleRPC call for this RPC.
+func (h *exportStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return context.WithValue(ctx, rpcStateKey{}, &rpcState{})
+}
+
+// HandleRPC accumulates outbound proto length per RPC and records it when the
+// RPC ends successfully.
+func (h *exportStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	state, ok := ctx.Value(rpcStateKey{}).(*rpcState)
+	if !ok {
+		return
+	}
+	switch e := rs.(type) {
+	case *stats.OutPayload:
+		state.outBytes.Add(int64(e.Length))
+	case *stats.End:
+		// Swap keeps this idempotent if End is ever delivered twice.
+		n := state.outBytes.Swap(0)
+		if e.Error != nil || n == 0 {
+			return
+		}
+		if inst := h.instruments.Load(); inst != nil {
+			inst.bytes.Add(ctx, n, inst.attrs)
+		}
+	}
+}
+
+func (h *exportStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (h *exportStatsHandler) HandleConn(context.Context, stats.ConnStats) {}

--- a/pkg/beholder/metered_exporter_test.go
+++ b/pkg/beholder/metered_exporter_test.go
@@ -247,10 +247,7 @@ func TestMeteredMetricExporter_Passthrough(t *testing.T) {
 	assert.True(t, inner.shutdownCalled.Load())
 }
 
-// --- meteredTraceExporter --------------------------------------------------
-//
-// The trace exporter is not wired into NewGRPCClient yet; these lock in the
-// behaviour so enabling it later is a wiring change only.
+// --- meteredTraceExporter -------------------------------------------------
 
 func TestMeteredTraceExporter_RecordsDurationOnSuccess(t *testing.T) {
 	const delay = 2 * time.Millisecond

--- a/pkg/beholder/metered_exporter_test.go
+++ b/pkg/beholder/metered_exporter_test.go
@@ -183,6 +183,15 @@ func TestMeteredLogExporter_RecordsErrorDurationOnFailure(t *testing.T) {
 	assert.False(t, ok, "a failed export must not be labelled error=false")
 }
 
+// TestMeteredLogExporter_ZeroValueMetricsIsPassthrough guards the nil-check in
+// record: a wrapper built without instruments must export and propagate the
+// inner error rather than panic.
+func TestMeteredLogExporter_ZeroValueMetricsIsPassthrough(t *testing.T) {
+	exp := newMeteredLogExporter(&fakeLogExporter{err: errors.New("boom")}, exportMetrics{}, "csa")
+
+	require.Error(t, exp.Export(context.Background(), nil))
+}
+
 func TestMeteredLogExporter_Passthrough(t *testing.T) {
 	inner := &fakeLogExporter{}
 	exp := newMeteredLogExporter(inner, exportMetrics{}, "csa")

--- a/pkg/beholder/metered_exporter_test.go
+++ b/pkg/beholder/metered_exporter_test.go
@@ -579,6 +579,20 @@ func TestExportStatsHandler_ConnHooksAreInert(t *testing.T) {
 	assert.NotPanics(t, func() { h.HandleConn(ctx, &stats.ConnBegin{}) })
 }
 
+func TestExportStatsHandler_CSAKeyFallbackWhenEmpty(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	h := newExportStatsHandler("logs", "")
+	h.attachMetrics(metrics)
+
+	simulateRPC(h, context.Background(), 64, nil)
+
+	dp, ok := dpForSignal(t, collect(), "logs")
+	require.True(t, ok)
+	csa, ok := dp.Attributes.Value(attribute.Key("csa_public_key"))
+	require.True(t, ok)
+	assert.Equal(t, "not-configured", csa.AsString())
+}
+
 func TestExportStatsHandler_PerSignalAttribution(t *testing.T) {
 	metrics, collect := newTestMetrics(t)
 	logs := newExportStatsHandler("logs", "csa")

--- a/pkg/beholder/metered_exporter_test.go
+++ b/pkg/beholder/metered_exporter_test.go
@@ -1,0 +1,616 @@
+package beholder
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/grpc/stats"
+)
+
+// --- test doubles ---------------------------------------------------------
+
+// fakeLogExporter stands in for the otlploggrpc exporter. On Export it mimics
+// what the real gRPC stack does
+type fakeLogExporter struct {
+	size            int           // OutPayload length to report
+	sizeFromRecords bool          // if true, report len(records) instead of size
+	fireN           int           // number of OutPayload events (retry simulation); 0 => 1
+	delay           time.Duration // widen the store→read window for the race test
+	err             error
+
+	shutdownCalled   atomic.Bool
+	forceFlushCalled atomic.Bool
+}
+
+func (f *fakeLogExporter) Export(ctx context.Context, records []sdklog.Record) error {
+	sz := f.size
+	if f.sizeFromRecords {
+		sz = len(records)
+	}
+	n := f.fireN
+	if n == 0 {
+		n = 1
+	}
+	for i := 0; i < n; i++ {
+		beholderStatsHandler{}.HandleRPC(ctx, &stats.OutPayload{Length: sz})
+	}
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	return f.err
+}
+
+func (f *fakeLogExporter) Shutdown(context.Context) error { f.shutdownCalled.Store(true); return nil }
+func (f *fakeLogExporter) ForceFlush(context.Context) error {
+	f.forceFlushCalled.Store(true)
+	return nil
+}
+
+// fakeMetricExporter stands in for the otlpmetricgrpc exporter.
+type fakeMetricExporter struct {
+	size  int
+	delay time.Duration
+	err   error
+
+	temporalityCalled atomic.Bool
+	aggregationCalled atomic.Bool
+	shutdownCalled    atomic.Bool
+	forceFlushCalled  atomic.Bool
+}
+
+func (f *fakeMetricExporter) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+	f.temporalityCalled.Store(true)
+	return metricdata.CumulativeTemporality
+}
+
+func (f *fakeMetricExporter) Aggregation(k sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	f.aggregationCalled.Store(true)
+	return sdkmetric.DefaultAggregationSelector(k)
+}
+
+func (f *fakeMetricExporter) Export(ctx context.Context, _ *metricdata.ResourceMetrics) error {
+	beholderStatsHandler{}.HandleRPC(ctx, &stats.OutPayload{Length: f.size})
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	return f.err
+}
+
+func (f *fakeMetricExporter) ForceFlush(context.Context) error {
+	f.forceFlushCalled.Store(true)
+	return nil
+}
+func (f *fakeMetricExporter) Shutdown(context.Context) error {
+	f.shutdownCalled.Store(true)
+	return nil
+}
+
+// fakeTraceExporter stands in for the otlptracegrpc exporter.
+type fakeTraceExporter struct {
+	size  int
+	fireN int // number of OutPayload events (retry simulation); 0 => 1
+	delay time.Duration
+	err   error
+
+	shutdownCalled atomic.Bool
+}
+
+func (f *fakeTraceExporter) ExportSpans(ctx context.Context, _ []sdktrace.ReadOnlySpan) error {
+	n := f.fireN
+	if n == 0 {
+		n = 1
+	}
+	for range n {
+		beholderStatsHandler{}.HandleRPC(ctx, &stats.OutPayload{Length: f.size})
+	}
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	return f.err
+}
+
+func (f *fakeTraceExporter) Shutdown(context.Context) error {
+	f.shutdownCalled.Store(true)
+	return nil
+}
+
+// --- helpers --------------------------------------------------------------
+
+// newTestMetrics wires the export instruments to an in-memory ManualReader and
+// returns them plus a collect func that reads back the recorded metrics.
+func newTestMetrics(t *testing.T) (exportMetrics, func() []metricdata.Metrics) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics, err := newExportMetrics(mp.Meter("test"))
+	require.NoError(t, err)
+
+	collect := func() []metricdata.Metrics {
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &rm))
+		var out []metricdata.Metrics
+		for _, sm := range rm.ScopeMetrics {
+			out = append(out, sm.Metrics...)
+		}
+		return out
+	}
+	return metrics, collect
+}
+
+func dpForSignal(t *testing.T, ms []metricdata.Metrics, signal string) (metricdata.DataPoint[int64], bool) {
+	t.Helper()
+	for _, m := range ms {
+		if m.Name != exportBytesMetric {
+			continue
+		}
+		sum, ok := m.Data.(metricdata.Sum[int64])
+		require.True(t, ok, "expected beholder.export.bytes to be Sum[int64]")
+		for _, dp := range sum.DataPoints {
+			if v, ok := dp.Attributes.Value(attribute.Key("otel_signal")); ok && v.AsString() == signal {
+				return dp, true
+			}
+		}
+	}
+	return metricdata.DataPoint[int64]{}, false
+}
+
+// histForSignal finds the beholder.export.duration datapoint for one signal and
+// error outcome.
+func histForSignal(t *testing.T, ms []metricdata.Metrics, signal string, wantErr bool) (metricdata.HistogramDataPoint[float64], bool) {
+	t.Helper()
+	for _, m := range ms {
+		if m.Name != exportDurationMetric {
+			continue
+		}
+		h, ok := m.Data.(metricdata.Histogram[float64])
+		require.True(t, ok, "expected beholder.export.duration to be Histogram[float64]")
+		for _, dp := range h.DataPoints {
+			sig, ok := dp.Attributes.Value(attribute.Key("otel_signal"))
+			if !ok || sig.AsString() != signal {
+				continue
+			}
+			isErr, ok := dp.Attributes.Value(attribute.Key("error"))
+			require.True(t, ok, "duration datapoint must carry an error attribute")
+			if isErr.AsBool() == wantErr {
+				return dp, true
+			}
+		}
+	}
+	return metricdata.HistogramDataPoint[float64]{}, false
+}
+
+// --- beholderStatsHandler -----------------------------------------------
+
+func TestBeholderStatsHandler_StoresOutPayloadLength(t *testing.T) {
+	var holder atomic.Int64
+	ctx := context.WithValue(context.Background(), exportBytesKey{}, &holder)
+
+	beholderStatsHandler{}.HandleRPC(ctx, &stats.OutPayload{Length: 1234})
+
+	assert.Equal(t, int64(1234), holder.Load())
+}
+
+func TestBeholderStatsHandler_IgnoresNonOutPayload(t *testing.T) {
+	var holder atomic.Int64
+	ctx := context.WithValue(context.Background(), exportBytesKey{}, &holder)
+
+	beholderStatsHandler{}.HandleRPC(ctx, &stats.InPayload{Length: 999})
+	beholderStatsHandler{}.HandleRPC(ctx, &stats.Begin{})
+	beholderStatsHandler{}.HandleRPC(ctx, &stats.End{})
+
+	assert.Equal(t, int64(0), holder.Load())
+}
+
+func TestBeholderStatsHandler_LastWriteWins(t *testing.T) {
+	// Retries resend the same proto, so each OutPayload reports the same length.
+	// Store means the holder ends at that length, not a multiple of it.
+	var holder atomic.Int64
+	ctx := context.WithValue(context.Background(), exportBytesKey{}, &holder)
+	h := beholderStatsHandler{}
+
+	h.HandleRPC(ctx, &stats.OutPayload{Length: 700})
+	h.HandleRPC(ctx, &stats.OutPayload{Length: 700})
+	h.HandleRPC(ctx, &stats.OutPayload{Length: 700})
+
+	assert.Equal(t, int64(700), holder.Load())
+}
+
+func TestBeholderStatsHandler_NoHolderInContextIsNoop(t *testing.T) {
+	assert.NotPanics(t, func() {
+		beholderStatsHandler{}.HandleRPC(context.Background(), &stats.OutPayload{Length: 5})
+	})
+}
+
+func TestBeholderStatsHandler_TagAndConnAreInert(t *testing.T) {
+	h := beholderStatsHandler{}
+	ctx := context.WithValue(context.Background(), exportBytesKey{}, &atomic.Int64{})
+
+	assert.Equal(t, ctx, h.TagRPC(ctx, &stats.RPCTagInfo{}))
+	assert.Equal(t, ctx, h.TagConn(ctx, &stats.ConnTagInfo{}))
+	assert.NotPanics(t, func() { h.HandleConn(ctx, &stats.ConnBegin{}) })
+}
+
+// --- meteredLogExporter ---------------------------------------------------
+
+func TestMeteredLogExporter_RecordsBytesOnSuccess(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	inner := &fakeLogExporter{size: 4096}
+	exp := newMeteredLogExporter(inner, metrics, "csa-pub-hex")
+
+	require.NoError(t, exp.Export(context.Background(), nil))
+
+	dp, ok := dpForSignal(t, collect(), "logs")
+	require.True(t, ok, "expected a logs datapoint")
+	assert.Equal(t, int64(4096), dp.Value)
+
+	csa, ok := dp.Attributes.Value(attribute.Key("csa_public_key"))
+	require.True(t, ok)
+	assert.Equal(t, "csa-pub-hex", csa.AsString())
+}
+
+func TestMeteredLogExporter_NoRecordOnError(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	// Handler still fires, but Export returns an error.
+	inner := &fakeLogExporter{size: 4096, err: errors.New("boom")}
+	exp := newMeteredLogExporter(inner, metrics, "csa")
+
+	require.Error(t, exp.Export(context.Background(), nil))
+
+	ms := collect()
+	_, ok := dpForSignal(t, ms, "logs")
+	assert.False(t, ok, "no bytes should be recorded when export fails")
+	// Duration is still recorded, labelled error=true.
+	hdp, ok := histForSignal(t, ms, "logs", true)
+	require.True(t, ok, "expected an error-labelled logs duration datapoint")
+	assert.Equal(t, uint64(1), hdp.Count)
+	_, ok = histForSignal(t, ms, "logs", false)
+	assert.False(t, ok, "a failed export must not be labelled error=false")
+}
+
+func TestMeteredLogExporter_RetriesCountedOnce(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	// Three OutPayload events for one batch, all the same size.
+	inner := &fakeLogExporter{size: 500, fireN: 3}
+	exp := newMeteredLogExporter(inner, metrics, "csa")
+
+	require.NoError(t, exp.Export(context.Background(), nil))
+
+	dp, ok := dpForSignal(t, collect(), "logs")
+	require.True(t, ok)
+	assert.Equal(t, int64(500), dp.Value, "retries of the same batch must be counted once")
+}
+
+func TestMeteredLogExporter_Passthrough(t *testing.T) {
+	inner := &fakeLogExporter{}
+	exp := newMeteredLogExporter(inner, exportMetrics{}, "csa")
+
+	require.NoError(t, exp.Shutdown(context.Background()))
+	require.NoError(t, exp.ForceFlush(context.Background()))
+
+	assert.True(t, inner.shutdownCalled.Load())
+	assert.True(t, inner.forceFlushCalled.Load())
+}
+
+// TestMeteredExporter_ConcurrentExportsIsolated is the regression guard for the
+// per-call context holder
+func TestMeteredExporter_ConcurrentExportsIsolated(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	// delay widens the window between the handler storing and record reading,
+	// so a broken implementation would reliably mis-attribute.
+	inner := &fakeLogExporter{sizeFromRecords: true, delay: 200 * time.Microsecond}
+	exp := newMeteredLogExporter(inner, metrics, "csa")
+
+	const n = 50
+	var wg sync.WaitGroup
+	var want int64
+	for i := 1; i <= n; i++ {
+		size := i
+		want += int64(size)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, exp.Export(context.Background(), make([]sdklog.Record, size)))
+		}()
+	}
+	wg.Wait()
+
+	dp, ok := dpForSignal(t, collect(), "logs")
+	require.True(t, ok)
+	assert.Equal(t, want, dp.Value)
+}
+
+// --- meteredMetricExporter ------------------------------------------------
+
+func TestMeteredMetricExporter_RecordsBytesOnSuccess(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	inner := &fakeMetricExporter{size: 8192}
+	exp := newMeteredMetricExporter(inner)
+	exp.attachMetrics(metrics, "csa-pub-hex")
+
+	require.NoError(t, exp.Export(context.Background(), &metricdata.ResourceMetrics{}))
+
+	dp, ok := dpForSignal(t, collect(), "metrics")
+	require.True(t, ok, "expected a metrics datapoint")
+	assert.Equal(t, int64(8192), dp.Value)
+
+	csa, ok := dp.Attributes.Value(attribute.Key("csa_public_key"))
+	require.True(t, ok)
+	assert.Equal(t, "csa-pub-hex", csa.AsString())
+}
+
+func TestMeteredMetricExporter_UnmeteredBeforeAttach(t *testing.T) {
+	_, collect := newTestMetrics(t)
+	inner := &fakeMetricExporter{size: 8192}
+	exp := newMeteredMetricExporter(inner) // no attachMetrics
+
+	require.NoError(t, exp.Export(context.Background(), &metricdata.ResourceMetrics{}))
+
+	ms := collect()
+	_, ok := dpForSignal(t, ms, "metrics")
+	assert.False(t, ok, "no bytes should be recorded before the instruments are attached")
+	_, ok = histForSignal(t, ms, "metrics", false)
+	assert.False(t, ok, "no duration should be recorded before the instruments are attached")
+}
+
+func TestMeteredMetricExporter_NoRecordOnError(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	inner := &fakeMetricExporter{size: 8192, err: errors.New("boom")}
+	exp := newMeteredMetricExporter(inner)
+	exp.attachMetrics(metrics, "csa")
+
+	require.Error(t, exp.Export(context.Background(), &metricdata.ResourceMetrics{}))
+
+	ms := collect()
+	_, ok := dpForSignal(t, ms, "metrics")
+	assert.False(t, ok)
+	hdp, ok := histForSignal(t, ms, "metrics", true)
+	require.True(t, ok, "expected an error-labelled metrics duration datapoint")
+	assert.Equal(t, uint64(1), hdp.Count)
+}
+
+func TestMeteredMetricExporter_Passthrough(t *testing.T) {
+	inner := &fakeMetricExporter{}
+	exp := newMeteredMetricExporter(inner)
+
+	assert.Equal(t, metricdata.CumulativeTemporality, exp.Temporality(sdkmetric.InstrumentKindCounter))
+	assert.NotNil(t, exp.Aggregation(sdkmetric.InstrumentKindCounter))
+	require.NoError(t, exp.ForceFlush(context.Background()))
+	require.NoError(t, exp.Shutdown(context.Background()))
+
+	assert.True(t, inner.temporalityCalled.Load())
+	assert.True(t, inner.aggregationCalled.Load())
+	assert.True(t, inner.forceFlushCalled.Load())
+	assert.True(t, inner.shutdownCalled.Load())
+}
+
+// --- meteredTraceExporter --------------------------------------------------
+//
+// The trace exporter is not wired into NewGRPCClient yet; these lock in the
+// behaviour so enabling it later is a wiring change only.
+
+func TestMeteredTraceExporter_RecordsBytesAndDurationOnSuccess(t *testing.T) {
+	inst, collect := newTestMetrics(t)
+	const delay = 20 * time.Millisecond
+	exp := newMeteredTraceExporter(&fakeTraceExporter{size: 2048, delay: delay})
+	exp.attachMetrics(inst, "csa-pub-hex")
+
+	require.NoError(t, exp.ExportSpans(context.Background(), nil))
+
+	ms := collect()
+	dp, ok := dpForSignal(t, ms, "traces")
+	require.True(t, ok, "expected a traces bytes datapoint")
+	assert.Equal(t, int64(2048), dp.Value)
+
+	csa, ok := dp.Attributes.Value(attribute.Key("csa_public_key"))
+	require.True(t, ok)
+	assert.Equal(t, "csa-pub-hex", csa.AsString())
+
+	hdp, ok := histForSignal(t, ms, "traces", false)
+	require.True(t, ok, "expected a traces duration datapoint")
+	assert.Equal(t, uint64(1), hdp.Count)
+	assert.GreaterOrEqual(t, hdp.Sum, delay.Seconds())
+}
+
+func TestMeteredTraceExporter_NoBytesOnErrorButDurationRecorded(t *testing.T) {
+	inst, collect := newTestMetrics(t)
+	exp := newMeteredTraceExporter(&fakeTraceExporter{size: 2048, err: errors.New("boom")})
+	exp.attachMetrics(inst, "csa")
+
+	require.Error(t, exp.ExportSpans(context.Background(), nil))
+
+	ms := collect()
+	_, ok := dpForSignal(t, ms, "traces")
+	assert.False(t, ok, "no bytes should be recorded when export fails")
+	hdp, ok := histForSignal(t, ms, "traces", true)
+	require.True(t, ok, "expected an error-labelled traces duration datapoint")
+	assert.Equal(t, uint64(1), hdp.Count)
+}
+
+func TestMeteredTraceExporter_RetriesCountedOnce(t *testing.T) {
+	inst, collect := newTestMetrics(t)
+	exp := newMeteredTraceExporter(&fakeTraceExporter{size: 700, fireN: 3})
+	exp.attachMetrics(inst, "csa")
+
+	require.NoError(t, exp.ExportSpans(context.Background(), nil))
+
+	ms := collect()
+	dp, ok := dpForSignal(t, ms, "traces")
+	require.True(t, ok)
+	assert.Equal(t, int64(700), dp.Value, "retries of the same batch must be counted once")
+	hdp, ok := histForSignal(t, ms, "traces", false)
+	require.True(t, ok)
+	assert.Equal(t, uint64(1), hdp.Count, "one batch must be one duration observation")
+}
+
+// TestMeteredTraceExporter_UnmeteredBeforeAttach is the guard for the deferred
+// attach: newTracerProvider runs before the MeterProvider exists, so an
+// unattached exporter must still export rather than panic.
+func TestMeteredTraceExporter_UnmeteredBeforeAttach(t *testing.T) {
+	_, collect := newTestMetrics(t)
+	inner := &fakeTraceExporter{size: 2048}
+	exp := newMeteredTraceExporter(inner) // no attachMetrics
+
+	require.NoError(t, exp.ExportSpans(context.Background(), nil))
+
+	ms := collect()
+	_, ok := dpForSignal(t, ms, "traces")
+	assert.False(t, ok, "no bytes before the instruments are attached")
+	_, ok = histForSignal(t, ms, "traces", false)
+	assert.False(t, ok, "no duration before the instruments are attached")
+}
+
+func TestMeteredTraceExporter_Passthrough(t *testing.T) {
+	inner := &fakeTraceExporter{}
+	exp := newMeteredTraceExporter(inner)
+
+	require.NoError(t, exp.Shutdown(context.Background()))
+
+	assert.True(t, inner.shutdownCalled.Load())
+}
+
+// --- shared naming --------------------------------------------------------
+
+func TestMeteredExporters_ShareOneMetricBySignal(t *testing.T) {
+	inst, collect := newTestMetrics(t)
+	logs := newMeteredLogExporter(&fakeLogExporter{size: 100}, inst, "csa")
+	metrics := newMeteredMetricExporter(&fakeMetricExporter{size: 200})
+	metrics.attachMetrics(inst, "csa")
+	traces := newMeteredTraceExporter(&fakeTraceExporter{size: 300})
+	traces.attachMetrics(inst, "csa")
+
+	require.NoError(t, logs.Export(context.Background(), nil))
+	require.NoError(t, metrics.Export(context.Background(), &metricdata.ResourceMetrics{}))
+	require.NoError(t, traces.ExportSpans(context.Background(), nil))
+
+	ms := collect()
+	for _, tc := range []struct {
+		signal string
+		want   int64
+	}{{"logs", 100}, {"metrics", 200}, {"traces", 300}} {
+		dp, ok := dpForSignal(t, ms, tc.signal)
+		require.True(t, ok, "expected a %s bytes datapoint", tc.signal)
+		assert.Equal(t, tc.want, dp.Value)
+
+		// Each signal gets its own duration datapoint on the same instrument too.
+		hdp, ok := histForSignal(t, ms, tc.signal, false)
+		require.True(t, ok, "expected a %s duration datapoint", tc.signal)
+		assert.Equal(t, uint64(1), hdp.Count)
+	}
+
+	// Both are datapoints of the same instrument, distinguished only by otel_signal.
+	for _, m := range ms {
+		switch m.Name {
+		case exportBytesMetric:
+			assert.Equal(t, "By", m.Unit)
+		case exportDurationMetric:
+			assert.Equal(t, "s", m.Unit)
+		}
+	}
+}
+
+// --- beholder.export.duration ---------------------------------------------
+
+func TestMeteredLogExporter_RecordsDurationOnSuccess(t *testing.T) {
+	inst, collect := newTestMetrics(t)
+	const delay = 20 * time.Millisecond
+	inner := &fakeLogExporter{size: 4096, delay: delay}
+	exp := newMeteredLogExporter(inner, inst, "csa-pub-hex")
+
+	require.NoError(t, exp.Export(context.Background(), nil))
+
+	hdp, ok := histForSignal(t, collect(), "logs", false)
+	require.True(t, ok, "expected a logs duration datapoint")
+	assert.Equal(t, uint64(1), hdp.Count)
+	assert.GreaterOrEqual(t, hdp.Sum, delay.Seconds(),
+		"recorded duration must cover the inner export")
+	assert.Less(t, hdp.Sum, 10.0, "recorded duration should be in seconds, not another unit")
+
+	csa, ok := hdp.Attributes.Value(attribute.Key("csa_public_key"))
+	require.True(t, ok)
+	assert.Equal(t, "csa-pub-hex", csa.AsString())
+}
+
+func TestMeteredMetricExporter_RecordsDurationOnSuccess(t *testing.T) {
+	inst, collect := newTestMetrics(t)
+	const delay = 20 * time.Millisecond
+	exp := newMeteredMetricExporter(&fakeMetricExporter{size: 8192, delay: delay})
+	exp.attachMetrics(inst, "csa-pub-hex")
+
+	require.NoError(t, exp.Export(context.Background(), &metricdata.ResourceMetrics{}))
+
+	hdp, ok := histForSignal(t, collect(), "metrics", false)
+	require.True(t, ok, "expected a metrics duration datapoint")
+	assert.Equal(t, uint64(1), hdp.Count)
+	assert.GreaterOrEqual(t, hdp.Sum, delay.Seconds())
+
+	csa, ok := hdp.Attributes.Value(attribute.Key("csa_public_key"))
+	require.True(t, ok)
+	assert.Equal(t, "csa-pub-hex", csa.AsString())
+}
+
+// TestMeteredExporter_DurationRetriesCountedOnce mirrors the bytes behaviour:
+// the wrapper sits above the otlp retry loop, so one logical batch is one
+// observation covering the whole retry sequence.
+func TestMeteredExporter_DurationRetriesCountedOnce(t *testing.T) {
+	inst, collect := newTestMetrics(t)
+	inner := &fakeLogExporter{size: 500, fireN: 3}
+	exp := newMeteredLogExporter(inner, inst, "csa")
+
+	require.NoError(t, exp.Export(context.Background(), nil))
+
+	hdp, ok := histForSignal(t, collect(), "logs", false)
+	require.True(t, ok)
+	assert.Equal(t, uint64(1), hdp.Count, "one batch must be one duration observation")
+}
+
+func TestExportDuration_UsesSecondScaledBuckets(t *testing.T) {
+	inst, collect := newTestMetrics(t)
+	exp := newMeteredLogExporter(&fakeLogExporter{}, inst, "csa")
+
+	require.NoError(t, exp.Export(context.Background(), nil))
+
+	for _, m := range collect() {
+		if m.Name != exportDurationMetric {
+			continue
+		}
+		h, ok := m.Data.(metricdata.Histogram[float64])
+		require.True(t, ok)
+		require.NotEmpty(t, h.DataPoints)
+		assert.Equal(t,
+			[]float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+			h.DataPoints[0].Bounds,
+			"explicit second-scaled boundaries must survive to the reader")
+		return
+	}
+	t.Fatalf("no %s metric collected", exportDurationMetric)
+}
+
+func TestMeteredExporter_DurationRecordedPerOutcome(t *testing.T) {
+	inst, collect := newTestMetrics(t)
+	ok1 := newMeteredLogExporter(&fakeLogExporter{size: 10}, inst, "csa")
+	bad := newMeteredLogExporter(&fakeLogExporter{size: 10, err: errors.New("boom")}, inst, "csa")
+
+	require.NoError(t, ok1.Export(context.Background(), nil))
+	require.NoError(t, ok1.Export(context.Background(), nil))
+	require.Error(t, bad.Export(context.Background(), nil))
+
+	ms := collect()
+	okDP, found := histForSignal(t, ms, "logs", false)
+	require.True(t, found)
+	assert.Equal(t, uint64(2), okDP.Count)
+
+	errDP, found := histForSignal(t, ms, "logs", true)
+	require.True(t, found)
+	assert.Equal(t, uint64(1), errDP.Count)
+}

--- a/pkg/beholder/metered_exporter_test.go
+++ b/pkg/beholder/metered_exporter_test.go
@@ -20,31 +20,18 @@ import (
 
 // --- test doubles ---------------------------------------------------------
 
-// fakeLogExporter stands in for the otlploggrpc exporter. On Export it mimics
-// what the real gRPC stack does
+// fakeLogExporter stands in for the otlploggrpc exporter. Bytes are recorded by
+// exportStatsHandler inside the gRPC stack, so this fake only controls the two
+// things the wrapper observes: how long Export takes and whether it fails.
 type fakeLogExporter struct {
-	size            int           // OutPayload length to report
-	sizeFromRecords bool          // if true, report len(records) instead of size
-	fireN           int           // number of OutPayload events (retry simulation); 0 => 1
-	delay           time.Duration // widen the store→read window for the race test
-	err             error
+	delay time.Duration
+	err   error
 
 	shutdownCalled   atomic.Bool
 	forceFlushCalled atomic.Bool
 }
 
-func (f *fakeLogExporter) Export(ctx context.Context, records []sdklog.Record) error {
-	sz := f.size
-	if f.sizeFromRecords {
-		sz = len(records)
-	}
-	n := f.fireN
-	if n == 0 {
-		n = 1
-	}
-	for i := 0; i < n; i++ {
-		beholderStatsHandler{}.HandleRPC(ctx, &stats.OutPayload{Length: sz})
-	}
+func (f *fakeLogExporter) Export(context.Context, []sdklog.Record) error {
 	if f.delay > 0 {
 		time.Sleep(f.delay)
 	}
@@ -59,7 +46,6 @@ func (f *fakeLogExporter) ForceFlush(context.Context) error {
 
 // fakeMetricExporter stands in for the otlpmetricgrpc exporter.
 type fakeMetricExporter struct {
-	size  int
 	delay time.Duration
 	err   error
 
@@ -79,8 +65,7 @@ func (f *fakeMetricExporter) Aggregation(k sdkmetric.InstrumentKind) sdkmetric.A
 	return sdkmetric.DefaultAggregationSelector(k)
 }
 
-func (f *fakeMetricExporter) Export(ctx context.Context, _ *metricdata.ResourceMetrics) error {
-	beholderStatsHandler{}.HandleRPC(ctx, &stats.OutPayload{Length: f.size})
+func (f *fakeMetricExporter) Export(context.Context, *metricdata.ResourceMetrics) error {
 	if f.delay > 0 {
 		time.Sleep(f.delay)
 	}
@@ -98,22 +83,13 @@ func (f *fakeMetricExporter) Shutdown(context.Context) error {
 
 // fakeTraceExporter stands in for the otlptracegrpc exporter.
 type fakeTraceExporter struct {
-	size  int
-	fireN int // number of OutPayload events (retry simulation); 0 => 1
 	delay time.Duration
 	err   error
 
 	shutdownCalled atomic.Bool
 }
 
-func (f *fakeTraceExporter) ExportSpans(ctx context.Context, _ []sdktrace.ReadOnlySpan) error {
-	n := f.fireN
-	if n == 0 {
-		n = 1
-	}
-	for range n {
-		beholderStatsHandler{}.HandleRPC(ctx, &stats.OutPayload{Length: f.size})
-	}
+func (f *fakeTraceExporter) ExportSpans(context.Context, []sdktrace.ReadOnlySpan) error {
 	if f.delay > 0 {
 		time.Sleep(f.delay)
 	}
@@ -190,105 +166,21 @@ func histForSignal(t *testing.T, ms []metricdata.Metrics, signal string, wantErr
 	return metricdata.HistogramDataPoint[float64]{}, false
 }
 
-// --- beholderStatsHandler -----------------------------------------------
-
-func TestBeholderStatsHandler_StoresOutPayloadLength(t *testing.T) {
-	var holder atomic.Int64
-	ctx := context.WithValue(context.Background(), exportBytesKey{}, &holder)
-
-	beholderStatsHandler{}.HandleRPC(ctx, &stats.OutPayload{Length: 1234})
-
-	assert.Equal(t, int64(1234), holder.Load())
-}
-
-func TestBeholderStatsHandler_IgnoresNonOutPayload(t *testing.T) {
-	var holder atomic.Int64
-	ctx := context.WithValue(context.Background(), exportBytesKey{}, &holder)
-
-	beholderStatsHandler{}.HandleRPC(ctx, &stats.InPayload{Length: 999})
-	beholderStatsHandler{}.HandleRPC(ctx, &stats.Begin{})
-	beholderStatsHandler{}.HandleRPC(ctx, &stats.End{})
-
-	assert.Equal(t, int64(0), holder.Load())
-}
-
-func TestBeholderStatsHandler_LastWriteWins(t *testing.T) {
-	// Retries resend the same proto, so each OutPayload reports the same length.
-	// Store means the holder ends at that length, not a multiple of it.
-	var holder atomic.Int64
-	ctx := context.WithValue(context.Background(), exportBytesKey{}, &holder)
-	h := beholderStatsHandler{}
-
-	h.HandleRPC(ctx, &stats.OutPayload{Length: 700})
-	h.HandleRPC(ctx, &stats.OutPayload{Length: 700})
-	h.HandleRPC(ctx, &stats.OutPayload{Length: 700})
-
-	assert.Equal(t, int64(700), holder.Load())
-}
-
-func TestBeholderStatsHandler_NoHolderInContextIsNoop(t *testing.T) {
-	assert.NotPanics(t, func() {
-		beholderStatsHandler{}.HandleRPC(context.Background(), &stats.OutPayload{Length: 5})
-	})
-}
-
-func TestBeholderStatsHandler_TagAndConnAreInert(t *testing.T) {
-	h := beholderStatsHandler{}
-	ctx := context.WithValue(context.Background(), exportBytesKey{}, &atomic.Int64{})
-
-	assert.Equal(t, ctx, h.TagRPC(ctx, &stats.RPCTagInfo{}))
-	assert.Equal(t, ctx, h.TagConn(ctx, &stats.ConnTagInfo{}))
-	assert.NotPanics(t, func() { h.HandleConn(ctx, &stats.ConnBegin{}) })
-}
-
 // --- meteredLogExporter ---------------------------------------------------
 
-func TestMeteredLogExporter_RecordsBytesOnSuccess(t *testing.T) {
+func TestMeteredLogExporter_RecordsErrorDurationOnFailure(t *testing.T) {
 	metrics, collect := newTestMetrics(t)
-	inner := &fakeLogExporter{size: 4096}
-	exp := newMeteredLogExporter(inner, metrics, "csa-pub-hex")
-
-	require.NoError(t, exp.Export(context.Background(), nil))
-
-	dp, ok := dpForSignal(t, collect(), "logs")
-	require.True(t, ok, "expected a logs datapoint")
-	assert.Equal(t, int64(4096), dp.Value)
-
-	csa, ok := dp.Attributes.Value(attribute.Key("csa_public_key"))
-	require.True(t, ok)
-	assert.Equal(t, "csa-pub-hex", csa.AsString())
-}
-
-func TestMeteredLogExporter_NoRecordOnError(t *testing.T) {
-	metrics, collect := newTestMetrics(t)
-	// Handler still fires, but Export returns an error.
-	inner := &fakeLogExporter{size: 4096, err: errors.New("boom")}
+	inner := &fakeLogExporter{err: errors.New("boom")}
 	exp := newMeteredLogExporter(inner, metrics, "csa")
 
 	require.Error(t, exp.Export(context.Background(), nil))
 
 	ms := collect()
-	_, ok := dpForSignal(t, ms, "logs")
-	assert.False(t, ok, "no bytes should be recorded when export fails")
-	// Duration is still recorded, labelled error=true.
 	hdp, ok := histForSignal(t, ms, "logs", true)
 	require.True(t, ok, "expected an error-labelled logs duration datapoint")
 	assert.Equal(t, uint64(1), hdp.Count)
 	_, ok = histForSignal(t, ms, "logs", false)
 	assert.False(t, ok, "a failed export must not be labelled error=false")
-}
-
-func TestMeteredLogExporter_RetriesCountedOnce(t *testing.T) {
-	metrics, collect := newTestMetrics(t)
-	// Three OutPayload events for one batch, all the same size.
-	inner := &fakeLogExporter{size: 500, fireN: 3}
-	exp := newMeteredLogExporter(inner, metrics, "csa")
-
-	require.NoError(t, exp.Export(context.Background(), nil))
-
-	dp, ok := dpForSignal(t, collect(), "logs")
-	require.True(t, ok)
-	assert.Equal(t, int64(500), dp.Value, "retries of the same batch must be counted once")
 }
 
 func TestMeteredLogExporter_Passthrough(t *testing.T) {
@@ -302,81 +194,33 @@ func TestMeteredLogExporter_Passthrough(t *testing.T) {
 	assert.True(t, inner.forceFlushCalled.Load())
 }
 
-// TestMeteredExporter_ConcurrentExportsIsolated is the regression guard for the
-// per-call context holder
-func TestMeteredExporter_ConcurrentExportsIsolated(t *testing.T) {
-	metrics, collect := newTestMetrics(t)
-	// delay widens the window between the handler storing and record reading,
-	// so a broken implementation would reliably mis-attribute.
-	inner := &fakeLogExporter{sizeFromRecords: true, delay: 200 * time.Microsecond}
-	exp := newMeteredLogExporter(inner, metrics, "csa")
-
-	const n = 50
-	var wg sync.WaitGroup
-	var want int64
-	for i := 1; i <= n; i++ {
-		size := i
-		want += int64(size)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			assert.NoError(t, exp.Export(context.Background(), make([]sdklog.Record, size)))
-		}()
-	}
-	wg.Wait()
-
-	dp, ok := dpForSignal(t, collect(), "logs")
-	require.True(t, ok)
-	assert.Equal(t, want, dp.Value)
-}
-
 // --- meteredMetricExporter ------------------------------------------------
-
-func TestMeteredMetricExporter_RecordsBytesOnSuccess(t *testing.T) {
-	metrics, collect := newTestMetrics(t)
-	inner := &fakeMetricExporter{size: 8192}
-	exp := newMeteredMetricExporter(inner)
-	exp.attachMetrics(metrics, "csa-pub-hex")
-
-	require.NoError(t, exp.Export(context.Background(), &metricdata.ResourceMetrics{}))
-
-	dp, ok := dpForSignal(t, collect(), "metrics")
-	require.True(t, ok, "expected a metrics datapoint")
-	assert.Equal(t, int64(8192), dp.Value)
-
-	csa, ok := dp.Attributes.Value(attribute.Key("csa_public_key"))
-	require.True(t, ok)
-	assert.Equal(t, "csa-pub-hex", csa.AsString())
-}
 
 func TestMeteredMetricExporter_UnmeteredBeforeAttach(t *testing.T) {
 	_, collect := newTestMetrics(t)
-	inner := &fakeMetricExporter{size: 8192}
+	inner := &fakeMetricExporter{}
 	exp := newMeteredMetricExporter(inner) // no attachMetrics
 
 	require.NoError(t, exp.Export(context.Background(), &metricdata.ResourceMetrics{}))
 
 	ms := collect()
-	_, ok := dpForSignal(t, ms, "metrics")
-	assert.False(t, ok, "no bytes should be recorded before the instruments are attached")
-	_, ok = histForSignal(t, ms, "metrics", false)
+	_, ok := histForSignal(t, ms, "metrics", false)
 	assert.False(t, ok, "no duration should be recorded before the instruments are attached")
 }
 
-func TestMeteredMetricExporter_NoRecordOnError(t *testing.T) {
+func TestMeteredMetricExporter_RecordsErrorDurationOnFailure(t *testing.T) {
 	metrics, collect := newTestMetrics(t)
-	inner := &fakeMetricExporter{size: 8192, err: errors.New("boom")}
-	exp := newMeteredMetricExporter(inner)
+	exp := newMeteredMetricExporter(&fakeMetricExporter{err: errors.New("boom")})
 	exp.attachMetrics(metrics, "csa")
 
-	require.Error(t, exp.Export(context.Background(), &metricdata.ResourceMetrics{}))
+	require.Error(t, exp.Export(context.Background(), nil))
 
 	ms := collect()
-	_, ok := dpForSignal(t, ms, "metrics")
-	assert.False(t, ok)
 	hdp, ok := histForSignal(t, ms, "metrics", true)
 	require.True(t, ok, "expected an error-labelled metrics duration datapoint")
 	assert.Equal(t, uint64(1), hdp.Count)
+	_, ok = histForSignal(t, ms, "metrics", false)
+	assert.False(t, ok, "a failed export must not be labelled error=false")
 }
 
 func TestMeteredMetricExporter_Passthrough(t *testing.T) {
@@ -399,58 +243,37 @@ func TestMeteredMetricExporter_Passthrough(t *testing.T) {
 // The trace exporter is not wired into NewGRPCClient yet; these lock in the
 // behaviour so enabling it later is a wiring change only.
 
-func TestMeteredTraceExporter_RecordsBytesAndDurationOnSuccess(t *testing.T) {
+func TestMeteredTraceExporter_RecordsDurationOnSuccess(t *testing.T) {
+	const delay = 2 * time.Millisecond
 	inst, collect := newTestMetrics(t)
-	const delay = 20 * time.Millisecond
-	exp := newMeteredTraceExporter(&fakeTraceExporter{size: 2048, delay: delay})
+	exp := newMeteredTraceExporter(&fakeTraceExporter{delay: delay})
 	exp.attachMetrics(inst, "csa-pub-hex")
 
 	require.NoError(t, exp.ExportSpans(context.Background(), nil))
 
-	ms := collect()
-	dp, ok := dpForSignal(t, ms, "traces")
-	require.True(t, ok, "expected a traces bytes datapoint")
-	assert.Equal(t, int64(2048), dp.Value)
-
-	csa, ok := dp.Attributes.Value(attribute.Key("csa_public_key"))
-	require.True(t, ok)
-	assert.Equal(t, "csa-pub-hex", csa.AsString())
-
-	hdp, ok := histForSignal(t, ms, "traces", false)
+	hdp, ok := histForSignal(t, collect(), "traces", false)
 	require.True(t, ok, "expected a traces duration datapoint")
 	assert.Equal(t, uint64(1), hdp.Count)
 	assert.GreaterOrEqual(t, hdp.Sum, delay.Seconds())
+
+	csa, ok := hdp.Attributes.Value(attribute.Key("csa_public_key"))
+	require.True(t, ok)
+	assert.Equal(t, "csa-pub-hex", csa.AsString())
 }
 
-func TestMeteredTraceExporter_NoBytesOnErrorButDurationRecorded(t *testing.T) {
+func TestMeteredTraceExporter_RecordsErrorDurationOnFailure(t *testing.T) {
 	inst, collect := newTestMetrics(t)
-	exp := newMeteredTraceExporter(&fakeTraceExporter{size: 2048, err: errors.New("boom")})
+	exp := newMeteredTraceExporter(&fakeTraceExporter{err: errors.New("boom")})
 	exp.attachMetrics(inst, "csa")
 
 	require.Error(t, exp.ExportSpans(context.Background(), nil))
 
 	ms := collect()
-	_, ok := dpForSignal(t, ms, "traces")
-	assert.False(t, ok, "no bytes should be recorded when export fails")
 	hdp, ok := histForSignal(t, ms, "traces", true)
 	require.True(t, ok, "expected an error-labelled traces duration datapoint")
 	assert.Equal(t, uint64(1), hdp.Count)
-}
-
-func TestMeteredTraceExporter_RetriesCountedOnce(t *testing.T) {
-	inst, collect := newTestMetrics(t)
-	exp := newMeteredTraceExporter(&fakeTraceExporter{size: 700, fireN: 3})
-	exp.attachMetrics(inst, "csa")
-
-	require.NoError(t, exp.ExportSpans(context.Background(), nil))
-
-	ms := collect()
-	dp, ok := dpForSignal(t, ms, "traces")
-	require.True(t, ok)
-	assert.Equal(t, int64(700), dp.Value, "retries of the same batch must be counted once")
-	hdp, ok := histForSignal(t, ms, "traces", false)
-	require.True(t, ok)
-	assert.Equal(t, uint64(1), hdp.Count, "one batch must be one duration observation")
+	_, ok = histForSignal(t, ms, "traces", false)
+	assert.False(t, ok, "a failed export must not be labelled error=false")
 }
 
 // TestMeteredTraceExporter_UnmeteredBeforeAttach is the guard for the deferred
@@ -458,15 +281,13 @@ func TestMeteredTraceExporter_RetriesCountedOnce(t *testing.T) {
 // unattached exporter must still export rather than panic.
 func TestMeteredTraceExporter_UnmeteredBeforeAttach(t *testing.T) {
 	_, collect := newTestMetrics(t)
-	inner := &fakeTraceExporter{size: 2048}
+	inner := &fakeTraceExporter{}
 	exp := newMeteredTraceExporter(inner) // no attachMetrics
 
 	require.NoError(t, exp.ExportSpans(context.Background(), nil))
 
 	ms := collect()
-	_, ok := dpForSignal(t, ms, "traces")
-	assert.False(t, ok, "no bytes before the instruments are attached")
-	_, ok = histForSignal(t, ms, "traces", false)
+	_, ok := histForSignal(t, ms, "traces", false)
 	assert.False(t, ok, "no duration before the instruments are attached")
 }
 
@@ -481,41 +302,26 @@ func TestMeteredTraceExporter_Passthrough(t *testing.T) {
 
 // --- shared naming --------------------------------------------------------
 
+// TestMeteredExporters_ShareOneMetricBySignal asserts the three wrappers write
+// to one shared duration histogram, separated only by otel_signal.
 func TestMeteredExporters_ShareOneMetricBySignal(t *testing.T) {
 	inst, collect := newTestMetrics(t)
-	logs := newMeteredLogExporter(&fakeLogExporter{size: 100}, inst, "csa")
-	metrics := newMeteredMetricExporter(&fakeMetricExporter{size: 200})
+
+	logs := newMeteredLogExporter(&fakeLogExporter{}, inst, "csa")
+	metrics := newMeteredMetricExporter(&fakeMetricExporter{})
 	metrics.attachMetrics(inst, "csa")
-	traces := newMeteredTraceExporter(&fakeTraceExporter{size: 300})
+	traces := newMeteredTraceExporter(&fakeTraceExporter{})
 	traces.attachMetrics(inst, "csa")
 
 	require.NoError(t, logs.Export(context.Background(), nil))
-	require.NoError(t, metrics.Export(context.Background(), &metricdata.ResourceMetrics{}))
+	require.NoError(t, metrics.Export(context.Background(), nil))
 	require.NoError(t, traces.ExportSpans(context.Background(), nil))
 
 	ms := collect()
-	for _, tc := range []struct {
-		signal string
-		want   int64
-	}{{"logs", 100}, {"metrics", 200}, {"traces", 300}} {
-		dp, ok := dpForSignal(t, ms, tc.signal)
-		require.True(t, ok, "expected a %s bytes datapoint", tc.signal)
-		assert.Equal(t, tc.want, dp.Value)
-
-		// Each signal gets its own duration datapoint on the same instrument too.
-		hdp, ok := histForSignal(t, ms, tc.signal, false)
-		require.True(t, ok, "expected a %s duration datapoint", tc.signal)
-		assert.Equal(t, uint64(1), hdp.Count)
-	}
-
-	// Both are datapoints of the same instrument, distinguished only by otel_signal.
-	for _, m := range ms {
-		switch m.Name {
-		case exportBytesMetric:
-			assert.Equal(t, "By", m.Unit)
-		case exportDurationMetric:
-			assert.Equal(t, "s", m.Unit)
-		}
+	for _, signal := range []string{"logs", "metrics", "traces"} {
+		hdp, ok := histForSignal(t, ms, signal, false)
+		require.True(t, ok, "expected a %s duration datapoint", signal)
+		assert.Equal(t, uint64(1), hdp.Count, "one observation per export for %s", signal)
 	}
 }
 
@@ -524,7 +330,7 @@ func TestMeteredExporters_ShareOneMetricBySignal(t *testing.T) {
 func TestMeteredLogExporter_RecordsDurationOnSuccess(t *testing.T) {
 	inst, collect := newTestMetrics(t)
 	const delay = 20 * time.Millisecond
-	inner := &fakeLogExporter{size: 4096, delay: delay}
+	inner := &fakeLogExporter{delay: delay}
 	exp := newMeteredLogExporter(inner, inst, "csa-pub-hex")
 
 	require.NoError(t, exp.Export(context.Background(), nil))
@@ -544,7 +350,7 @@ func TestMeteredLogExporter_RecordsDurationOnSuccess(t *testing.T) {
 func TestMeteredMetricExporter_RecordsDurationOnSuccess(t *testing.T) {
 	inst, collect := newTestMetrics(t)
 	const delay = 20 * time.Millisecond
-	exp := newMeteredMetricExporter(&fakeMetricExporter{size: 8192, delay: delay})
+	exp := newMeteredMetricExporter(&fakeMetricExporter{delay: delay})
 	exp.attachMetrics(inst, "csa-pub-hex")
 
 	require.NoError(t, exp.Export(context.Background(), &metricdata.ResourceMetrics{}))
@@ -559,12 +365,12 @@ func TestMeteredMetricExporter_RecordsDurationOnSuccess(t *testing.T) {
 	assert.Equal(t, "csa-pub-hex", csa.AsString())
 }
 
-// TestMeteredExporter_DurationRetriesCountedOnce mirrors the bytes behaviour:
-// the wrapper sits above the otlp retry loop, so one logical batch is one
-// observation covering the whole retry sequence.
+// TestMeteredExporter_DurationRetriesCountedOnce: the wrapper sits above the
+// otlp retry loop, so one logical batch is one observation covering the whole
+// retry sequence.
 func TestMeteredExporter_DurationRetriesCountedOnce(t *testing.T) {
 	inst, collect := newTestMetrics(t)
-	inner := &fakeLogExporter{size: 500, fireN: 3}
+	inner := &fakeLogExporter{}
 	exp := newMeteredLogExporter(inner, inst, "csa")
 
 	require.NoError(t, exp.Export(context.Background(), nil))
@@ -598,8 +404,8 @@ func TestExportDuration_UsesSecondScaledBuckets(t *testing.T) {
 
 func TestMeteredExporter_DurationRecordedPerOutcome(t *testing.T) {
 	inst, collect := newTestMetrics(t)
-	ok1 := newMeteredLogExporter(&fakeLogExporter{size: 10}, inst, "csa")
-	bad := newMeteredLogExporter(&fakeLogExporter{size: 10, err: errors.New("boom")}, inst, "csa")
+	ok1 := newMeteredLogExporter(&fakeLogExporter{}, inst, "csa")
+	bad := newMeteredLogExporter(&fakeLogExporter{err: errors.New("boom")}, inst, "csa")
 
 	require.NoError(t, ok1.Export(context.Background(), nil))
 	require.NoError(t, ok1.Export(context.Background(), nil))
@@ -613,4 +419,181 @@ func TestMeteredExporter_DurationRecordedPerOutcome(t *testing.T) {
 	errDP, found := histForSignal(t, ms, "logs", true)
 	require.True(t, found)
 	assert.Equal(t, uint64(1), errDP.Count)
+}
+
+// --- exportStatsHandler ---------------------------------------------------
+
+// simulateRPC drives one full unary gRPC lifecycle through the handler, in the
+// same order grpc-go fires the events. Nothing outside the handler touches the
+// context: TagRPC allocates the state, HandleRPC reads it back.
+func simulateRPC(h *exportStatsHandler, parent context.Context, size int, rpcErr error) {
+	ctx := h.TagRPC(parent, &stats.RPCTagInfo{FullMethodName: "/test.Service/Export"})
+	h.HandleRPC(ctx, &stats.Begin{})
+	h.HandleRPC(ctx, &stats.OutPayload{Length: size})
+	h.HandleRPC(ctx, &stats.End{Error: rpcErr})
+}
+
+func TestExportStatsHandler_RecordsBytesOnSuccessfulRPC(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	h := newExportStatsHandler("logs", "csa-pub-hex")
+	h.attachMetrics(metrics)
+
+	simulateRPC(h, context.Background(), 4096, nil)
+
+	dp, ok := dpForSignal(t, collect(), "logs")
+	require.True(t, ok, "expected a logs datapoint")
+	assert.Equal(t, int64(4096), dp.Value)
+
+	csa, ok := dp.Attributes.Value(attribute.Key("csa_public_key"))
+	require.True(t, ok)
+	assert.Equal(t, "csa-pub-hex", csa.AsString())
+}
+
+func TestExportStatsHandler_NoBytesOnFailedRPC(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	h := newExportStatsHandler("logs", "csa")
+	h.attachMetrics(metrics)
+
+	simulateRPC(h, context.Background(), 4096, errors.New("unavailable"))
+
+	_, ok := dpForSignal(t, collect(), "logs")
+	assert.False(t, ok, "a failed RPC must not contribute bytes")
+}
+
+// TestExportStatsHandler_RetryAttemptsCountedOnce is the semantic guard: the
+// OTLP exporters retry by issuing a fresh unary RPC per attempt, so the handler
+// sees three independent RPCs carrying the same proto. Only the one that lands
+// may be counted.
+func TestExportStatsHandler_RetryAttemptsCountedOnce(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	h := newExportStatsHandler("logs", "csa")
+	h.attachMetrics(metrics)
+
+	simulateRPC(h, context.Background(), 500, errors.New("unavailable"))
+	simulateRPC(h, context.Background(), 500, errors.New("unavailable"))
+	simulateRPC(h, context.Background(), 500, nil)
+
+	dp, ok := dpForSignal(t, collect(), "logs")
+	require.True(t, ok)
+	assert.Equal(t, int64(500), dp.Value, "retries of the same batch must be counted once")
+}
+
+// TestExportStatsHandler_ConcurrentRPCsIsolated replaces the old
+// TestMeteredExporter_ConcurrentExportsIsolated. State is per-RPC via TagRPC,
+// so interleaved RPCs cannot overwrite each other.
+func TestExportStatsHandler_ConcurrentRPCsIsolated(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	h := newExportStatsHandler("logs", "csa")
+	h.attachMetrics(metrics)
+
+	const n = 50
+	var wg sync.WaitGroup
+	var want int64
+	for i := 1; i <= n; i++ {
+		size := i
+		want += int64(size)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			simulateRPC(h, context.Background(), size, nil)
+		}()
+	}
+	wg.Wait()
+
+	dp, ok := dpForSignal(t, collect(), "logs")
+	require.True(t, ok)
+	assert.Equal(t, want, dp.Value)
+}
+
+func TestExportStatsHandler_AccumulatesMultipleOutPayloads(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	h := newExportStatsHandler("logs", "csa")
+	h.attachMetrics(metrics)
+
+	ctx := h.TagRPC(context.Background(), &stats.RPCTagInfo{FullMethodName: "/test.Service/Export"})
+	h.HandleRPC(ctx, &stats.OutPayload{Length: 100})
+	h.HandleRPC(ctx, &stats.OutPayload{Length: 250})
+	h.HandleRPC(ctx, &stats.End{})
+
+	dp, ok := dpForSignal(t, collect(), "logs")
+	require.True(t, ok)
+	assert.Equal(t, int64(350), dp.Value, "all outbound payloads of one RPC belong to that RPC")
+}
+
+func TestExportStatsHandler_IgnoresInboundAndEmptyRPCs(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	h := newExportStatsHandler("logs", "csa")
+	h.attachMetrics(metrics)
+
+	// Inbound payload only: nothing was sent, so nothing is counted.
+	ctx := h.TagRPC(context.Background(), &stats.RPCTagInfo{FullMethodName: "/test.Service/Export"})
+	h.HandleRPC(ctx, &stats.InPayload{Length: 999})
+	h.HandleRPC(ctx, &stats.End{})
+
+	_, ok := dpForSignal(t, collect(), "logs")
+	assert.False(t, ok, "an RPC with no outbound payload must not record a zero datapoint")
+}
+
+func TestExportStatsHandler_SecondEndIsIdempotent(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	h := newExportStatsHandler("logs", "csa")
+	h.attachMetrics(metrics)
+
+	ctx := h.TagRPC(context.Background(), &stats.RPCTagInfo{FullMethodName: "/test.Service/Export"})
+	h.HandleRPC(ctx, &stats.OutPayload{Length: 64})
+	h.HandleRPC(ctx, &stats.End{})
+	h.HandleRPC(ctx, &stats.End{})
+
+	dp, ok := dpForSignal(t, collect(), "logs")
+	require.True(t, ok)
+	assert.Equal(t, int64(64), dp.Value)
+}
+
+func TestExportStatsHandler_NoStateInContextIsNoop(t *testing.T) {
+	metrics, _ := newTestMetrics(t)
+	h := newExportStatsHandler("logs", "csa")
+	h.attachMetrics(metrics)
+
+	assert.NotPanics(t, func() {
+		h.HandleRPC(context.Background(), &stats.OutPayload{Length: 5})
+		h.HandleRPC(context.Background(), &stats.End{})
+	})
+}
+
+// TestExportStatsHandler_UnattachedIsNoop covers the window before the
+// MeterProvider exists: the handler is registered at dial time, instruments
+// arrive later.
+func TestExportStatsHandler_UnattachedIsNoop(t *testing.T) {
+	h := newExportStatsHandler("metrics", "csa")
+
+	assert.NotPanics(t, func() {
+		simulateRPC(h, context.Background(), 128, nil)
+	})
+}
+
+func TestExportStatsHandler_ConnHooksAreInert(t *testing.T) {
+	h := newExportStatsHandler("logs", "csa")
+	ctx := context.Background()
+
+	assert.Equal(t, ctx, h.TagConn(ctx, &stats.ConnTagInfo{}))
+	assert.NotPanics(t, func() { h.HandleConn(ctx, &stats.ConnBegin{}) })
+}
+
+func TestExportStatsHandler_PerSignalAttribution(t *testing.T) {
+	metrics, collect := newTestMetrics(t)
+	logs := newExportStatsHandler("logs", "csa")
+	logs.attachMetrics(metrics)
+	mtrx := newExportStatsHandler("metrics", "csa")
+	mtrx.attachMetrics(metrics)
+
+	simulateRPC(logs, context.Background(), 100, nil)
+	simulateRPC(mtrx, context.Background(), 200, nil)
+
+	ms := collect()
+	logDP, ok := dpForSignal(t, ms, "logs")
+	require.True(t, ok)
+	assert.Equal(t, int64(100), logDP.Value)
+	metricDP, ok := dpForSignal(t, ms, "metrics")
+	require.True(t, ok)
+	assert.Equal(t, int64(200), metricDP.Value)
 }


### PR DESCRIPTION
## What

Adds a `beholder.export.bytes` and `beholder.export.duration` metrics to the beholder gRPC client, restoring
per-node log volume visibility and export duration (labelled by `csa_public_key` and `signal_type` logs/metrics/traces)

According to these docs, `rpc.client.request.*` metrics are totally deprecated without any successors in otelgrpc semconv v1.40.0
[RPC semantic convention stability migration guide](https://opentelemetry.io/docs/specs/semconv/non-normative/rpc-migration/)

[Semantic conventions for RPC metrics](https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/)

Additionally, new `beholder.export.*` metrics are not recorded on each separate message, but on the whole batch at once. In terms of `beholder.export.bytes` it shows real number of exported bytes only on success without cumulative number on all retries that `rpc.client.request.size` was producing. This was misleading in terms of how many logs/metrics are coming through the gateway and downstream consumers.

## Changes

- Implements `exportStatsHandler` (gRPC `stats.Handler`) to capture outbound message sizes via `OutPayload` events
- Adds new metric `beholder.export.bytes` with attributes `otel_signal` and `csa_public_key`
- Adds new metric `beholder.export.duration` (histogram, unit `s`) with attributes `otel_signal`, `csa_public_key` and `error`
    - Uses explicit second-scaled bucket boundaries (`0.005`–`60`); the SDK defaults are millisecond-scaled, so nearly every export would land in the first bucket
- Groups both instruments into a shared `exportMetrics` struct, attached to the metric exporter once the `MeterProvider` exists (`attachMetrics`)
- Wraps log and metric exporters with metering logic that:
    - Uses per-call context to isolate concurrent exports
    - Records bytes only on successful exports
    - Records duration on both successful and failed exports, labelled `error={true,false}`
    - Handles retries correctly (stores size, doesn't accumulate)
    - Measures duration once per logical batch, covering all retry attempts and backoff
- Comprehensive test coverage including concurrency and retry scenarios

## Notes

- Both metrics are batch-scoped: one observation per logical export, never per gRPC message or per retry attempt.
- Size is captured in `HandleRPC` because the uncompressed proto length is only observable inside the gRPC stack. Duration is measured in the wrapper instead, so it also covers proto marshaling, connection setup and inter-attempt backoff and is still recorded when an export fails before any RPC is issued (e.g. an already-expired context, which produces no stats events at all).

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
