### PR TITLE
Add limit for confidential relay handler timeout

### DIFF
--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -306,12 +306,22 @@ flowchart
         end
     end
 
+    subgraph HandleGatewayMessage[EnclaveRelayHandler.HandleGatewayMessage]
+%%      enclave → gateway → relay DON node. The server side of the exchange the
+%%      executor's ConfidentialCompute.EnclaveRequestTimeout bounds, so it is a
+%%      separate entry point rather than part of the executor subgraph above.
+        ConfidentialCompute.ConfidentialRelayHandlerTimeout>ConfidentialCompute.ConfidentialRelayHandlerTimeout]:::time
+    end
+
     handleRequest-->Store.FetchWorkflowArtifacts-->host.NewModule-->Engine.init-->Engine.runTriggerSubscriptionPhase-->triggers-->Engine.handleAllTriggerEvents-->Engine.startExecution
     Engine.startExecution-->ExecutionHelper.CallCapability-->actions
     Engine.startExecution-->PerWorkflow.SecretsConcurrencyLimit-->vault
 
 %%  DON nodes → gateway is a separate entry point, not connected to the trigger/execution chain above
     HandleNodeMessage
+
+%%  enclave → gateway → relay DON node is likewise its own entry point
+    HandleGatewayMessage
 
     classDef bound stroke:#f00
     classDef gate stroke:#0f0

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -54,6 +54,7 @@
 		"SecretsCacheEnabled": "false",
 		"EnclaveRequestTimeout": "30s",
 		"PublicKeyRequestTimeout": "5s",
+		"ConfidentialRelayHandlerTimeout": "60s",
 		"InsecureSkipTLSVerify": "false",
 		"EnclaveRefreshInterval": "10s",
 		"PublicKeyCache": {

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -54,7 +54,7 @@
 		"SecretsCacheEnabled": "false",
 		"EnclaveRequestTimeout": "30s",
 		"PublicKeyRequestTimeout": "5s",
-		"ConfidentialRelayHandlerTimeout": "60s",
+		"ConfidentialRelayHandlerTimeout": "1m0s",
 		"InsecureSkipTLSVerify": "false",
 		"EnclaveRefreshInterval": "10s",
 		"PublicKeyCache": {

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -54,6 +54,7 @@ RetryBackoff = '2s'
 SecretsCacheEnabled = 'false'
 EnclaveRequestTimeout = '30s'
 PublicKeyRequestTimeout = '5s'
+ConfidentialRelayHandlerTimeout = '60s'
 InsecureSkipTLSVerify = 'false'
 EnclaveRefreshInterval = '10s'
 

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -54,7 +54,7 @@ RetryBackoff = '2s'
 SecretsCacheEnabled = 'false'
 EnclaveRequestTimeout = '30s'
 PublicKeyRequestTimeout = '5s'
-ConfidentialRelayHandlerTimeout = '60s'
+ConfidentialRelayHandlerTimeout = '1m0s'
 InsecureSkipTLSVerify = 'false'
 EnclaveRefreshInterval = '10s'
 

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -143,14 +143,15 @@ var Default = Schema{
 	// mirror the previous hardcoded executor defaults so behavior is unchanged
 	// until explicitly overridden.
 	ConfidentialCompute: confidentialCompute{
-		GlobalRate:              Rate(rate.Limit(1000), 1000),
-		MaxRetries:              Int(3),
-		RetryBackoff:            Duration(2 * time.Second),
-		SecretsCacheEnabled:     Bool(false),
-		EnclaveRequestTimeout:   Duration(30 * time.Second),
-		PublicKeyRequestTimeout: Duration(5 * time.Second),
-		InsecureSkipTLSVerify:   Bool(false),
-		EnclaveRefreshInterval:  Duration(10 * time.Second),
+		GlobalRate:                      Rate(rate.Limit(1000), 1000),
+		MaxRetries:                      Int(3),
+		RetryBackoff:                    Duration(2 * time.Second),
+		SecretsCacheEnabled:             Bool(false),
+		EnclaveRequestTimeout:           Duration(30 * time.Second),
+		PublicKeyRequestTimeout:         Duration(5 * time.Second),
+		ConfidentialRelayHandlerTimeout: Duration(60 * time.Second),
+		InsecureSkipTLSVerify:           Bool(false),
+		EnclaveRefreshInterval:          Duration(10 * time.Second),
 		PublicKeyCache: ccPublicKeyCache{
 			Enabled:                 Bool(true),
 			TTL:                     Duration(5 * time.Minute),
@@ -546,6 +547,17 @@ type confidentialCompute struct {
 	SecretsCacheEnabled     Setting[bool]
 	EnclaveRequestTimeout   Setting[time.Duration]
 	PublicKeyRequestTimeout Setting[time.Duration]
+
+	// ConfidentialRelayHandlerTimeout bounds how long a relay-DON node may spend
+	// serving one confidential relay request from the gateway: attestation
+	// validation, the DON authorization checks, and the vault or capability call
+	// it proxies.
+	//
+	// This is the server side of the exchange EnclaveRequestTimeout bounds on the
+	// client side, so it should not exceed that value. The enclave derives its
+	// gateway HTTP timeout from EnclaveRequestTimeout, so a node still working
+	// past that point can only produce a response nobody is waiting for.
+	ConfidentialRelayHandlerTimeout Setting[time.Duration]
 
 	InsecureSkipTLSVerify  Setting[bool]
 	EnclaveRefreshInterval Setting[time.Duration]


### PR DESCRIPTION
## Summary

Adds a `ConfidentialRelayHandlerTimeout` setting (default `1m0s`) to the CRE `ConfidentialCompute` settings schema, bounding how long the relay DON's `HandleGatewayMessage` handler can run.

## Changes

- `pkg/settings/cresettings/settings.go`: add `ConfidentialRelayHandlerTimeout Setting[time.Duration]` (default 60s) to `confidentialCompute`.
- `defaults.json` / `defaults.toml`: add `ConfidentialRelayHandlerTimeout = "1m0s"`.
- `README.md`: add a `HandleGatewayMessage` subgraph to the settings flow diagram showing the timeout as a separate entry point from the executor subgraph.

## Why

The enclave → gateway → relay DON exchange is a separate server-side entry point from the executor's `EnclaveRequestTimeout`; without its own bound a stuck handler could hang indefinitely.
