### PR TITLE
Make TEE tests required in CRE standard tests

### DIFF
--- a/pkg/workflows/wasm/host/standard_test.go
+++ b/pkg/workflows/wasm/host/standard_test.go
@@ -685,7 +685,7 @@ func makeTestModuleWithConfig(t *testing.T, cfg *ModuleConfig) *module {
 	return makeTestModuleByName(t, testPath, testName, cfg, true)
 }
 
-// nolint:unused This function makes it easy to add tests that will become required later, but are optional now.
+// nolint:unused // This function makes it easy to add tests that will become required later, but are optional now.
 func makeOptionalTestModuleWithConfig(t *testing.T, cfg *ModuleConfig) *module {
 	testName := strcase.ToSnake(t.Name()[len("TestStandard"):])
 	return makeTestModuleByName(t, testPath, testName, cfg, false)

--- a/pkg/workflows/wasm/host/standard_test.go
+++ b/pkg/workflows/wasm/host/standard_test.go
@@ -569,7 +569,7 @@ func TestStandardTeeRuntime(t *testing.T) {
 	t.Parallel()
 
 	cfg := defaultNoDAGModCfg(t)
-	m := makeOptionalTestModuleWithConfig(t, cfg)
+	m := makeTestModuleWithConfig(t, cfg)
 	mockExecutionHelper := mocks.NewMockExecutionHelper(t)
 	mockExecutionHelper.EXPECT().GetWorkflowExecutionID().Return("id")
 	mockExecutionHelper.EXPECT().GetNodeTime().RunAndReturn(func() time.Time {
@@ -634,7 +634,7 @@ func TestStandardRestrictions(t *testing.T) {
 	// subscribe so pre-hooks are known.
 	// subscriptions are always done before the first trigger
 	subscribe := &sdk.ExecuteRequest{Request: &sdk.ExecuteRequest_Subscribe{Subscribe: &emptypb.Empty{}}}
-	underlying := makeOptionalTestModuleWithConfig(t, nil)
+	underlying := makeTestModuleWithConfig(t, nil)
 	m := host.NewRequirementSelectingModule(host.ModuleAndHandler{Module: underlying}, []host.ModuleAndHandler{})
 	_, err := m.Execute(t.Context(), subscribe, mockExecutionHelper)
 	require.NoError(t, err)
@@ -685,6 +685,7 @@ func makeTestModuleWithConfig(t *testing.T, cfg *ModuleConfig) *module {
 	return makeTestModuleByName(t, testPath, testName, cfg, true)
 }
 
+// nolint:unused This function makes it easy to add tests that will become required later, but are optional now.
 func makeOptionalTestModuleWithConfig(t *testing.T, cfg *ModuleConfig) *module {
 	testName := strcase.ToSnake(t.Name()[len("TestStandard"):])
 	return makeTestModuleByName(t, testPath, testName, cfg, false)


### PR DESCRIPTION
TEEs will be released soon, next cut of SDKs will have them. As such, make the tests required to enforce no regression when consumers use the new tag for the standard tests :).