### PR TITLE
chore: bump pkg/chipingress submodule to include batch histogram fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.100
-	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62
+	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260721054349-caf610156e92
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/smartcontractkit/chain-selectors v1.0.100 h1:wpiSpmI/eFjY+wx/nPr5VuNF4hki0prIBMKEaQWn3g4=
 github.com/smartcontractkit/chain-selectors v1.0.100/go.mod h1:qy7whtgG5g+7z0jt0nRyii9bLND9m15NZTzuQPkMZ5w=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62 h1:o7vfwNQjQbMKQ9YsZFQOxvU7RMXD/wKnZsX5N9sDS3w=
-github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260626151909-052e55e62e62/go.mod h1:HmUyH2oD9m+GRpKq7q3vuRnm1F2Uczf/Nd1v3ipMSK8=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260721054349-caf610156e92 h1:FsIM+pN3YgEfAWihnQSQ9RDl4RUMOyXiX9YtPvGg3jo=
+github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.11-0.20260721054349-caf610156e92/go.mod h1:UYcRMb4dZcoaIPgZJ3hckCySTqtJc9K4Q+tOKErwTq0=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4 h1:GCzrxDWn3b7jFfEA+WiYRi8CKoegsayiDoJBCjYkneE=
 github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20251024234028-0988426d98f4/go.mod h1:HHGeDUpAsPa0pmOx7wrByCitjQ0mbUxf0R9v+g67uCA=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b h1:VDgJWDipihV9f7M5+d21d1RzSsg5rEv+iI12oN1VQbo=


### PR DESCRIPTION
## Summary

Bump the `pkg/chipingress` submodule dependency in the main chainlink-common `go.mod` to include the histogram bucket changes that are part of the chip-ingress batch tuning work.

## Intent

`github.com/smartcontractkit/chainlink-common` depends on its own nested module `github.com/smartcontractkit/chainlink-common/pkg/chipingress`. PR #2207 updates the histogram bucket boundaries in `pkg/chipingress/batch/client.go`. Once #2207 merges, the main module must reference the new `pkg/chipingress` commit so that external consumers resolve the updated package instead of the older pre-#2207 version.

## Depends on

- #2207 — must merge first. After #2207 merges, the submodule reference here points to the squashed commit `caf610156`.

## Changes

- `go.mod`: bumped `github.com/smartcontractkit/chainlink-common/pkg/chipingress` from `v0.0.11-0.20260626151909-052e55e62e62` to `v0.0.11-0.20260721054349-caf610156e92`
- `go.sum`: updated checksums

## Testing

- `make gomodtidy`
- `go test ./pkg/chipingress/...`

## Notes

- This PR intentionally contains **only** the submodule bump; no application code changes.
- The submodule reference was refreshed to point to the squashed commit after #2207 was force-pushed to a single commit.
