### PR TITLE
fixing chip domain

### DIFF
--- a/pkg/resourcemanager/resourcemanager.go
+++ b/pkg/resourcemanager/resourcemanager.go
@@ -73,7 +73,7 @@ import (
 // the CHiP schema registration and the consumer topic name; all must match
 // exactly.
 const (
-	domain             = "cll-meter"
+	domain             = "cll.meter"
 	entity             = "metering.v1.MeterRecord"
 	dataSchema         = "metering.v1.meter_record"
 	snapshotEntity     = "metering.v1.MeterSnapshot"

--- a/pkg/resourcemanager/resourcemanager_test.go
+++ b/pkg/resourcemanager/resourcemanager_test.go
@@ -146,7 +146,7 @@ func TestEmitDelta_Success(t *testing.T) {
 	call := emitter.calls[0]
 	attrs := attrMap(t, call.attrKVs)
 	assert.Equal(t, "metering.v1.meter_record", attrs[beholder.AttrKeyDataSchema])
-	assert.Equal(t, "cll-meter", attrs[beholder.AttrKeyDomain])
+	assert.Equal(t, "cll.meter", attrs[beholder.AttrKeyDomain])
 	assert.Equal(t, "metering.v1.MeterRecord", attrs[beholder.AttrKeyEntity])
 
 	var record meteringpb.MeterRecord
@@ -265,8 +265,8 @@ func decodeSnapshots(t *testing.T, calls []emitCall) []*meteringpb.MeterSnapshot
 		if attrs[beholder.AttrKeyEntity] != "metering.v1.MeterSnapshot" {
 			continue
 		}
-		// Snapshots route on the cll-meter beholder domain, same as records.
-		assert.Equal(t, "cll-meter", attrs[beholder.AttrKeyDomain])
+		// Snapshots route on the cll.meter beholder domain, same as records.
+		assert.Equal(t, "cll.meter", attrs[beholder.AttrKeyDomain])
 		var s meteringpb.MeterSnapshot
 		require.NoError(t, proto.Unmarshal(c.body, &s))
 		snaps = append(snaps, &s)


### PR DESCRIPTION
`cll-meter` to `cll.meter`. Data platform team decided to change to implicitly create a topic hierarchy