### PR TITLE
pkg/settings/limits: raise missing org ID tenant log level from warn to error

### DIFF
--- a/pkg/beholder/batch_emitter_service_test.go
+++ b/pkg/beholder/batch_emitter_service_test.go
@@ -35,12 +35,11 @@ func newTestConfig() beholder.Config {
 	}
 }
 
+// Deprecated: use [logger.Test] instead.
+//
+//go:fix inline
 func newTestLogger(t *testing.T) logger.Logger {
-	t.Helper()
-	lggr, err := logger.New()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = lggr.Sync() })
-	return lggr
+	return logger.Test(t)
 }
 
 func TestNewChipIngressBatchEmitterService(t *testing.T) {

--- a/pkg/capabilities/base_trigger_test.go
+++ b/pkg/capabilities/base_trigger_test.go
@@ -52,12 +52,13 @@ func TestValidateBaseTriggerRetryInterval(t *testing.T) {
 
 // atomicJSONGetter swaps a whole settings.Getter under a mutex for dynamic-settings tests.
 type atomicJSONGetter struct {
-	mu sync.Mutex
-	g  settings.Getter
+	lggr logger.Logger
+	mu   sync.Mutex
+	g    settings.Getter
 }
 
 func (f *atomicJSONGetter) setJSON(js string) error {
-	g, err := settings.NewJSONGetter([]byte(js))
+	g, err := settings.GetterConfig{Logger: f.lggr}.NewJSONGetter([]byte(js))
 	if err != nil {
 		return err
 	}
@@ -78,12 +79,11 @@ func (f *atomicJSONGetter) GetScoped(ctx context.Context, scope settings.Scope, 
 }
 
 func TestBaseTrigger_CRE_DynamicDisableStopsResend(t *testing.T) {
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 	ctx := t.Context()
 	ctx = contexts.WithCRE(ctx, contexts.CRE{Org: "testorg"})
 
-	getter := &atomicJSONGetter{}
+	getter := &atomicJSONGetter{lggr: logger.Test(t)}
 	require.NoError(t, getter.setJSON(`{
 		"global": {
 			"PerOrg": {"BaseTriggerRetransmitEnabled": "true"},
@@ -122,14 +122,13 @@ func TestBaseTrigger_CRE_DynamicDisableStopsResend(t *testing.T) {
 }
 
 func TestBaseTrigger_CRE_PerOrgRetransmit(t *testing.T) {
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 	baseCtx := t.Context()
 	ctxOrgA := contexts.WithCRE(baseCtx, contexts.CRE{Org: "orgA"})
 	ctxOrgB := contexts.WithCRE(baseCtx, contexts.CRE{Org: "orgB"})
 
 	// Global default: no retransmit. Org orgA overrides PerOrg.BaseTriggerRetransmitEnabled to true.
-	getter, err := settings.NewJSONGetter([]byte(`{
+	getter, err := settings.GetterConfig{Logger: lggr}.NewJSONGetter([]byte(`{
 		"global": {
 			"PerOrg": {"BaseTriggerRetransmitEnabled": "false"},
 			"BaseTriggerRetryInterval": "20ms",
@@ -192,8 +191,7 @@ func newBase(t *testing.T, store EventStore) *BaseTriggerCapability[*wrapperspb.
 }
 
 func newBaseWithRetransmit(t *testing.T, store EventStore, tRetransmit time.Duration) *BaseTriggerCapability[*wrapperspb.BytesValue] {
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 	return NewBaseTriggerCapability(store, func() *wrapperspb.BytesValue { return &wrapperspb.BytesValue{} }, lggr,
 		"testCap", tRetransmit, nil)
 }
@@ -391,19 +389,18 @@ func TestRetransmitDisabled_AckReconcilesStore(t *testing.T) {
 }
 
 func TestBaseTrigger_MaxRetries_GivesUp(t *testing.T) {
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 	ctx := t.Context()
 	ctx = contexts.WithCRE(ctx, contexts.CRE{Org: "testorg"})
 
-	getter := &atomicJSONGetter{}
-	require.NoError(t, getter.setJSON(`{
+	getter, err := settings.GetterConfig{Logger: logger.Test(t)}.NewJSONGetter([]byte(`{
 		"global": {
 			"PerOrg": {"BaseTriggerRetransmitEnabled": "true"},
 			"BaseTriggerRetryInterval": "20ms",
 			"BaseTriggerMaxRetries": "3"
 		}
 	}`))
+	require.NoError(t, err)
 
 	store := NewMemEventStore()
 	b, err := NewBaseTriggerCapabilityWithCRESettings(ctx, store,
@@ -440,19 +437,18 @@ func TestBaseTrigger_MaxRetries_GivesUp(t *testing.T) {
 }
 
 func TestBaseTrigger_MaxRetries_AckBeforeLimit(t *testing.T) {
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 	ctx := t.Context()
 	ctx = contexts.WithCRE(ctx, contexts.CRE{Org: "testorg"})
 
-	getter := &atomicJSONGetter{}
-	require.NoError(t, getter.setJSON(`{
+	getter, err := settings.GetterConfig{Logger: logger.Test(t)}.NewJSONGetter([]byte(`{
 		"global": {
 			"PerOrg": {"BaseTriggerRetransmitEnabled": "true"},
 			"BaseTriggerRetryInterval": "20ms",
 			"BaseTriggerMaxRetries": "100"
 		}
 	}`))
+	require.NoError(t, err)
 
 	store := NewMemEventStore()
 	b, err := NewBaseTriggerCapabilityWithCRESettings(ctx, store,
@@ -764,17 +760,16 @@ func TestBaseTrigger_RedeliveryAfterAck_Skipped(t *testing.T) {
 func TestBaseTrigger_MaxSendsPerTick(t *testing.T) {
 	store := NewMemEventStore()
 
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 
-	getter := &atomicJSONGetter{}
-	require.NoError(t, getter.setJSON(`{
+	getter, err := settings.GetterConfig{Logger: logger.Test(t)}.NewJSONGetter([]byte(`{
 		"global": {
 			"PerOrg": {"BaseTriggerRetransmitEnabled": "true"},
 			"BaseTriggerRetryInterval": "50ms",
 			"BaseTriggerMaxRetries": "1000"
 		}
 	}`))
+	require.NoError(t, err)
 
 	b, err := NewBaseTriggerCapabilityWithCRESettings(context.Background(), store,
 		func() *wrapperspb.BytesValue { return &wrapperspb.BytesValue{} },
@@ -822,8 +817,7 @@ drainCap:
 }
 
 func TestBaseTrigger_PruneStaleEvents(t *testing.T) {
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 	ctx := t.Context()
 
 	store := NewMemEventStore()
@@ -848,14 +842,14 @@ func TestBaseTrigger_PruneStaleEvents(t *testing.T) {
 	}
 	require.NoError(t, store.Insert(ctx, recentRec))
 
-	getter := &atomicJSONGetter{}
-	require.NoError(t, getter.setJSON(`{
+	getter, err := settings.GetterConfig{Logger: logger.Test(t)}.NewJSONGetter([]byte(`{
 		"global": {
 			"PerOrg": {"BaseTriggerRetransmitEnabled": "false"},
 			"BaseTriggerRetryInterval": "30s",
 			"BaseTriggerPruneAge": "1h"
 		}
 	}`))
+	require.NoError(t, err)
 
 	b := NewBaseTriggerCapability(store,
 		func() *wrapperspb.BytesValue { return &wrapperspb.BytesValue{} },
@@ -871,8 +865,7 @@ func TestBaseTrigger_PruneStaleEvents(t *testing.T) {
 }
 
 func TestBaseTrigger_PrunePurgesStaleInMemoryEvents(t *testing.T) {
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 	ctx := t.Context()
 
 	store := NewMemEventStore()
@@ -886,14 +879,14 @@ func TestBaseTrigger_PrunePurgesStaleInMemoryEvents(t *testing.T) {
 	}
 	require.NoError(t, store.Insert(ctx, oldRec))
 
-	getter := &atomicJSONGetter{}
-	require.NoError(t, getter.setJSON(`{
+	getter, err := settings.GetterConfig{Logger: logger.Test(t)}.NewJSONGetter([]byte(`{
 		"global": {
 			"PerOrg": {"BaseTriggerRetransmitEnabled": "false"},
 			"BaseTriggerRetryInterval": "30s",
 			"BaseTriggerPruneAge": "1h"
 		}
 	}`))
+	require.NoError(t, err)
 
 	b := NewBaseTriggerCapability(store,
 		func() *wrapperspb.BytesValue { return &wrapperspb.BytesValue{} },
@@ -917,19 +910,18 @@ func TestBaseTrigger_PrunePurgesStaleInMemoryEvents(t *testing.T) {
 }
 
 func TestBaseTrigger_ScanPendingSkipsEventsWithoutInbox(t *testing.T) {
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 	ctx := t.Context()
 	ctx = contexts.WithCRE(ctx, contexts.CRE{Org: "testorg"})
 
-	getter := &atomicJSONGetter{}
-	require.NoError(t, getter.setJSON(`{
+	getter, err := settings.GetterConfig{Logger: logger.Test(t)}.NewJSONGetter([]byte(`{
 		"global": {
 			"PerOrg": {"BaseTriggerRetransmitEnabled": "true"},
 			"BaseTriggerRetryInterval": "50ms",
 			"BaseTriggerMaxRetries": "5"
 		}
 	}`))
+	require.NoError(t, err)
 
 	store := NewMemEventStore()
 
@@ -1217,11 +1209,9 @@ drain:
 }
 
 func TestBaseTrigger_ScanPending_TriggerIDTiebreaker(t *testing.T) {
-	lggr, err := logger.New()
-	require.NoError(t, err)
+	lggr := logger.Test(t)
 
-	getter := &atomicJSONGetter{}
-	require.NoError(t, getter.setJSON(`{
+	getter, err := settings.GetterConfig{Logger: logger.Test(t)}.NewJSONGetter([]byte(`{
 		"global": {
 			"PerOrg": {"BaseTriggerRetransmitEnabled": "true"},
 			"BaseTriggerRetryInterval":     "1ms",
@@ -1229,6 +1219,7 @@ func TestBaseTrigger_ScanPending_TriggerIDTiebreaker(t *testing.T) {
 			"BaseTriggerMaxRetries":        "1000"
 		}
 	}`))
+	require.NoError(t, err)
 
 	store := NewMemEventStore()
 	b, err := NewBaseTriggerCapabilityWithCRESettings(context.Background(), store,

--- a/pkg/loop/settings.go
+++ b/pkg/loop/settings.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 )
@@ -15,14 +16,25 @@ var _ core.SettingsBroadcaster = (*AtomicSettings)(nil)
 
 // AtomicSettings implements settings.Getter, and supports atomic updates with subscriptions.
 type AtomicSettings struct {
+	Lggr logger.Logger // optional
+
 	mu      sync.RWMutex
 	current *core.SettingsUpdate
 	getter  settings.Getter
 	subs    []chan core.SettingsUpdate
 }
 
+// Deprecated: instantiate AtomicSettings directly, then use AtomicSettings.SetGetter.
 func NewAtomicSettings(initial settings.Getter) *AtomicSettings {
-	return &AtomicSettings{getter: initial}
+	var as AtomicSettings
+	as.SetGetter(initial)
+	return &as
+}
+
+func (a *AtomicSettings) SetGetter(getter settings.Getter) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.getter = getter
 }
 
 func (a *AtomicSettings) Subscribe(ctx context.Context) (<-chan core.SettingsUpdate, error) {
@@ -73,11 +85,18 @@ func (a *AtomicSettings) Unsubscribe(ch <-chan core.SettingsUpdate) {
 func (a *AtomicSettings) Load() (core.SettingsUpdate, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
+	if a.current == nil {
+		return core.SettingsUpdate{}, nil
+	}
 	return *a.current, nil
 }
 
 func (a *AtomicSettings) Store(update core.SettingsUpdate) error {
-	getter, err := settings.NewTOMLGetter([]byte(update.Settings))
+	cfg := settings.GetterConfig{Logger: a.Lggr}
+	if cfg.Logger == nil {
+		cfg.Logger = logger.Nop()
+	}
+	getter, err := cfg.NewTOMLGetter([]byte(update.Settings))
 	if err != nil {
 		return fmt.Errorf("failed to initialize settings: %w", err)
 	}

--- a/pkg/settings/json.go
+++ b/pkg/settings/json.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"maps"
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // CombineJSONFiles reads a set of JSON config files and combines them in to one file. The expected inputs are:
@@ -169,25 +172,40 @@ func (s *jsonSettings) get(key string) (string, error) {
 	return "", nil // no value
 }
 
+// TODO https://smartcontract-it.atlassian.net/browse/CAPPL-775
+// NewJSONRegistry with polling & subscriptions
 type jsonGetter struct {
 	settings *jsonSettings
+	lggr     logger.Logger
 }
 
 // NewJSONGetter returns a static Getter backed by the given JSON.
-// TODO https://smartcontract-it.atlassian.net/browse/CAPPL-775
-// NewJSONRegistry with polling & subscriptions
+// Deprecated: use GetterConfig.NewJSONGetter to include a [logger.Logger]
 func NewJSONGetter(b []byte) (Getter, error) {
+	return GetterConfig{}.NewJSONGetter(b)
+}
+
+// NewJSONGetter returns a static Getter backed by the given JSON.
+func (c GetterConfig) NewJSONGetter(b []byte) (Getter, error) {
+	if c.Logger == nil {
+		c.Logger = logger.Nop()
+	}
 	s, err := newJSONSettings(b)
 	if err != nil {
 		return nil, err
 	}
-	return &jsonGetter{settings: s}, nil
+	return &jsonGetter{settings: s, lggr: c.Logger}, nil
 }
 
 func (j *jsonGetter) GetScoped(ctx context.Context, scope Scope, key string) (value string, err error) {
 	keys, err := scope.rawKeys(ctx, key)
 	if err != nil {
-		return "", fmt.Errorf("failed to get raw keys: %w", err)
+		tme, ok := errors.AsType[tenantMissingError](err)
+		if ok && tme.Scope.IsTenantRequired() {
+			return "", fmt.Errorf("failed to get raw keys: %w", err)
+		} else {
+			j.lggr.Errorf("Settings lookup for "+key+" limited by missing tenant at scope "+tme.Scope.String(), "key", key, "err", err)
+		}
 	}
 	return j.settings.getFirst(keys...)
 }

--- a/pkg/settings/json_test.go
+++ b/pkg/settings/json_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 //go:embed testdata/json
@@ -34,7 +35,7 @@ func TestCombineJSONFiles(t *testing.T) {
 func Test_jsonSettings_GetScoped(t *testing.T) {
 	s, err := newJSONSettings([]byte(configJSON))
 	require.NoError(t, err)
-	r := jsonGetter{s}
+	r := jsonGetter{settings: s, lggr: logger.Test(t)}
 
 	ctx := contexts.WithCRE(t.Context(), contexts.CRE{
 		Org:      "123",

--- a/pkg/settings/keys.go
+++ b/pkg/settings/keys.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // rawKeys returns a slice of keys to check for this scope, ordered by decreasing priority.
@@ -14,13 +16,23 @@ func (s Scope) rawKeys(ctx context.Context, key string) (keys []string, err erro
 	for i := s; i > ScopeGlobal; i-- {
 		tenant := i.Value(ctx)
 		if tenant == "" {
-			if i.IsTenantRequired() {
-				err = errors.Join(err, fmt.Errorf("empty %s key", i))
-			}
+			err = errors.Join(err, tenantMissingError{Scope: i})
 		} else {
 			keys = append(keys, i.String()+"."+tenant+"."+key)
 		}
 	}
 	keys = append(keys, ScopeGlobal.String()+"."+key) // ScopeGlobal
 	return
+}
+
+type tenantMissingError struct {
+	Scope Scope
+}
+
+func (t tenantMissingError) Error() string {
+	return fmt.Sprintf("missing tenant for scope: %s", t.Scope)
+}
+
+type GetterConfig struct {
+	Logger logger.Logger
 }

--- a/pkg/settings/limits/bound.go
+++ b/pkg/settings/limits/bound.go
@@ -227,7 +227,7 @@ func (b *boundLimiter[N]) get(ctx context.Context) (tenant string, bound N, err 
 		if tenant == "" {
 			if !b.scope.IsTenantRequired() {
 				kvs := contexts.CREValue(ctx).LoggerKVs()
-				b.lggr.Warnw("Unable to get scoped bound limit due to missing tenant: failing open", append([]any{"scope", b.scope}, kvs...)...)
+				b.lggr.Errorw("Unable to get scoped bound limit due to missing tenant: failing open", append([]any{"scope", b.scope}, kvs...)...)
 				return
 			}
 			err = fmt.Errorf("unable to get scoped bound limit due to missing tenant for scope: %s", b.scope)

--- a/pkg/settings/limits/gate.go
+++ b/pkg/settings/limits/gate.go
@@ -205,7 +205,7 @@ func (g *gateLimiter) get(ctx context.Context) (tenant string, open bool, err er
 		if tenant == "" {
 			if !g.scope.IsTenantRequired() {
 				kvs := contexts.CREValue(ctx).LoggerKVs()
-				g.lggr.Warnw("Unable to get scoped gate status due to missing tenant: failing open", append([]any{"scope", g.scope}, kvs...)...)
+				g.lggr.Errorw("Unable to get scoped gate status due to missing tenant: failing open", append([]any{"scope", g.scope}, kvs...)...)
 				return
 			}
 			err = fmt.Errorf("unable to get scoped gate status due to missing tenant for scope: %s", g.scope)

--- a/pkg/settings/limits/range.go
+++ b/pkg/settings/limits/range.go
@@ -218,7 +218,7 @@ func (b *rangeLimiter[N]) get(ctx context.Context) (tenant string, bound setting
 		if tenant == "" {
 			if !b.scope.IsTenantRequired() {
 				kvs := contexts.CREValue(ctx).LoggerKVs()
-				b.lggr.Warnw("Unable to get scoped bounds limit due to missing tenant: failing open", append([]any{"scope", b.scope}, kvs...)...)
+				b.lggr.Errorw("Unable to get scoped bounds limit due to missing tenant: failing open", append([]any{"scope", b.scope}, kvs...)...)
 				return
 			}
 			err = fmt.Errorf("unable to get scoped bounds limit due to missing tenant for scope: %s", b.scope)

--- a/pkg/settings/limits/rate.go
+++ b/pkg/settings/limits/rate.go
@@ -435,7 +435,7 @@ func (s *scopedRateLimiter) getOrCreate(ctx context.Context) (RateLimiter, func(
 	if tenant == "" {
 		if !s.scope.IsTenantRequired() {
 			kvs := contexts.CREValue(ctx).LoggerKVs()
-			s.lggr.Warnw("Unable to apply scoped rate limit due to missing tenant: failing open", append([]any{"scope", s.scope}, kvs...)...)
+			s.lggr.Errorw("Unable to apply scoped rate limit due to missing tenant: failing open", append([]any{"scope", s.scope}, kvs...)...)
 			return UnlimitedRateLimiter(), s.wg.Done, nil
 		}
 		s.wg.Done()

--- a/pkg/settings/limits/resource.go
+++ b/pkg/settings/limits/resource.go
@@ -674,7 +674,7 @@ func (s *scopedResourcePoolLimiter[N]) getOrCreate(ctx context.Context) (resourc
 	if tenant == "" {
 		if !s.scope.IsTenantRequired() {
 			kvs := contexts.CREValue(ctx).LoggerKVs()
-			s.lggr.Warnw("Unable to apply scoped resource pool limit due to missing tenant: failing open", append([]any{"scope", s.scope}, kvs...)...)
+			s.lggr.Errorw("Unable to apply scoped resource pool limit due to missing tenant: failing open", append([]any{"scope", s.scope}, kvs...)...)
 			return unlimitedResourcePool[N]{}, s.wg.Done, nil
 		}
 		s.wg.Done()

--- a/pkg/settings/limits/time.go
+++ b/pkg/settings/limits/time.go
@@ -237,7 +237,7 @@ func (l *timeLimiter) get(ctx context.Context) (tenant string, timeout time.Dura
 		if tenant == "" {
 			if !l.scope.IsTenantRequired() {
 				kvs := contexts.CREValue(ctx).LoggerKVs()
-				l.lggr.Warnw("Unable to get scoped time limit due to missing tenant: failing open", append([]any{"scope", l.scope}, kvs...)...)
+				l.lggr.Errorw("Unable to get scoped time limit due to missing tenant: failing open", append([]any{"scope", l.scope}, kvs...)...)
 				return
 			}
 			err = fmt.Errorf("unable to get scoped time limit due to missing tenant for scope: %s", l.scope)

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -31,7 +31,6 @@ type Registry interface {
 	SubscribeScoped(ctx context.Context, scope Scope, key string) (updates <-chan Update[string], stop func())
 }
 
-// TODO use this everywhere
 type IsSetting[T any] interface {
 	GetSpec() SettingSpec[T]
 }

--- a/pkg/settings/toml.go
+++ b/pkg/settings/toml.go
@@ -3,12 +3,15 @@ package settings
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"strings"
 
 	"github.com/pelletier/go-toml"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 const generatedHeader = "# File generated from source files. DO NOT EDIT.\n"
@@ -134,25 +137,40 @@ func (t *tomlSettings) getFirst(keys ...string) (string, error) {
 
 var _ Getter = &tomlGetter{}
 
+// TODO https://smartcontract-it.atlassian.net/browse/CAPPL-775
+// NewTOMLRegistry with polling & subscriptions
 type tomlGetter struct {
 	settings *tomlSettings
+	lggr     logger.Logger
 }
 
 // NewTOMLGetter returns a static Getter backed by the given TOML.
-// TODO https://smartcontract-it.atlassian.net/browse/CAPPL-775
-// NewTOMLRegistry with polling & subscriptions
+// Deprecated: use GetterConfig.NewTOMLGetter to include a [logger.Logger]
 func NewTOMLGetter(b []byte) (Getter, error) {
+	return GetterConfig{}.NewTOMLGetter(b)
+}
+
+// NewTOMLGetter returns a static Getter backed by the given TOML.
+func (c GetterConfig) NewTOMLGetter(b []byte) (Getter, error) {
+	if c.Logger == nil {
+		c.Logger = logger.Nop()
+	}
 	s, err := newTOMLSettings(b)
 	if err != nil {
 		return nil, err
 	}
-	return &tomlGetter{settings: s}, nil
+	return &tomlGetter{settings: s, lggr: c.Logger}, nil
 }
 
 func (t *tomlGetter) GetScoped(ctx context.Context, scope Scope, key string) (value string, err error) {
 	keys, err := scope.rawKeys(ctx, key)
 	if err != nil {
-		return "", fmt.Errorf("failed to get raw keys: %w", err)
+		tme, ok := errors.AsType[tenantMissingError](err)
+		if ok && tme.Scope.IsTenantRequired() {
+			return "", fmt.Errorf("failed to get raw keys: %w", err)
+		} else {
+			t.lggr.Errorf("Settings lookup for "+key+" limited by missing tenant at scope "+tme.Scope.String(), "key", key, "err", err)
+		}
 	}
 	return t.settings.getFirst(keys...)
 }

--- a/pkg/settings/toml_test.go
+++ b/pkg/settings/toml_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 var update = flag.Bool("update", false, "update the golden files of this test")
@@ -53,7 +54,7 @@ func TestCombineTOMLFiles(t *testing.T) {
 func Test_tomlSettings_GetScoped(t *testing.T) {
 	s, err := newTOMLSettings([]byte(configTOML))
 	require.NoError(t, err)
-	r := tomlGetter{s}
+	r := tomlGetter{settings: s, lggr: logger.Test(t)}
 
 	ctx := contexts.WithCRE(t.Context(), contexts.CRE{
 		Org:      "123",

--- a/pkg/workflows/sdk/testutils/runtime.go
+++ b/pkg/workflows/sdk/testutils/runtime.go
@@ -14,8 +14,7 @@ func (nr *NoopRuntime) Fetch(sdk.FetchRequest) (sdk.FetchResponse, error) {
 }
 
 func (nr *NoopRuntime) Logger() logger.Logger {
-	l, _ := logger.New()
-	return l
+	return logger.Nop()
 }
 
 func (nr *NoopRuntime) Emitter() sdk.MessageEmitter {


### PR DESCRIPTION
Towards https://smartcontract-it.atlassian.net/browse/CRE-1707

Raise level, and add logs for when just doing a setting lookup, which was a silent failure before via omission of the key.

I also cleaned up some production loggers being used from tests (which just spams std out in real time, even when a test is passing)