### PR TITLE
go:fix inline

### DIFF
--- a/pkg/beholder/auth.go
+++ b/pkg/beholder/auth.go
@@ -70,8 +70,10 @@ func NewStaticAuth(headers map[string]string, requireTransportSecurity bool) Aut
 }
 
 // Deprecated: use NewStaticAuth instead
+//
+//go:fix inline
 func NewStaticAuthHeaderProvider(headers map[string]string) chipingress.HeaderProvider {
-	return &staticAuth{headers: headers}
+	return NewStaticAuth(headers, false)
 }
 
 type rotatingAuth struct {

--- a/pkg/beholder/batch_emitter_service_test.go
+++ b/pkg/beholder/batch_emitter_service_test.go
@@ -49,13 +49,13 @@ func TestNewChipIngressBatchEmitterService(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		clientMock := mocks.NewClient(t)
 		clientMock.EXPECT().Close().Return(nil).Maybe()
-		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, newTestConfig(), newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, newTestConfig(), logger.Test(t))
 		require.NoError(t, err)
 		assert.NotNil(t, emitter)
 	})
 
 	t.Run("returns error when client is nil", func(t *testing.T) {
-		emitter, err := beholder.NewChipIngressBatchEmitterService(nil, newTestConfig(), newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(nil, newTestConfig(), logger.Test(t))
 		assert.Error(t, err)
 		assert.Nil(t, emitter)
 	})
@@ -65,7 +65,7 @@ func TestChipIngressBatchEmitterService_Emit(t *testing.T) {
 	t.Run("returns error when domain/entity missing", func(t *testing.T) {
 		clientMock := mocks.NewClient(t)
 		clientMock.EXPECT().Close().Return(nil).Maybe()
-		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, newTestConfig(), newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, newTestConfig(), logger.Test(t))
 		require.NoError(t, err)
 		require.NoError(t, emitter.Start(t.Context()))
 		defer emitter.Close() //nolint:errcheck
@@ -93,7 +93,7 @@ func TestChipIngressBatchEmitterService_Emit(t *testing.T) {
 		cfg := newTestConfig()
 		cfg.ChipIngressSendInterval = 50 * time.Millisecond
 
-		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 		require.NoError(t, err)
 		require.NoError(t, emitter.Start(t.Context()))
 
@@ -142,7 +142,7 @@ func TestChipIngressBatchEmitterService_CloudEventFormat(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.ChipIngressSendInterval = 50 * time.Millisecond
 
-	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 	require.NoError(t, err)
 	require.NoError(t, emitter.Start(t.Context()))
 
@@ -188,7 +188,7 @@ func TestChipIngressBatchEmitterService_PublishBatchError(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.ChipIngressSendInterval = 50 * time.Millisecond
 
-	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 	require.NoError(t, err)
 	require.NoError(t, emitter.Start(t.Context()))
 
@@ -221,7 +221,7 @@ func TestChipIngressBatchEmitterService_ContextCancellation(t *testing.T) {
 	cfg.ChipIngressBufferSize = 1
 	cfg.ChipIngressSendInterval = 10 * time.Second
 
-	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 	require.NoError(t, err)
 	require.NoError(t, emitter.Start(t.Context()))
 	defer emitter.Close() //nolint:errcheck
@@ -251,7 +251,7 @@ func TestChipIngressBatchEmitterService_DefaultConfig(t *testing.T) {
 		}).
 		Return(nil, nil)
 
-	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, beholder.Config{}, newTestLogger(t))
+	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, beholder.Config{}, logger.Test(t))
 	require.NoError(t, err)
 	require.NoError(t, emitter.Start(t.Context()))
 
@@ -282,7 +282,7 @@ func TestChipIngressBatchEmitterService_EmitAfterClose(t *testing.T) {
 		Return(nil, nil).
 		Maybe()
 
-	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, newTestConfig(), newTestLogger(t))
+	emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, newTestConfig(), logger.Test(t))
 	require.NoError(t, err)
 	require.NoError(t, emitter.Start(t.Context()))
 	require.NoError(t, emitter.Close())
@@ -305,7 +305,7 @@ func TestChipIngressBatchEmitterService_EmitWithCallback(t *testing.T) {
 		cfg := newTestConfig()
 		cfg.ChipIngressSendInterval = 50 * time.Millisecond
 
-		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 		require.NoError(t, err)
 		require.NoError(t, emitter.Start(t.Context()))
 
@@ -338,7 +338,7 @@ func TestChipIngressBatchEmitterService_EmitWithCallback(t *testing.T) {
 		cfg := newTestConfig()
 		cfg.ChipIngressSendInterval = 50 * time.Millisecond
 
-		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 		require.NoError(t, err)
 		require.NoError(t, emitter.Start(t.Context()))
 
@@ -447,7 +447,7 @@ func TestChipIngressBatchEmitterService_EmitWithCallback(t *testing.T) {
 		cfg := newTestConfig()
 		cfg.ChipIngressSendInterval = 50 * time.Millisecond
 
-		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 		require.NoError(t, err)
 		require.NoError(t, emitter.Start(t.Context()))
 
@@ -542,7 +542,7 @@ func TestChipIngressBatchEmitterService_PartialDeliveryError(t *testing.T) {
 		cfg.ChipIngressMaxBatchSize = 1
 		cfg.ChipIngressSendInterval = time.Second
 
-		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 		require.NoError(t, err)
 		require.NoError(t, emitter.Start(t.Context()))
 
@@ -589,7 +589,7 @@ func TestChipIngressBatchEmitterService_RPCError(t *testing.T) {
 		cfg.ChipIngressMaxBatchSize = 1
 		cfg.ChipIngressSendInterval = time.Second
 
-		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 		require.NoError(t, err)
 		require.NoError(t, emitter.Start(t.Context()))
 
@@ -620,7 +620,6 @@ func TestChipIngressBatchEmitterService_RPCError(t *testing.T) {
 	})
 }
 
-
 func TestChipIngressBatchEmitterService_Metrics(t *testing.T) {
 	t.Run("records events_sent on successful publish", func(t *testing.T) {
 		reader, restore := useEmitterTestMeterProvider(t)
@@ -638,7 +637,7 @@ func TestChipIngressBatchEmitterService_Metrics(t *testing.T) {
 		cfg := newTestConfig()
 		cfg.ChipIngressMaxBatchSize = 1
 		cfg.ChipIngressSendInterval = time.Second
-		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, newTestLogger(t))
+		emitter, err := beholder.NewChipIngressBatchEmitterService(clientMock, cfg, logger.Test(t))
 		require.NoError(t, err)
 		require.NoError(t, emitter.Start(t.Context()))
 

--- a/pkg/beholder/client.go
+++ b/pkg/beholder/client.go
@@ -290,6 +290,8 @@ func (n noCloseEmitter) Close() error { return nil }
 
 // Returns a new Client with the same configuration but with a different package name
 // Deprecated: Use ForName
+//
+//go:fix inline
 func (c Client) ForPackage(name string) Client {
 	return c.ForName(name)
 }

--- a/pkg/beholder/client_test.go
+++ b/pkg/beholder/client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/chipingress"
 	chipmocks "github.com/smartcontractkit/chainlink-common/pkg/chipingress/mocks"
 	"github.com/smartcontractkit/chainlink-common/pkg/chipingress/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
@@ -947,7 +948,7 @@ func TestClient_batchEmitterService(t *testing.T) {
 			ChipIngressEmitterGRPCEndpoint: "localhost:9090",
 			ChipIngressInsecureConnection:  true,
 			ChipIngressBatchEmitterEnabled: true,
-			ChipIngressLogger:              newTestLogger(t),
+			ChipIngressLogger:              logger.Test(t),
 			ChipIngressBufferSize:          10,
 			ChipIngressMaxBatchSize:        5,
 			ChipIngressSendInterval:        50 * time.Millisecond,

--- a/pkg/capabilities/consensus/requests/store_test.go
+++ b/pkg/capabilities/consensus/requests/store_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/requests"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
 )
 
@@ -197,7 +196,7 @@ func TestOCR3Store_ReadRequestsCopy(t *testing.T) {
 		t.Run(tc.name, func(st *testing.T) {
 			st.Parallel()
 
-			gr := tc.get(tests.Context(st), rid)
+			gr := tc.get(st.Context(), rid)
 			require.NoError(t, err)
 
 			// Mutating the received observations doesn't mutate the store
@@ -206,7 +205,7 @@ func TestOCR3Store_ReadRequestsCopy(t *testing.T) {
 			gr.WorkflowExecutionID = "incorrect mutation"
 			assert.Len(t, gr.Observations.Underlying, 3)
 
-			gr2 := tc.get(tests.Context(st), rid)
+			gr2 := tc.get(st.Context(), rid)
 			assert.Equal(t, req, gr2)
 
 			gr.StopCh <- struct{}{}

--- a/pkg/config/configtest/defaults.go
+++ b/pkg/config/configtest/defaults.go
@@ -10,6 +10,8 @@ import (
 // Fields without defaults will set to zero values.
 // Arrays of tables are ignored.
 // Deprecated: use configdoc.DefaultsOnly
+//
+//go:fix inline
 func DocDefaultsOnly(r io.Reader, cfg any, decode func(io.Reader, any) error) error {
 	return configdoc.DefaultsOnly(r, cfg, decode)
 }

--- a/pkg/loop/internal/relayer/keystore_bench_test.go
+++ b/pkg/loop/internal/relayer/keystore_bench_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/relayer"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/internal/test"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 func BenchmarkKeystore_Sign(b *testing.B) {
@@ -47,7 +46,7 @@ func BenchmarkKeystore_Sign(b *testing.B) {
 		b.Run(tt.name, func(b *testing.B) {
 			ks := tt.ks()
 			b.Run("in-process", func(b *testing.B) {
-				ctx := tests.Context(b)
+				ctx := b.Context()
 				acct := "0x1234"
 				data := []byte("asdf")
 				for b.Loop() {
@@ -66,7 +65,7 @@ func BenchmarkKeystore_Sign(b *testing.B) {
 					b.ResetTimer()
 					defer b.StopTimer()
 
-					ctx := tests.Context(b)
+					ctx := b.Context()
 					acct := "0x1234"
 					data := []byte("asdf")
 					for b.Loop() {

--- a/pkg/loop/internal/test/test_plugin.go
+++ b/pkg/loop/internal/test/test_plugin.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/hashicorp/go-plugin"
 	"github.com/stretchr/testify/require"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 )
 
 type HelperProcessCommand struct {
@@ -46,7 +44,7 @@ func (h HelperProcessCommand) New() *exec.Cmd {
 }
 
 func PluginTest[TB testing.TB, I any](tb TB, name string, p plugin.Plugin, testFn func(TB, I)) {
-	ctx, cancel := context.WithCancel(tests.Context(tb))
+	ctx, cancel := context.WithCancel(tb.Context())
 	defer cancel()
 
 	ch := make(chan *plugin.ReattachConfig, 1)

--- a/pkg/loop/plugin_median.go
+++ b/pkg/loop/plugin_median.go
@@ -15,9 +15,13 @@ import (
 const PluginMedianName = "median"
 
 // Deprecated
+//
+//go:fix inline
 type PluginMedian = core.PluginMedian
 
 // Deprecated
+//
+//go:fix inline
 type ErrorLog = core.ErrorLog
 
 func PluginMedianHandshakeConfig() plugin.HandshakeConfig {
@@ -28,6 +32,8 @@ func PluginMedianHandshakeConfig() plugin.HandshakeConfig {
 }
 
 // Deprecated
+//
+//go:fix inline
 type ReportingPluginFactory = types.ReportingPluginFactory
 
 type GRPCPluginMedian struct {

--- a/pkg/loop/plugin_relayer.go
+++ b/pkg/loop/plugin_relayer.go
@@ -25,6 +25,8 @@ func PluginRelayerHandshakeConfig() plugin.HandshakeConfig {
 }
 
 // Deprecated
+//
+//go:fix inline
 type Keystore = core.Keystore
 
 type Relayer = looptypes.Relayer

--- a/pkg/loop/server.go
+++ b/pkg/loop/server.go
@@ -70,11 +70,15 @@ func MustNewStartedServer(loggerName string, opts ...ServerOpt) *Server {
 }
 
 // Deprecated: use NewStartedServer(loggerName, WithOtelViews(otelViews))
+//
+//go:fix inline
 func NewStartedServerWithOtelViews(loggerName string, otelViews []sdkmetric.View) (*Server, error) {
 	return NewStartedServer(loggerName, WithOtelViews(otelViews))
 }
 
 // Deprecated: use MustNewStartedServer(loggerName, WithOtelViews(otelViews))
+//
+//go:fix inline
 func MustNewStartedServerWithOtelViews(loggerName string, otelViews []sdkmetric.View) *Server {
 	return MustNewStartedServer(loggerName, WithOtelViews(otelViews))
 }
@@ -200,7 +204,7 @@ func (s *Server) start(opts ...ServerOpt) error {
 			ChipIngressLogger:              s.Logger,
 			MetricCompressor:               s.EnvConfig.TelemetryMetricCompressor,
 			MetricCardinalityLimit:         *s.EnvConfig.TelemetryMetricCardinalityLimit,
-			MetricViewsDenyAttributes:    s.EnvConfig.TelemetryMetricViewsDenyAttributes,
+			MetricViewsDenyAttributes:      s.EnvConfig.TelemetryMetricViewsDenyAttributes,
 		}
 
 		if s.EnvConfig.TelemetryPrometheusBridgeEnabled {

--- a/pkg/services/orgresolver/linking.go
+++ b/pkg/services/orgresolver/linking.go
@@ -56,12 +56,16 @@ type orgResolver struct {
 
 // NewOrgResolver creates a new org resolver with the specified configuration
 // Deprecated: Use Config.New
+//
+//go:fix inline
 func NewOrgResolver(cfg Config, logger log.Logger) (*orgResolver, error) {
 	return cfg.New(logger)
 }
 
 // NewOrgResolverWithClient creates a new org resolver with an optional injected client (for testing)
 // Deprecated: Use Config.New
+//
+//go:fix inlin
 func NewOrgResolverWithClient(cfg Config, client linkingclient.LinkingServiceClient, logger log.Logger) (*orgResolver, error) {
 	cfg.Client = client
 	return cfg.New(logger)

--- a/pkg/settings/limits/bound.go
+++ b/pkg/settings/limits/bound.go
@@ -23,6 +23,8 @@ type BoundLimiter[N Number] interface {
 }
 
 // Deprecated: use NewUpperBoundLimiter
+//
+//go:fix inline
 func NewBoundLimiter[N Number](bound N) BoundLimiter[N] {
 	return NewUpperBoundLimiter(bound)
 }

--- a/pkg/settings/limits/factory.go
+++ b/pkg/settings/limits/factory.go
@@ -25,6 +25,8 @@ type Factory struct {
 }
 
 // Deprecated: use MakeRateLimiter
+//
+//go:fix inline
 func (f Factory) NewRateLimiter(rate settings.Setting[config.Rate]) (RateLimiter, error) {
 	return f.MakeRateLimiter(rate)
 }
@@ -43,6 +45,8 @@ func (f Factory) MakeRateLimiter(rate settings.Setting[config.Rate]) (RateLimite
 }
 
 // Deprecated: use MakeTimeLimiter
+//
+//go:fix inline
 func (f Factory) NewTimeLimiter(timeout settings.Setting[time.Duration]) (TimeLimiter, error) {
 	return f.newTimeLimiter(timeout)
 }
@@ -60,6 +64,8 @@ func (f Factory) MakeTimeLimiter(timeout settings.Setting[time.Duration]) (TimeL
 }
 
 // Deprecated: use MakeResourcePoolLimiter
+//
+//go:fix inline
 func NewResourcePoolLimiter[N Number](f Factory, limit settings.Setting[N]) (ResourcePoolLimiter[N], error) {
 	return MakeResourcePoolLimiter(f, limit)
 }
@@ -78,6 +84,8 @@ func MakeResourcePoolLimiter[N Number](f Factory, limit settings.Setting[N]) (Re
 }
 
 // Deprecated: use MakeUpperBoundLimiter
+//
+//go:fix inline
 func MakeBoundLimiter[N Number](f Factory, bound settings.IsSetting[N]) (BoundLimiter[N], error) {
 	return MakeUpperBoundLimiter(f, bound)
 }

--- a/pkg/sqlutil/pg/pg.go
+++ b/pkg/sqlutil/pg/pg.go
@@ -140,9 +140,12 @@ type DialectName string
 
 const (
 	// Deprecated: Use DriverPostgres
+	//go:fix inline
 	Postgres DialectName = DriverPostgres
 	// Deprecated: Use DriverTxWrappedPostgres
+	//go:fix inline
 	TransactionWrappedPostgres DialectName = DriverTxWrappedPostgres
 	// Deprecated: Use DriverTxWrappedPostgres DriverInMemoryPostgres
+	//go:fix inline
 	InMemoryPostgres DialectName = DriverInMemoryPostgres
 )

--- a/pkg/types/provider.go
+++ b/pkg/types/provider.go
@@ -20,6 +20,8 @@ type ConfigProvider interface {
 
 // Plugin is an alias for PluginProvider, for compatibility.
 // Deprecated
+//
+//go:fix inline
 type Plugin = PluginProvider
 
 // PluginProvider provides common components for any OCR2 plugin.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -5,6 +5,8 @@ import (
 )
 
 // Deprecated: use services.Service
+//
+//go:fix inline
 type Service interface {
 	Name() string
 	Start(context.Context) error

--- a/pkg/utils/duration.go
+++ b/pkg/utils/duration.go
@@ -7,10 +7,16 @@ import (
 )
 
 // Deprecated: use config.Duration
+//
+//go:fix inline
 type Duration = config.Duration
 
 // Deprecated: use config.NewDuration
-func NewDuration(d time.Duration) (Duration, error) { return config.NewDuration(d) }
+//
+//go:fix inline
+func NewDuration(d time.Duration) (config.Duration, error) { return config.NewDuration(d) }
 
 // Deprecated: use config.MustNewDuration
-func MustNewDuration(d time.Duration) *Duration { return config.MustNewDuration(d) }
+//
+//go:fix inline
+func MustNewDuration(d time.Duration) *config.Duration { return config.MustNewDuration(d) }

--- a/pkg/utils/tests/beholder.go
+++ b/pkg/utils/tests/beholder.go
@@ -7,10 +7,13 @@ import (
 )
 
 // Deprecated: use beholdertest.Observer
+//
+//go:fix inline
 type BeholderTester = beholdertest.Observer
 
 // Deprecated: use beholdertest.NewObserver
-func Beholder(t *testing.T) BeholderTester {
-	t.Helper()
+//
+//go:fix inline
+func Beholder(t *testing.T) beholdertest.Observer {
 	return beholdertest.NewObserver(t)
 }

--- a/pkg/utils/testutils.go
+++ b/pkg/utils/testutils.go
@@ -11,6 +11,8 @@ import (
 )
 
 // Deprecated: use [*testing.T.Context]
+//
+//go:fix inline
 func Context(t *testing.T) context.Context {
 	return t.Context()
 }

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -3,10 +3,16 @@ package utils
 import "github.com/smartcontractkit/chainlink-common/pkg/config"
 
 // Deprecated: use config.URL
+//
+//go:fix inline
 type URL = config.URL
 
 // Deprecated: use config.ParseURL
-func ParseURL(s string) (*URL, error) { return config.ParseURL(s) }
+//
+//go:fix inline
+func ParseURL(s string) (*config.URL, error) { return config.ParseURL(s) }
 
 // Deprecated: use config.MustParseURL
-func MustParseURL(s string) *URL { return config.MustParseURL(s) }
+//
+//go:fix inline
+func MustParseURL(s string) *config.URL { return config.MustParseURL(s) }


### PR DESCRIPTION
Add more `go:fix inline` to deprecated identifiers, and run `gomods -go fix ./...`