### PR TITLE
feat(observability-lib): upgrade grafana-foundation-sdk to latest v0.0.18

### DIFF
--- a/observability-lib/go.mod
+++ b/observability-lib/go.mod
@@ -3,8 +3,8 @@ module github.com/smartcontractkit/chainlink-common/observability-lib
 go 1.26.2
 
 require (
-	github.com/go-resty/resty/v2 v2.17.1
-	github.com/grafana/grafana-foundation-sdk/go v0.0.12
+	github.com/go-resty/resty/v2 v2.17.2
+	github.com/grafana/grafana-foundation-sdk/go v0.0.18
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/observability-lib/go.sum
+++ b/observability-lib/go.sum
@@ -2,10 +2,10 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-resty/resty/v2 v2.17.1 h1:x3aMpHK1YM9e4va/TMDRlusDDoZiQ+ViDu/WpA6xTM4=
-github.com/go-resty/resty/v2 v2.17.1/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
-github.com/grafana/grafana-foundation-sdk/go v0.0.12 h1:ggGWIJ3ylX16/xtAYlVi1TtUdv+mybYPusOmi1x35kg=
-github.com/grafana/grafana-foundation-sdk/go v0.0.12/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
+github.com/go-resty/resty/v2 v2.17.2 h1:FQW5oHYcIlkCNrMD2lloGScxcHJ0gkjshV3qcQAyHQk=
+github.com/go-resty/resty/v2 v2.17.2/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
+github.com/grafana/grafana-foundation-sdk/go v0.0.18 h1:DkWn1vY9FYYVVWzrZQCqZnGxsN8R/RQUJigG6UkfXIo=
+github.com/grafana/grafana-foundation-sdk/go v0.0.18/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/observability-lib/grafana/alerts.go
+++ b/observability-lib/grafana/alerts.go
@@ -76,6 +76,7 @@ type MathExpression struct {
 
 type ResampleExpression struct {
 	Expression  string
+	Window      string
 	DownSampler expr.TypeResampleDownsampler
 	UpSampler   expr.TypeResampleUpsampler
 }
@@ -137,7 +138,7 @@ func newConditionQuery(options ConditionQuery) *alerting.QueryBuilder {
 		DatasourceUid("__expr__")
 
 	if options.ReduceExpression != nil {
-		reduceBuider := expr.NewTypeReduceBuilder().
+		reduceBuilder := expr.NewTypeReduceBuilder().
 			RefId(options.RefID).
 			Expression(options.ReduceExpression.Expression).
 			IntervalMs(*options.IntervalMs).
@@ -145,10 +146,10 @@ func newConditionQuery(options ConditionQuery) *alerting.QueryBuilder {
 			Reducer(options.ReduceExpression.Reducer)
 
 		if options.ReduceExpression.ReduceSettings != nil && options.ReduceExpression.ReduceSettings.Mode != "" {
-			reduceBuider.Settings(newReduceSettingsOptions(*options.ReduceExpression.ReduceSettings))
+			reduceBuilder.Settings(newReduceSettingsOptions(*options.ReduceExpression.ReduceSettings))
 		}
 		res.Model(expr.NewTypeMathOrTypeReduceOrTypeResampleOrTypeClassicConditionsOrTypeThresholdOrTypeSqlBuilder().
-			TypeReduce(reduceBuider))
+			TypeReduce(reduceBuilder))
 	}
 
 	if options.MathExpression != nil {
@@ -162,12 +163,18 @@ func newConditionQuery(options ConditionQuery) *alerting.QueryBuilder {
 	}
 
 	if options.ResampleExpression != nil {
+		window := options.ResampleExpression.Window
+		if window == "" {
+			// Window is required (>= 1 char) by the SDK; default to the relative time range.
+			window = "10m"
+		}
 		res.Model(expr.NewTypeMathOrTypeReduceOrTypeResampleOrTypeClassicConditionsOrTypeThresholdOrTypeSqlBuilder().
 			TypeResample(expr.NewTypeResampleBuilder().
 				RefId(options.RefID).
 				Expression(options.ResampleExpression.Expression).
 				IntervalMs(*options.IntervalMs).
 				MaxDataPoints(*options.MaxDataPoints).
+				Window(window).
 				Downsampler(options.ResampleExpression.DownSampler).
 				Upsampler(options.ResampleExpression.UpSampler),
 			))

--- a/observability-lib/grafana/alerts.go
+++ b/observability-lib/grafana/alerts.go
@@ -147,37 +147,41 @@ func newConditionQuery(options ConditionQuery) *alerting.QueryBuilder {
 		if options.ReduceExpression.ReduceSettings != nil && options.ReduceExpression.ReduceSettings.Mode != "" {
 			reduceBuider.Settings(newReduceSettingsOptions(*options.ReduceExpression.ReduceSettings))
 		}
-		res.Model(reduceBuider)
+		res.Model(expr.NewTypeMathOrTypeReduceOrTypeResampleOrTypeClassicConditionsOrTypeThresholdOrTypeSqlBuilder().
+			TypeReduce(reduceBuider))
 	}
 
 	if options.MathExpression != nil {
-		res.Model(expr.NewTypeMathBuilder().
-			RefId(options.RefID).
-			Expression(options.MathExpression.Expression).
-			IntervalMs(*options.IntervalMs).
-			MaxDataPoints(*options.MaxDataPoints),
-		)
+		res.Model(expr.NewTypeMathOrTypeReduceOrTypeResampleOrTypeClassicConditionsOrTypeThresholdOrTypeSqlBuilder().
+			TypeMath(expr.NewTypeMathBuilder().
+				RefId(options.RefID).
+				Expression(options.MathExpression.Expression).
+				IntervalMs(*options.IntervalMs).
+				MaxDataPoints(*options.MaxDataPoints),
+			))
 	}
 
 	if options.ResampleExpression != nil {
-		res.Model(expr.NewTypeResampleBuilder().
-			RefId(options.RefID).
-			Expression(options.ResampleExpression.Expression).
-			IntervalMs(*options.IntervalMs).
-			MaxDataPoints(*options.MaxDataPoints).
-			Downsampler(options.ResampleExpression.DownSampler).
-			Upsampler(options.ResampleExpression.UpSampler),
-		)
+		res.Model(expr.NewTypeMathOrTypeReduceOrTypeResampleOrTypeClassicConditionsOrTypeThresholdOrTypeSqlBuilder().
+			TypeResample(expr.NewTypeResampleBuilder().
+				RefId(options.RefID).
+				Expression(options.ResampleExpression.Expression).
+				IntervalMs(*options.IntervalMs).
+				MaxDataPoints(*options.MaxDataPoints).
+				Downsampler(options.ResampleExpression.DownSampler).
+				Upsampler(options.ResampleExpression.UpSampler),
+			))
 	}
 
 	if options.ThresholdExpression != nil {
-		res.Model(expr.NewTypeThresholdBuilder().
-			RefId(options.RefID).
-			Expression(options.ThresholdExpression.Expression).
-			IntervalMs(*options.IntervalMs).
-			MaxDataPoints(*options.MaxDataPoints).
-			Conditions(newThresholdConditionsOptions(options.ThresholdExpression.ThresholdConditionsOptions)),
-		)
+		res.Model(expr.NewTypeMathOrTypeReduceOrTypeResampleOrTypeClassicConditionsOrTypeThresholdOrTypeSqlBuilder().
+			TypeThreshold(expr.NewTypeThresholdBuilder().
+				RefId(options.RefID).
+				Expression(options.ThresholdExpression.Expression).
+				IntervalMs(*options.IntervalMs).
+				MaxDataPoints(*options.MaxDataPoints).
+				Conditions(newThresholdConditionsOptions(options.ThresholdExpression.ThresholdConditionsOptions)),
+			))
 	}
 
 	return res

--- a/observability-lib/grafana/builder_test.go
+++ b/observability-lib/grafana/builder_test.go
@@ -1,6 +1,7 @@
 package grafana_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/grafana/grafana-foundation-sdk/go/alerting"
@@ -478,6 +479,81 @@ func TestBuilder_AddPanel(t *testing.T) {
 			t.Errorf("Error building dashboard: %v", err)
 		}
 		require.IsType(t, dashboard.Panel{}, *o.Dashboard.Panels[0].Panel)
+	})
+}
+
+func TestNewAlertRule_ConditionExpressionModels(t *testing.T) {
+	t.Run("builds a model for every expression type", func(t *testing.T) {
+		ruleBuilder := grafana.NewAlertRule(&grafana.AlertOptions{
+			Title: "Expression Alert",
+			Query: []grafana.RuleQuery{
+				{
+					Expr:       `my_metric`,
+					Instant:    true,
+					RefID:      "A",
+					Datasource: "datasource-uid",
+				},
+			},
+			QueryRefCondition: "E",
+			Condition: []grafana.ConditionQuery{
+				{
+					RefID: "B",
+					ReduceExpression: &grafana.ReduceExpression{
+						Expression: "A",
+						Reducer:    expr.TypeReduceReducerSum,
+					},
+				},
+				{
+					RefID: "C",
+					MathExpression: &grafana.MathExpression{
+						Expression: "$B * 2",
+					},
+				},
+				{
+					RefID: "D",
+					ResampleExpression: &grafana.ResampleExpression{
+						Expression:  "A",
+						Window:      "10s",
+						DownSampler: expr.TypeResampleDownsamplerMean,
+						UpSampler:   expr.TypeResampleUpsamplerPad,
+					},
+				},
+				{
+					RefID: "E",
+					ThresholdExpression: &grafana.ThresholdExpression{
+						Expression: "D",
+						ThresholdConditionsOptions: grafana.ThresholdConditionsOption{
+							Params: []float64{2},
+							Type:   expr.ExprTypeThresholdConditionsEvaluatorTypeLt,
+						},
+					},
+				},
+			},
+		})
+
+		rule, err := ruleBuilder.Build()
+		require.NoError(t, err)
+
+		models := map[string]string{}
+		for _, query := range rule.Data {
+			require.NotNil(t, query.RefId)
+			raw, errMarshal := json.Marshal(query.Model)
+			require.NoError(t, errMarshal)
+			models[*query.RefId] = string(raw)
+		}
+
+		require.Contains(t, models["B"], `"type":"reduce"`)
+
+		require.Contains(t, models["C"], `"type":"math"`)
+		require.Contains(t, models["C"], `"expression":"$B * 2"`)
+
+		require.Contains(t, models["D"], `"type":"resample"`)
+		require.Contains(t, models["D"], `"downsampler":"mean"`)
+		require.Contains(t, models["D"], `"upsampler":"pad"`)
+		require.Contains(t, models["D"], `"expression":"A"`)
+		require.Contains(t, models["D"], `"window":"10s"`)
+
+		require.Contains(t, models["E"], `"type":"threshold"`)
 	})
 }
 


### PR DESCRIPTION
The grafana-foundation-sdk v0.0.18 changed the type contract for QueryBuilder.Model().

In v0.0.12, each expression builder (TypeReduceBuilder, TypeMathBuilder, etc.) implemented cog.Builder[variants.Dataquery] directly. In v0.0.18 their Build() now returns concrete types (expr.TypeReduce, expr.TypeMath, …) instead of variants.Dataquery, so they no longer satisfy Model()'s parameter type.

The fix

v0.0.18 introduces a union builder — TypeMathOrTypeReduceOrTypeResampleOrTypeClassicConditionsOrTypeThresholdOrTypeSqlBuilder — which is the thing that now implements cog.Builder[variants.Dataquery]. I wrapped each expression builder in it via the matching method (.TypeReduce(...), .TypeMath(...), .TypeResample(...), .TypeThreshold(...)) in newConditionQuery (grafana/alerts.go:139-181).

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/libocr/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/chainlink/pull/7777777
-->
