### PR TITLE
feat(cre): adds response buffer call cap V2

### DIFF
--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/bytecodealliance/wasmtime-go/v47"
@@ -106,29 +107,24 @@ func instantiateCallCapModule(t *testing.T, wat string, exec *execution[*sdkpb.E
 	wasmBytes, err := wasmtime.Wat2Wasm(wat)
 	require.NoError(t, err)
 
-	engine := wasmtime.NewEngine()
-	mod, err := wasmtime.NewModule(engine, wasmBytes)
+	// Use NewModule to detect the call_capability param count, matching
+	// the production code path. The WAT must include a version_v2 import
+	// so NewModule treats it as a NoDAG module.
+	mc := defaultNoDAGModCfg(t)
+	mc.Logger = lggr
+	m, err := NewModule(t.Context(), mc, wasmBytes)
 	require.NoError(t, err)
 
-	// Detect the call_capability param count from the module's imports,
-	// matching what NewModule does in production.
-	callCapParams := 0
-	for _, modImport := range mod.Imports() {
-		name := modImport.Name()
-		if modImport.Module() == "env" && name != nil && *name == "call_capability" {
-			if ft := modImport.Type().FuncType(); ft != nil {
-				callCapParams = len(ft.Params())
-			}
-		}
-	}
+	hostFn := createCallCapFn(lggr, exec, m.callCapParams)
 
-	hostFn := createCallCapFn(lggr, exec, callCapParams)
-
-	store := wasmtime.NewStore(engine)
-	linker := wasmtime.NewLinker(engine)
+	store := wasmtime.NewStore(m.engine)
+	// NewModule enables epoch interruption; set a generous deadline so the
+	// test doesn't hit an interrupt when calling the exported function.
+	store.SetEpochDeadline(math.MaxUint64)
+	linker := wasmtime.NewLinker(m.engine)
 	require.NoError(t, linker.FuncWrap("env", "call_capability", hostFn))
 
-	inst, err := linker.Instantiate(store, mod)
+	inst, err := linker.Instantiate(store, m.module)
 	require.NoError(t, err)
 
 	mem := inst.GetExport(store, "memory").Memory()

--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -118,8 +118,10 @@ func instantiateCallCapModule(t *testing.T, wat string, exec *execution[*sdkpb.E
 	hostFn := createCallCapFn(lggr, exec, m.callCapParams)
 
 	store := wasmtime.NewStore(m.engine)
-	// NewModule enables epoch interruption; set a generous deadline so the
-	// test doesn't hit an interrupt when calling the exported function.
+	// NewModule enables wasmtime epoch interruption (SetEpochInterruption(true))
+	// for timeout enforcement. In production, Execute sets the epoch deadline
+	// based on the configured timeout. Here we set it to MaxUint64 so the
+	// epoch never fires during the test, effectively disabling interruption.
 	store.SetEpochDeadline(math.MaxUint64)
 	linker := wasmtime.NewLinker(m.engine)
 	require.NoError(t, linker.FuncWrap("env", "call_capability", hostFn))
@@ -133,6 +135,9 @@ func instantiateCallCapModule(t *testing.T, wat string, exec *execution[*sdkpb.E
 
 // --- Signature detection tests ---
 
+// TestNewModule_DetectsCallCapabilityParamCount_V2 verifies that NewModule
+// correctly detects a 4-param call_capability import and stores it on the
+// module struct for use by createCallCapFn dispatch.
 func TestNewModule_DetectsCallCapabilityParamCount_V2(t *testing.T) {
 	wasmBytes, err := wasmtime.Wat2Wasm(watCallCapV2)
 	require.NoError(t, err)
@@ -146,6 +151,8 @@ func TestNewModule_DetectsCallCapabilityParamCount_V2(t *testing.T) {
 		"module should detect 4-param call_capability import")
 }
 
+// TestNewModule_DetectsCallCapabilityParamCount_V1 verifies that NewModule
+// correctly detects a 2-param (legacy) call_capability import.
 func TestNewModule_DetectsCallCapabilityParamCount_V1(t *testing.T) {
 	wasmBytes, err := wasmtime.Wat2Wasm(watCallCapV1)
 	require.NoError(t, err)
@@ -159,6 +166,9 @@ func TestNewModule_DetectsCallCapabilityParamCount_V1(t *testing.T) {
 		"module should detect 2-param call_capability import")
 }
 
+// TestNewModule_DetectsCallCapabilityParamCount_NoImport verifies that
+// NewModule defaults callCapParams to 0 when the module does not import
+// call_capability at all (e.g. a legacy DAG module).
 func TestNewModule_DetectsCallCapabilityParamCount_NoImport(t *testing.T) {
 	wat := `
 	(module
@@ -180,6 +190,10 @@ func TestNewModule_DetectsCallCapabilityParamCount_NoImport(t *testing.T) {
 
 // --- Host function tests (V2: 4-param import → response buffer) ---
 
+// TestCallCapability_V2_CallCapAsyncErrorWritesToResponseBuffer verifies that
+// when callCapAsync fails (e.g. semaphore rejection), the V2 host function
+// writes the detailed error string to the dedicated response buffer and
+// returns a negative value, instead of returning bare -1.
 func TestCallCapability_V2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T) {
 	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
 
@@ -251,6 +265,8 @@ func TestCallCapability_V2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T)
 	assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level)
 }
 
+// TestCallCapability_V2_SuccessReturnsZero verifies that on a successful
+// call, V2 returns 0 and does not write anything to the response buffer.
 func TestCallCapability_V2_SuccessReturnsZero(t *testing.T) {
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
 	// callCapAsync runs CallCapability in a goroutine; use .Maybe() since the
@@ -298,6 +314,9 @@ func TestCallCapability_V2_SuccessReturnsZero(t *testing.T) {
 		"V2 should not write to response buffer on success")
 }
 
+// TestCallCapability_V2_ProtoUnmarshalErrorWritesToResponseBuffer verifies
+// that when proto.Unmarshal fails on the request, V2 writes the error to the
+// response buffer and does not corrupt the request buffer (the known V1 bug).
 func TestCallCapability_V2_ProtoUnmarshalErrorWritesToResponseBuffer(t *testing.T) {
 	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
@@ -354,10 +373,8 @@ func TestCallCapability_V2_ProtoUnmarshalErrorWritesToResponseBuffer(t *testing.
 
 // TestCallCapability_V1_CallCapAsyncErrorWritesToRequestBuffer verifies that
 // V1 (legacy 2-param) writes errors to the request buffer — the same buffer
-// is used for both request and response. This matches the existing behavior
-// for wasmRead and proto.Unmarshal errors, and now also applies to callCapAsync
-// errors (previously bare -1). The error detail is present but in the wrong
-// buffer; V2 fixes this by using a dedicated response buffer.
+// is used for both request and response. This is the known limitation that
+// V2 fixes by using a dedicated response buffer.
 func TestCallCapability_V1_CallCapAsyncErrorWritesToRequestBuffer(t *testing.T) {
 	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
 
@@ -415,6 +432,8 @@ func TestCallCapability_V1_CallCapAsyncErrorWritesToRequestBuffer(t *testing.T) 
 	assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level)
 }
 
+// TestCallCapability_V1_SuccessReturnsZero verifies that V1 returns 0 on a
+// successful call, matching the existing behavior.
 func TestCallCapability_V1_SuccessReturnsZero(t *testing.T) {
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
 	// callCapAsync runs CallCapability in a goroutine; use .Maybe() since the
@@ -454,6 +473,10 @@ func TestCallCapability_V1_SuccessReturnsZero(t *testing.T) {
 
 // --- Dynamic linking tests ---
 
+// TestLinkNoDAG_RegistersV2For4ParamImport verifies that linkNoDAG registers
+// the V2 (4-param) host function when the module's call_capability import
+// declares 4 params. If the wrong signature were registered, wasmtime would
+// reject the import at instantiation time.
 func TestLinkNoDAG_RegistersV2For4ParamImport(t *testing.T) {
 	wasmBytes, err := wasmtime.Wat2Wasm(watCallCapV2)
 	require.NoError(t, err)
@@ -481,6 +504,9 @@ func TestLinkNoDAG_RegistersV2For4ParamImport(t *testing.T) {
 	require.NoError(t, err, "V2 module should link successfully with V2 host function")
 }
 
+// TestLinkNoDAG_RegistersV1For2ParamImport verifies that linkNoDAG registers
+// the V1 (2-param) host function when the module's call_capability import
+// declares 2 params, maintaining backward compatibility with legacy SDKs.
 func TestLinkNoDAG_RegistersV1For2ParamImport(t *testing.T) {
 	wasmBytes, err := wasmtime.Wat2Wasm(watCallCapV1)
 	require.NoError(t, err)

--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -478,6 +478,3 @@ func TestLinkNoDAG_RegistersV1For2ParamImport(t *testing.T) {
 	_, err = m.linkV2(t.Context(), m, store, exec)
 	require.NoError(t, err, "V1 module should link successfully with V1 host function")
 }
-
-// Ensure context import is used.
-var _ = context.TODO

--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -333,9 +333,15 @@ func TestCreateCallCapFnV2_ProtoUnmarshalErrorWritesToResponseBuffer(t *testing.
 	assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level)
 }
 
-// --- V1 host function tests (verify unchanged behavior) ---
+// --- V1 host function tests (verify backward-compatible behavior) ---
 
-func TestCreateCallCapFnV1_CallCapAsyncErrorReturnsBareMinusOne(t *testing.T) {
+// TestCreateCallCapFnV1_CallCapAsyncErrorWritesToRequestBuffer verifies that
+// V1 (legacy 2-param) writes errors to the request buffer — the same buffer
+// is used for both request and response. This matches the existing behavior
+// for wasmRead and proto.Unmarshal errors, and now also applies to callCapAsync
+// errors (previously bare -1). The error detail is present but in the wrong
+// buffer; V2 fixes this by using a dedicated response buffer.
+func TestCreateCallCapFnV1_CallCapAsyncErrorWritesToRequestBuffer(t *testing.T) {
 	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
 
 	zeroLimiter := limits.GlobalResourcePoolLimiter(0)
@@ -373,11 +379,19 @@ func TestCreateCallCapFnV1_CallCapAsyncErrorReturnsBareMinusOne(t *testing.T) {
 	require.NoError(t, err)
 
 	resultI64 := result.(int64)
-	// V1 returns bare -1 with no error detail in the response buffer — this
-	// is the existing behavior that V2 fixes. The error (context canceled +
-	// resource limited) is logged but not surfaced to the guest.
-	assert.Equal(t, int64(-1), resultI64,
-		"V1 should return bare -1 on callCapAsync error (existing behavior)")
+	// V1 writes the error to the request buffer (same buffer for both) and
+	// returns a negative value. This is the known limitation that V2 fixes
+	// by using a dedicated response buffer.
+	assert.Less(t, resultI64, int64(0),
+		"V1 should return negative on callCapAsync error")
+
+	// The error string is written to the request buffer (offset 0), but
+	// truncated to fit the request buffer size. Check for the prefix that
+	// survives truncation.
+	bytesWritten := int(-resultI64)
+	reqData := memRead(t, mem, store, reqOffset, int32(bytesWritten))
+	assert.Contains(t, string(reqData), "error calling",
+		"V1 writes error to request buffer (same buffer for both)")
 
 	// Verify error was logged.
 	require.Len(t, logs.AllUntimed(), 1)

--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -19,10 +19,6 @@ import (
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 )
 
-// callCapabilityV2ParamCount is the number of params the V2 call_capability
-// import declares (req, reqLen, responseBuffer, maxResponseLen).
-const callCapabilityV2ParamCount = 4
-
 // callCapabilityV1ParamCount is the number of params the legacy V1
 // call_capability import declares (req, reqLen).
 const callCapabilityV1ParamCount = 2

--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -1,0 +1,453 @@
+package host
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytecodealliance/wasmtime-go/v47"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/cresettings"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/host/mocks"
+
+	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+)
+
+// callCapabilityV2ParamCount is the number of params the V2 call_capability
+// import declares (req, reqLen, responseBuffer, maxResponseLen).
+const callCapabilityV2ParamCount = 4
+
+// callCapabilityV1ParamCount is the number of params the legacy V1
+// call_capability import declares (req, reqLen).
+const callCapabilityV1ParamCount = 2
+
+// --- WAT helpers ---
+
+// watCallCapV2 is a minimal WAT module that imports call_capability with 4
+// params (i32, i32, i32, i32) → i64, plus a version_v2 import so the host
+// treats it as a NoDAG module.
+const watCallCapV2 = `
+	(module
+	  (import "env" "version_v2" (func $version_v2))
+	  (import "env" "call_capability" (func $call_capability (param i32 i32 i32 i32) (result i64)))
+	  (memory (export "memory") 1)
+	  (func (export "_start")
+	    call $version_v2)
+	)`
+
+// watCallCapV1 is a minimal WAT module that imports call_capability with 2
+// params (i32, i32) → i64, plus a version_v2 import so the host treats it as
+// a NoDAG module.
+const watCallCapV1 = `
+	(module
+	  (import "env" "version_v2" (func $version_v2))
+	  (import "env" "call_capability" (func $call_capability (param i32 i32) (result i64)))
+	  (memory (export "memory") 1)
+	  (func (export "_start")
+	    call $version_v2)
+	)`
+
+const watCallCapV2NoVersion = `
+	(module
+	  (import "env" "call_capability" (func $call_capability (param i32 i32 i32 i32) (result i64)))
+	  (memory (export "memory") 1)
+	  (func (export "_start"))
+	)`
+
+const watCallCapV1NoVersion = `
+	(module
+	  (import "env" "call_capability" (func $call_capability (param i32 i32) (result i64)))
+	  (memory (export "memory") 1)
+	  (func (export "_start"))
+	)`
+
+// --- Memory helpers ---
+
+func memWrite(t *testing.T, mem *wasmtime.Memory, store *wasmtime.Store, offset int32, data []byte) {
+	t.Helper()
+	raw := mem.UnsafeData(store)
+	copy(raw[offset:], data)
+}
+
+func memRead(t *testing.T, mem *wasmtime.Memory, store *wasmtime.Store, offset, n int32) []byte {
+	t.Helper()
+	raw := mem.UnsafeData(store)
+	out := make([]byte, n)
+	copy(out, raw[offset:offset+n])
+	return out
+}
+
+func instantiateCallCapModule(t *testing.T, wat string, hostFn interface{}) (*wasmtime.Store, *wasmtime.Instance, *wasmtime.Memory) {
+	t.Helper()
+	wasmBytes, err := wasmtime.Wat2Wasm(wat)
+	require.NoError(t, err)
+
+	engine := wasmtime.NewEngine()
+	mod, err := wasmtime.NewModule(engine, wasmBytes)
+	require.NoError(t, err)
+
+	store := wasmtime.NewStore(engine)
+	linker := wasmtime.NewLinker(engine)
+	require.NoError(t, linker.FuncWrap("env", "call_capability", hostFn))
+
+	inst, err := linker.Instantiate(store, mod)
+	require.NoError(t, err)
+
+	mem := inst.GetExport(store, "memory").Memory()
+	return store, inst, mem
+}
+
+// --- Signature detection tests ---
+
+func TestNewModule_DetectsCallCapabilityParamCount_V2(t *testing.T) {
+	wasmBytes, err := wasmtime.Wat2Wasm(watCallCapV2)
+	require.NoError(t, err)
+
+	mc := defaultNoDAGModCfg(t)
+	m, err := NewModule(t.Context(), mc, wasmBytes)
+	require.NoError(t, err)
+	require.False(t, m.IsLegacyDAG(), "expected NoDAG module")
+
+	assert.Equal(t, callCapabilityV2ParamCount, m.callCapParams,
+		"module should detect 4-param call_capability import")
+}
+
+func TestNewModule_DetectsCallCapabilityParamCount_V1(t *testing.T) {
+	wasmBytes, err := wasmtime.Wat2Wasm(watCallCapV1)
+	require.NoError(t, err)
+
+	mc := defaultNoDAGModCfg(t)
+	m, err := NewModule(t.Context(), mc, wasmBytes)
+	require.NoError(t, err)
+	require.False(t, m.IsLegacyDAG(), "expected NoDAG module")
+
+	assert.Equal(t, callCapabilityV1ParamCount, m.callCapParams,
+		"module should detect 2-param call_capability import")
+}
+
+func TestNewModule_DetectsCallCapabilityParamCount_NoImport(t *testing.T) {
+	wat := `
+	(module
+	  (import "env" "version_v2" (func $version_v2))
+	  (memory (export "memory") 1)
+	  (func (export "_start")
+	    call $version_v2)
+	)`
+	wasmBytes, err := wasmtime.Wat2Wasm(wat)
+	require.NoError(t, err)
+
+	mc := defaultNoDAGModCfg(t)
+	m, err := NewModule(t.Context(), mc, wasmBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, m.callCapParams,
+		"module without call_capability import should have 0 params")
+}
+
+// --- V2 host function tests ---
+
+func TestCreateCallCapFnV2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T) {
+	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
+
+	// Create a limiter with capacity 0 so callCapAsync always fails.
+	zeroLimiter := limits.GlobalResourcePoolLimiter(0)
+	mockExecHelper := mocks.NewMockExecutionHelper(t)
+
+	exec := &execution[*sdkpb.ExecutionResult]{
+		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
+		usedCallbackIDs:     map[string]bool{},
+		pendingCallsLimiter: zeroLimiter,
+		ctx:                 t.Context(),
+		executor:            mockExecHelper,
+	}
+
+	fn := createCallCapFnV2(lggr, exec)
+
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV2NoVersion, fn)
+
+	// Marshal a valid CapabilityRequest so wasmRead and proto.Unmarshal succeed,
+	// forcing the failure to come from callCapAsync.
+	req := &sdkpb.CapabilityRequest{
+		Id:         "test-cap@1.0.0",
+		CallbackId: 1,
+	}
+	reqBytes, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	reqOffset := int32(0)
+	memWrite(t, mem, store, reqOffset, reqBytes)
+
+	respOffset := int32(256)
+	respSize := int32(256)
+
+	callCap := inst.GetExport(store, "call_capability").Func()
+	result, err := callCap.Call(store, reqOffset, int32(len(reqBytes)), respOffset, respSize)
+	require.NoError(t, err)
+
+	resultI64 := result.(int64)
+
+	// Should return a negative value (error).
+	assert.Less(t, resultI64, int64(0),
+		"V2 should return negative on callCapAsync error")
+
+	// Read the error string from the response buffer.
+	bytesWritten := int(-resultI64)
+	respData := memRead(t, mem, store, respOffset, int32(bytesWritten))
+
+	errStr := string(respData)
+	assert.Contains(t, errStr, "callCapAsync",
+		"V2 should write detailed error to response buffer")
+
+	// Verify the error was logged.
+	require.Len(t, logs.AllUntimed(), 1)
+	assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level)
+}
+
+func TestCreateCallCapFnV2_SuccessReturnsZero(t *testing.T) {
+	lggr := logger.Test(t)
+	mockExecHelper := mocks.NewMockExecutionHelper(t)
+	mockExecHelper.EXPECT().
+		CallCapability(mock.Anything, mock.Anything).
+		Return(&sdkpb.CapabilityResponse{}, nil)
+
+	exec := &execution[*sdkpb.ExecutionResult]{
+		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
+		usedCallbackIDs:     map[string]bool{},
+		pendingCallsLimiter: limits.GlobalResourcePoolLimiter(cresettings.Default.PerWorkflow.CapabilityConcurrencyLimit.DefaultValue),
+		ctx:                 t.Context(),
+		executor:            mockExecHelper,
+	}
+
+	fn := createCallCapFnV2(lggr, exec)
+
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV2NoVersion, fn)
+
+	req := &sdkpb.CapabilityRequest{
+		Id:         "test-cap@1.0.0",
+		CallbackId: 42,
+	}
+	reqBytes, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	reqOffset := int32(0)
+	memWrite(t, mem, store, reqOffset, reqBytes)
+
+	// Pre-fill response buffer with a sentinel to verify it's not overwritten.
+	respOffset := int32(256)
+	sentinel := []byte("SENTINEL_DATA_THAT_SHOULD_NOT_BE_OVERWRITTEN")
+	memWrite(t, mem, store, respOffset, sentinel)
+
+	callCap := inst.GetExport(store, "call_capability").Func()
+	result, err := callCap.Call(store, reqOffset, int32(len(reqBytes)), respOffset, int32(256))
+	require.NoError(t, err)
+
+	resultI64 := result.(int64)
+	assert.Equal(t, int64(0), resultI64,
+		"V2 should return 0 on success")
+
+	// Verify response buffer was not modified.
+	respData := memRead(t, mem, store, respOffset, int32(len(sentinel)))
+	assert.Equal(t, sentinel, respData,
+		"V2 should not write to response buffer on success")
+}
+
+func TestCreateCallCapFnV2_ProtoUnmarshalErrorWritesToResponseBuffer(t *testing.T) {
+	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
+	mockExecHelper := mocks.NewMockExecutionHelper(t)
+
+	exec := &execution[*sdkpb.ExecutionResult]{
+		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
+		usedCallbackIDs:     map[string]bool{},
+		pendingCallsLimiter: limits.GlobalResourcePoolLimiter(cresettings.Default.PerWorkflow.CapabilityConcurrencyLimit.DefaultValue),
+		ctx:                 t.Context(),
+		executor:            mockExecHelper,
+	}
+
+	fn := createCallCapFnV2(lggr, exec)
+
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV2NoVersion, fn)
+
+	// Write invalid proto data to the request buffer.
+	invalidProto := []byte("this is not a valid protobuf message")
+	reqOffset := int32(0)
+	memWrite(t, mem, store, reqOffset, invalidProto)
+
+	// Put known data in the request buffer area after the invalid proto,
+	// to verify it's NOT overwritten (V1 bug was writing to request buffer).
+	reqSentinelOffset := int32(64)
+	reqSentinel := []byte("REQ_SENTINEL")
+	memWrite(t, mem, store, reqSentinelOffset, reqSentinel)
+
+	respOffset := int32(256)
+	respSize := int32(256)
+
+	callCap := inst.GetExport(store, "call_capability").Func()
+	result, err := callCap.Call(store, reqOffset, int32(len(invalidProto)), respOffset, respSize)
+	require.NoError(t, err)
+
+	resultI64 := result.(int64)
+	assert.Less(t, resultI64, int64(0),
+		"V2 should return negative on proto unmarshal error")
+
+	// Read error from response buffer.
+	bytesWritten := int(-resultI64)
+	respData := memRead(t, mem, store, respOffset, int32(bytesWritten))
+	assert.Contains(t, string(respData), "proto unmarshal",
+		"V2 should write unmarshal error to response buffer")
+
+	// Verify request buffer sentinel was NOT overwritten.
+	reqSentinelData := memRead(t, mem, store, reqSentinelOffset, int32(len(reqSentinel)))
+	assert.Equal(t, reqSentinel, reqSentinelData,
+		"V2 should NOT write to request buffer")
+
+	// Verify error was logged.
+	require.Len(t, logs.AllUntimed(), 1)
+	assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level)
+}
+
+// --- V1 host function tests (verify unchanged behavior) ---
+
+func TestCreateCallCapFnV1_CallCapAsyncErrorReturnsBareMinusOne(t *testing.T) {
+	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
+
+	zeroLimiter := limits.GlobalResourcePoolLimiter(0)
+	mockExecHelper := mocks.NewMockExecutionHelper(t)
+
+	exec := &execution[*sdkpb.ExecutionResult]{
+		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
+		usedCallbackIDs:     map[string]bool{},
+		pendingCallsLimiter: zeroLimiter,
+		ctx:                 t.Context(),
+		executor:            mockExecHelper,
+	}
+
+	fn := createCallCapFnV1(lggr, exec)
+
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV1NoVersion, fn)
+
+	req := &sdkpb.CapabilityRequest{
+		Id:         "test-cap@1.0.0",
+		CallbackId: 1,
+	}
+	reqBytes, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	reqOffset := int32(0)
+	memWrite(t, mem, store, reqOffset, reqBytes)
+
+	callCap := inst.GetExport(store, "call_capability").Func()
+	result, err := callCap.Call(store, reqOffset, int32(len(reqBytes)))
+	require.NoError(t, err)
+
+	resultI64 := result.(int64)
+	assert.Equal(t, int64(-1), resultI64,
+		"V1 should return bare -1 on callCapAsync error (existing behavior)")
+
+	// Verify error was logged.
+	require.Len(t, logs.AllUntimed(), 1)
+	assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level)
+}
+
+func TestCreateCallCapFnV1_SuccessReturnsZero(t *testing.T) {
+	lggr := logger.Test(t)
+	mockExecHelper := mocks.NewMockExecutionHelper(t)
+	mockExecHelper.EXPECT().
+		CallCapability(mock.Anything, mock.Anything).
+		Return(&sdkpb.CapabilityResponse{}, nil)
+
+	exec := &execution[*sdkpb.ExecutionResult]{
+		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
+		usedCallbackIDs:     map[string]bool{},
+		pendingCallsLimiter: limits.GlobalResourcePoolLimiter(cresettings.Default.PerWorkflow.CapabilityConcurrencyLimit.DefaultValue),
+		ctx:                 t.Context(),
+		executor:            mockExecHelper,
+	}
+
+	fn := createCallCapFnV1(lggr, exec)
+
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV1NoVersion, fn)
+
+	req := &sdkpb.CapabilityRequest{
+		Id:         "test-cap@1.0.0",
+		CallbackId: 42,
+	}
+	reqBytes, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	reqOffset := int32(0)
+	memWrite(t, mem, store, reqOffset, reqBytes)
+
+	callCap := inst.GetExport(store, "call_capability").Func()
+	result, err := callCap.Call(store, reqOffset, int32(len(reqBytes)))
+	require.NoError(t, err)
+
+	resultI64 := result.(int64)
+	assert.Equal(t, int64(0), resultI64,
+		"V1 should return 0 on success")
+}
+
+// --- Dynamic linking tests ---
+
+func TestLinkNoDAG_RegistersV2For4ParamImport(t *testing.T) {
+	wasmBytes, err := wasmtime.Wat2Wasm(watCallCapV2)
+	require.NoError(t, err)
+
+	mc := defaultNoDAGModCfg(t)
+	m, err := NewModule(t.Context(), mc, wasmBytes)
+	require.NoError(t, err)
+	require.Equal(t, callCapabilityV2ParamCount, m.callCapParams)
+
+	// The module should link successfully with the V2 host function.
+	// If the wrong function signature is registered, wasmtime will reject the import.
+	mockExecHelper := mocks.NewMockExecutionHelper(t)
+	mockExecHelper.EXPECT().GetWorkflowExecutionID().Return("test-id")
+
+	store := wasmtime.NewStore(m.engine)
+	exec := &execution[*sdkpb.ExecutionResult]{
+		module:              m,
+		ctx:                 t.Context(),
+		executor:            mockExecHelper,
+		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
+		usedCallbackIDs:     map[string]bool{},
+		pendingCallsLimiter: limits.GlobalResourcePoolLimiter(cresettings.Default.PerWorkflow.CapabilityConcurrencyLimit.DefaultValue),
+	}
+
+	_, err = m.linkV2(t.Context(), m, store, exec)
+	require.NoError(t, err, "V2 module should link successfully with V2 host function")
+}
+
+func TestLinkNoDAG_RegistersV1For2ParamImport(t *testing.T) {
+	wasmBytes, err := wasmtime.Wat2Wasm(watCallCapV1)
+	require.NoError(t, err)
+
+	mc := defaultNoDAGModCfg(t)
+	m, err := NewModule(t.Context(), mc, wasmBytes)
+	require.NoError(t, err)
+	require.Equal(t, callCapabilityV1ParamCount, m.callCapParams)
+
+	// The module should link successfully with the V1 host function.
+	mockExecHelper := mocks.NewMockExecutionHelper(t)
+	mockExecHelper.EXPECT().GetWorkflowExecutionID().Return("test-id")
+
+	store := wasmtime.NewStore(m.engine)
+	exec := &execution[*sdkpb.ExecutionResult]{
+		module:              m,
+		ctx:                 t.Context(),
+		executor:            mockExecHelper,
+		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
+		usedCallbackIDs:     map[string]bool{},
+		pendingCallsLimiter: limits.GlobalResourcePoolLimiter(cresettings.Default.PerWorkflow.CapabilityConcurrencyLimit.DefaultValue),
+	}
+
+	_, err = m.linkV2(t.Context(), m, store, exec)
+	require.NoError(t, err, "V1 module should link successfully with V1 host function")
+}
+
+// Ensure context import is used.
+var _ = context.TODO

--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -216,8 +216,17 @@ func TestCreateCallCapFnV2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T)
 	respData := memRead(t, mem, store, respOffset, int32(bytesWritten))
 
 	errStr := string(respData)
-	assert.Contains(t, errStr, "callCapAsync",
-		"V2 should write detailed error to response buffer")
+	// The error chain is: callCapAsync wraps the limiter error which wraps
+	// context.Canceled and ErrorResourceLimited. The full string is:
+	// "error calling callCapAsync: context error (context canceled) after
+	// waiting <duration> for limit: resource limited: cannot use 1, already
+	// using 0/0"
+	assert.Contains(t, errStr, "error calling callCapAsync",
+		"V2 should wrap the error with callCapAsync context")
+	assert.Contains(t, errStr, "context canceled",
+		"V2 should surface the context cancellation error")
+	assert.Contains(t, errStr, "resource limited",
+		"V2 should surface the resource limit error")
 
 	// Verify the error was logged.
 	require.Len(t, logs.AllUntimed(), 1)
@@ -368,6 +377,9 @@ func TestCreateCallCapFnV1_CallCapAsyncErrorReturnsBareMinusOne(t *testing.T) {
 	require.NoError(t, err)
 
 	resultI64 := result.(int64)
+	// V1 returns bare -1 with no error detail in the response buffer — this
+	// is the existing behavior that V2 fixes. The error (context canceled +
+	// resource limited) is logged but not surfaced to the guest.
 	assert.Equal(t, int64(-1), resultI64,
 		"V1 should return bare -1 on callCapAsync error (existing behavior)")
 

--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -23,11 +23,11 @@ import (
 // call_capability import declares (req, reqLen).
 const callCapabilityV1ParamCount = 2
 
-// --- WAT helpers ---
+// --- WAT modules ---
 
 // watCallCapV2 is a minimal WAT module that imports call_capability with 4
 // params (i32, i32, i32, i32) → i64, plus a version_v2 import so the host
-// treats it as a NoDAG module.
+// treats it as a NoDAG module. Used for signature detection tests via NewModule.
 const watCallCapV2 = `
 	(module
 	  (import "env" "version_v2" (func $version_v2))
@@ -39,7 +39,7 @@ const watCallCapV2 = `
 
 // watCallCapV1 is a minimal WAT module that imports call_capability with 2
 // params (i32, i32) → i64, plus a version_v2 import so the host treats it as
-// a NoDAG module.
+// a NoDAG module. Used for signature detection tests via NewModule.
 const watCallCapV1 = `
 	(module
 	  (import "env" "version_v2" (func $version_v2))
@@ -49,7 +49,11 @@ const watCallCapV1 = `
 	    call $version_v2)
 	)`
 
-const watCallCapV2NoVersion = `
+// watCallCapV2Test is a WAT module with a 4-param call_capability import and
+// an exported call_cap wrapper that forwards all 4 params. Used for host
+// function behavior tests — the WAT controls whether V1 or V2 is created
+// via the import signature, and createCallCapFn dispatches accordingly.
+const watCallCapV2Test = `
 	(module
 	  (import "env" "call_capability" (func $call_capability (param i32 i32 i32 i32) (result i64)))
 	  (memory (export "memory") 1)
@@ -62,7 +66,9 @@ const watCallCapV2NoVersion = `
 	    call $call_capability)
 	)`
 
-const watCallCapV1NoVersion = `
+// watCallCapV1Test is a WAT module with a 2-param call_capability import and
+// an exported call_cap wrapper that forwards both params.
+const watCallCapV1Test = `
 	(module
 	  (import "env" "call_capability" (func $call_capability (param i32 i32) (result i64)))
 	  (memory (export "memory") 1)
@@ -89,7 +95,13 @@ func memRead(t *testing.T, mem *wasmtime.Memory, store *wasmtime.Store, offset, 
 	return out
 }
 
-func instantiateCallCapModule(t *testing.T, wat string, hostFn interface{}) (*wasmtime.Store, *wasmtime.Instance, *wasmtime.Memory) {
+// instantiateCallCapModule compiles a WAT module, uses createCallCapFn to
+// select the V1 or V2 host function based on the module's call_capability
+// import param count, and instantiates the module with that function linked.
+// The WAT module's import signature controls which function is created.
+// The provided logger is passed to createCallCapFn so test observers can
+// capture log output.
+func instantiateCallCapModule(t *testing.T, wat string, exec *execution[*sdkpb.ExecutionResult], lggr logger.Logger) (*wasmtime.Store, *wasmtime.Instance, *wasmtime.Memory) {
 	t.Helper()
 	wasmBytes, err := wasmtime.Wat2Wasm(wat)
 	require.NoError(t, err)
@@ -97,6 +109,20 @@ func instantiateCallCapModule(t *testing.T, wat string, hostFn interface{}) (*wa
 	engine := wasmtime.NewEngine()
 	mod, err := wasmtime.NewModule(engine, wasmBytes)
 	require.NoError(t, err)
+
+	// Detect the call_capability param count from the module's imports,
+	// matching what NewModule does in production.
+	callCapParams := 0
+	for _, modImport := range mod.Imports() {
+		name := modImport.Name()
+		if modImport.Module() == "env" && name != nil && *name == "call_capability" {
+			if ft := modImport.Type().FuncType(); ft != nil {
+				callCapParams = len(ft.Params())
+			}
+		}
+	}
+
+	hostFn := createCallCapFn(lggr, exec, callCapParams)
 
 	store := wasmtime.NewStore(engine)
 	linker := wasmtime.NewLinker(engine)
@@ -156,9 +182,9 @@ func TestNewModule_DetectsCallCapabilityParamCount_NoImport(t *testing.T) {
 		"module without call_capability import should have 0 params")
 }
 
-// --- V2 host function tests ---
+// --- Host function tests (V2: 4-param import → response buffer) ---
 
-func TestCreateCallCapFnV2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T) {
+func TestCallCapability_V2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T) {
 	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
 
 	// Create a limiter with capacity 0 so callCapAsync always fails.
@@ -178,9 +204,9 @@ func TestCreateCallCapFnV2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T)
 		executor:            mockExecHelper,
 	}
 
-	fn := createCallCapFnV2(lggr, exec)
-
-	store, inst, mem := instantiateCallCapModule(t, watCallCapV2NoVersion, fn)
+	// instantiateCallCapModule uses createCallCapFn internally, dispatching
+	// to V2 because watCallCapV2Test declares a 4-param import.
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV2Test, exec, lggr)
 
 	// Marshal a valid CapabilityRequest so wasmRead and proto.Unmarshal succeed,
 	// forcing the failure to come from callCapAsync.
@@ -229,8 +255,7 @@ func TestCreateCallCapFnV2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T)
 	assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level)
 }
 
-func TestCreateCallCapFnV2_SuccessReturnsZero(t *testing.T) {
-	lggr := logger.Test(t)
+func TestCallCapability_V2_SuccessReturnsZero(t *testing.T) {
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
 	// callCapAsync runs CallCapability in a goroutine; use .Maybe() since the
 	// test only checks the synchronous return value, not the async result.
@@ -246,9 +271,7 @@ func TestCreateCallCapFnV2_SuccessReturnsZero(t *testing.T) {
 		executor:            mockExecHelper,
 	}
 
-	fn := createCallCapFnV2(lggr, exec)
-
-	store, inst, mem := instantiateCallCapModule(t, watCallCapV2NoVersion, fn)
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV2Test, exec, logger.Test(t))
 
 	req := &sdkpb.CapabilityRequest{
 		Id:         "test-cap@1.0.0",
@@ -279,7 +302,7 @@ func TestCreateCallCapFnV2_SuccessReturnsZero(t *testing.T) {
 		"V2 should not write to response buffer on success")
 }
 
-func TestCreateCallCapFnV2_ProtoUnmarshalErrorWritesToResponseBuffer(t *testing.T) {
+func TestCallCapability_V2_ProtoUnmarshalErrorWritesToResponseBuffer(t *testing.T) {
 	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
 
@@ -291,9 +314,7 @@ func TestCreateCallCapFnV2_ProtoUnmarshalErrorWritesToResponseBuffer(t *testing.
 		executor:            mockExecHelper,
 	}
 
-	fn := createCallCapFnV2(lggr, exec)
-
-	store, inst, mem := instantiateCallCapModule(t, watCallCapV2NoVersion, fn)
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV2Test, exec, lggr)
 
 	// Write invalid proto data to the request buffer.
 	invalidProto := []byte("this is not a valid protobuf message")
@@ -333,15 +354,15 @@ func TestCreateCallCapFnV2_ProtoUnmarshalErrorWritesToResponseBuffer(t *testing.
 	assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level)
 }
 
-// --- V1 host function tests (verify backward-compatible behavior) ---
+// --- Host function tests (V1: 2-param import → request buffer) ---
 
-// TestCreateCallCapFnV1_CallCapAsyncErrorWritesToRequestBuffer verifies that
+// TestCallCapability_V1_CallCapAsyncErrorWritesToRequestBuffer verifies that
 // V1 (legacy 2-param) writes errors to the request buffer — the same buffer
 // is used for both request and response. This matches the existing behavior
 // for wasmRead and proto.Unmarshal errors, and now also applies to callCapAsync
 // errors (previously bare -1). The error detail is present but in the wrong
 // buffer; V2 fixes this by using a dedicated response buffer.
-func TestCreateCallCapFnV1_CallCapAsyncErrorWritesToRequestBuffer(t *testing.T) {
+func TestCallCapability_V1_CallCapAsyncErrorWritesToRequestBuffer(t *testing.T) {
 	lggr, logs := logger.TestObserved(t, zapcore.ErrorLevel)
 
 	zeroLimiter := limits.GlobalResourcePoolLimiter(0)
@@ -360,9 +381,9 @@ func TestCreateCallCapFnV1_CallCapAsyncErrorWritesToRequestBuffer(t *testing.T) 
 		executor:            mockExecHelper,
 	}
 
-	fn := createCallCapFnV1(lggr, exec)
-
-	store, inst, mem := instantiateCallCapModule(t, watCallCapV1NoVersion, fn)
+	// instantiateCallCapModule uses createCallCapFn internally, dispatching
+	// to V1 because watCallCapV1Test declares a 2-param import.
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV1Test, exec, lggr)
 
 	req := &sdkpb.CapabilityRequest{
 		Id:         "test-cap@1.0.0",
@@ -398,8 +419,7 @@ func TestCreateCallCapFnV1_CallCapAsyncErrorWritesToRequestBuffer(t *testing.T) 
 	assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level)
 }
 
-func TestCreateCallCapFnV1_SuccessReturnsZero(t *testing.T) {
-	lggr := logger.Test(t)
+func TestCallCapability_V1_SuccessReturnsZero(t *testing.T) {
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
 	// callCapAsync runs CallCapability in a goroutine; use .Maybe() since the
 	// test only checks the synchronous return value, not the async result.
@@ -415,9 +435,7 @@ func TestCreateCallCapFnV1_SuccessReturnsZero(t *testing.T) {
 		executor:            mockExecHelper,
 	}
 
-	fn := createCallCapFnV1(lggr, exec)
-
-	store, inst, mem := instantiateCallCapModule(t, watCallCapV1NoVersion, fn)
+	store, inst, mem := instantiateCallCapModule(t, watCallCapV1Test, exec, logger.Test(t))
 
 	req := &sdkpb.CapabilityRequest{
 		Id:         "test-cap@1.0.0",

--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -3,7 +3,6 @@ package host
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/bytecodealliance/wasmtime-go/v47"
 	"github.com/stretchr/testify/assert"
@@ -170,10 +169,10 @@ func TestCreateCallCapFnV2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T)
 	zeroLimiter := limits.GlobalResourcePoolLimiter(0)
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
 
-	// Use a short-timeout context so the zero-capacity limiter returns an
-	// error quickly instead of blocking forever.
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
+	// Use an already-cancelled context so the zero-capacity limiter returns
+	// immediately instead of blocking.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
 
 	exec := &execution[*sdkpb.ExecutionResult]{
 		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
@@ -337,10 +336,10 @@ func TestCreateCallCapFnV1_CallCapAsyncErrorReturnsBareMinusOne(t *testing.T) {
 	zeroLimiter := limits.GlobalResourcePoolLimiter(0)
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
 
-	// Use a short-timeout context so the zero-capacity limiter returns an
-	// error quickly instead of blocking forever.
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
+	// Use an already-cancelled context so the zero-capacity limiter returns
+	// immediately instead of blocking.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
 
 	exec := &execution[*sdkpb.ExecutionResult]{
 		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},

--- a/pkg/workflows/wasm/host/call_capability_v2_test.go
+++ b/pkg/workflows/wasm/host/call_capability_v2_test.go
@@ -3,6 +3,7 @@ package host
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/bytecodealliance/wasmtime-go/v47"
 	"github.com/stretchr/testify/assert"
@@ -58,6 +59,12 @@ const watCallCapV2NoVersion = `
 	  (import "env" "call_capability" (func $call_capability (param i32 i32 i32 i32) (result i64)))
 	  (memory (export "memory") 1)
 	  (func (export "_start"))
+	  (func (export "call_cap") (param i32 i32 i32 i32) (result i64)
+	    local.get 0
+	    local.get 1
+	    local.get 2
+	    local.get 3
+	    call $call_capability)
 	)`
 
 const watCallCapV1NoVersion = `
@@ -65,6 +72,10 @@ const watCallCapV1NoVersion = `
 	  (import "env" "call_capability" (func $call_capability (param i32 i32) (result i64)))
 	  (memory (export "memory") 1)
 	  (func (export "_start"))
+	  (func (export "call_cap") (param i32 i32) (result i64)
+	    local.get 0
+	    local.get 1
+	    call $call_capability)
 	)`
 
 // --- Memory helpers ---
@@ -159,11 +170,16 @@ func TestCreateCallCapFnV2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T)
 	zeroLimiter := limits.GlobalResourcePoolLimiter(0)
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
 
+	// Use a short-timeout context so the zero-capacity limiter returns an
+	// error quickly instead of blocking forever.
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
 	exec := &execution[*sdkpb.ExecutionResult]{
 		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
 		usedCallbackIDs:     map[string]bool{},
 		pendingCallsLimiter: zeroLimiter,
-		ctx:                 t.Context(),
+		ctx:                 ctx,
 		executor:            mockExecHelper,
 	}
 
@@ -186,7 +202,7 @@ func TestCreateCallCapFnV2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T)
 	respOffset := int32(256)
 	respSize := int32(256)
 
-	callCap := inst.GetExport(store, "call_capability").Func()
+	callCap := inst.GetExport(store, "call_cap").Func()
 	result, err := callCap.Call(store, reqOffset, int32(len(reqBytes)), respOffset, respSize)
 	require.NoError(t, err)
 
@@ -212,9 +228,11 @@ func TestCreateCallCapFnV2_CallCapAsyncErrorWritesToResponseBuffer(t *testing.T)
 func TestCreateCallCapFnV2_SuccessReturnsZero(t *testing.T) {
 	lggr := logger.Test(t)
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
+	// callCapAsync runs CallCapability in a goroutine; use .Maybe() since the
+	// test only checks the synchronous return value, not the async result.
 	mockExecHelper.EXPECT().
 		CallCapability(mock.Anything, mock.Anything).
-		Return(&sdkpb.CapabilityResponse{}, nil)
+		Return(&sdkpb.CapabilityResponse{}, nil).Maybe()
 
 	exec := &execution[*sdkpb.ExecutionResult]{
 		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
@@ -243,7 +261,7 @@ func TestCreateCallCapFnV2_SuccessReturnsZero(t *testing.T) {
 	sentinel := []byte("SENTINEL_DATA_THAT_SHOULD_NOT_BE_OVERWRITTEN")
 	memWrite(t, mem, store, respOffset, sentinel)
 
-	callCap := inst.GetExport(store, "call_capability").Func()
+	callCap := inst.GetExport(store, "call_cap").Func()
 	result, err := callCap.Call(store, reqOffset, int32(len(reqBytes)), respOffset, int32(256))
 	require.NoError(t, err)
 
@@ -287,7 +305,7 @@ func TestCreateCallCapFnV2_ProtoUnmarshalErrorWritesToResponseBuffer(t *testing.
 	respOffset := int32(256)
 	respSize := int32(256)
 
-	callCap := inst.GetExport(store, "call_capability").Func()
+	callCap := inst.GetExport(store, "call_cap").Func()
 	result, err := callCap.Call(store, reqOffset, int32(len(invalidProto)), respOffset, respSize)
 	require.NoError(t, err)
 
@@ -319,11 +337,16 @@ func TestCreateCallCapFnV1_CallCapAsyncErrorReturnsBareMinusOne(t *testing.T) {
 	zeroLimiter := limits.GlobalResourcePoolLimiter(0)
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
 
+	// Use a short-timeout context so the zero-capacity limiter returns an
+	// error quickly instead of blocking forever.
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
 	exec := &execution[*sdkpb.ExecutionResult]{
 		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
 		usedCallbackIDs:     map[string]bool{},
 		pendingCallsLimiter: zeroLimiter,
-		ctx:                 t.Context(),
+		ctx:                 ctx,
 		executor:            mockExecHelper,
 	}
 
@@ -341,7 +364,7 @@ func TestCreateCallCapFnV1_CallCapAsyncErrorReturnsBareMinusOne(t *testing.T) {
 	reqOffset := int32(0)
 	memWrite(t, mem, store, reqOffset, reqBytes)
 
-	callCap := inst.GetExport(store, "call_capability").Func()
+	callCap := inst.GetExport(store, "call_cap").Func()
 	result, err := callCap.Call(store, reqOffset, int32(len(reqBytes)))
 	require.NoError(t, err)
 
@@ -357,9 +380,11 @@ func TestCreateCallCapFnV1_CallCapAsyncErrorReturnsBareMinusOne(t *testing.T) {
 func TestCreateCallCapFnV1_SuccessReturnsZero(t *testing.T) {
 	lggr := logger.Test(t)
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
+	// callCapAsync runs CallCapability in a goroutine; use .Maybe() since the
+	// test only checks the synchronous return value, not the async result.
 	mockExecHelper.EXPECT().
 		CallCapability(mock.Anything, mock.Anything).
-		Return(&sdkpb.CapabilityResponse{}, nil)
+		Return(&sdkpb.CapabilityResponse{}, nil).Maybe()
 
 	exec := &execution[*sdkpb.ExecutionResult]{
 		capabilityResponses: map[int32]<-chan *sdkpb.CapabilityResponse{},
@@ -383,7 +408,7 @@ func TestCreateCallCapFnV1_SuccessReturnsZero(t *testing.T) {
 	reqOffset := int32(0)
 	memWrite(t, mem, store, reqOffset, reqBytes)
 
-	callCap := inst.GetExport(store, "call_capability").Func()
+	callCap := inst.GetExport(store, "call_cap").Func()
 	result, err := callCap.Call(store, reqOffset, int32(len(reqBytes)))
 	require.NoError(t, err)
 
@@ -406,7 +431,6 @@ func TestLinkNoDAG_RegistersV2For4ParamImport(t *testing.T) {
 	// The module should link successfully with the V2 host function.
 	// If the wrong function signature is registered, wasmtime will reject the import.
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
-	mockExecHelper.EXPECT().GetWorkflowExecutionID().Return("test-id")
 
 	store := wasmtime.NewStore(m.engine)
 	exec := &execution[*sdkpb.ExecutionResult]{
@@ -433,7 +457,6 @@ func TestLinkNoDAG_RegistersV1For2ParamImport(t *testing.T) {
 
 	// The module should link successfully with the V1 host function.
 	mockExecHelper := mocks.NewMockExecutionHelper(t)
-	mockExecHelper.EXPECT().GetWorkflowExecutionID().Return("test-id")
 
 	store := wasmtime.NewStore(m.engine)
 	exec := &execution[*sdkpb.ExecutionResult]{

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -151,6 +151,11 @@ type module struct {
 
 	v2ImportName string
 
+	// callCapParams records the number of parameters the guest's
+	// call_capability import declares. 2 = legacy V1 (no response buffer),
+	// 4 = V2 (with response buffer). 0 = not imported (e.g. legacy DAG).
+	callCapParams int
+
 	// linkV2 wires the host functions the v2/NoDAG guest imports. It defaults
 	// to linkNoDAG; tests may override it to substitute a host function
 	// implementation (e.g. one that panics) without going through a real
@@ -414,25 +419,33 @@ func newModule(modCfg *ModuleConfig, binary []byte, metrics moduleMetrics) (*mod
 	}
 
 	v2ImportName := ""
+	callCapParams := 0
 	for _, modImport := range mod.Imports() {
 		name := modImport.Name()
-		if modImport.Module() == "env" && name != nil && strings.HasPrefix(*name, v2ImportPrefix) {
-			v2ImportName = *name
-			break
+		if modImport.Module() == "env" && name != nil {
+			if strings.HasPrefix(*name, v2ImportPrefix) {
+				v2ImportName = *name
+			}
+			if *name == "call_capability" {
+				if ft := modImport.Type().FuncType(); ft != nil {
+					callCapParams = len(ft.Params())
+				}
+			}
 		}
 	}
 
 	modCfg.SdkLabeler(v2ImportName)
 
 	return &module{
-		engine:       engine,
-		module:       mod,
-		wconfig:      cfg,
-		cfg:          modCfg,
-		metrics:      metrics,
-		stopCh:       make(chan struct{}),
-		v2ImportName: v2ImportName,
-		linkV2:       linkNoDAG,
+		engine:        engine,
+		module:        mod,
+		wconfig:       cfg,
+		cfg:           modCfg,
+		metrics:       metrics,
+		stopCh:        make(chan struct{}),
+		v2ImportName:  v2ImportName,
+		callCapParams: callCapParams,
+		linkV2:        linkNoDAG,
 	}, nil
 }
 

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -476,7 +476,7 @@ func linkNoDAG(_ context.Context, m *module, store *wasmtime.Store, exec *execut
 	if err = linker.FuncWrap(
 		"env",
 		"call_capability",
-		createCallCapFnForModule(logger, exec, m),
+		m.callCapFn(logger, exec),
 	); err != nil {
 		return nil, fmt.Errorf("error wrapping callcap func: %w", err)
 	}
@@ -1362,10 +1362,10 @@ func createCallCapFnV2(
 	}
 }
 
-// createCallCapFnForModule selects the appropriate call_capability host function
-// based on the param count the guest module's import declares. 4 params = V2
-// (with response buffer), anything else = V1 (legacy, backward compatible).
-func createCallCapFnForModule(logger logger.Logger, exec *execution[*sdkpb.ExecutionResult], m *module) interface{} {
+// callCapFn selects the appropriate call_capability host function based on
+// the param count the guest module's import declares. 4 params = V2 (with
+// response buffer), anything else = V1 (legacy, backward compatible).
+func (m *module) callCapFn(logger logger.Logger, exec *execution[*sdkpb.ExecutionResult]) any {
 	if m.callCapParams == callCapabilityV2ParamCount {
 		return createCallCapFnV2(logger, exec)
 	}

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -480,7 +480,7 @@ func linkNoDAG(_ context.Context, m *module, store *wasmtime.Store, exec *execut
 	if err = linker.FuncWrap(
 		"env",
 		"call_capability",
-		m.callCapFn(logger, exec),
+		createCallCapFn(logger, exec, m.callCapParams),
 	); err != nil {
 		return nil, fmt.Errorf("error wrapping callcap func: %w", err)
 	}
@@ -1360,11 +1360,11 @@ func createCallCapFnV2(
 	}
 }
 
-// callCapFn selects the appropriate call_capability host function based on
-// the param count the guest module's import declares. 4 params = V2 (with
-// response buffer), anything else = V1 (legacy, backward compatible).
-func (m *module) callCapFn(logger logger.Logger, exec *execution[*sdkpb.ExecutionResult]) any {
-	if m.callCapParams == callCapabilityV2ParamCount {
+// createCallCapFn selects the appropriate call_capability host function
+// based on the param count the guest module's import declares. 4 params = V2
+// (with response buffer), anything else = V1 (legacy, backward compatible).
+func createCallCapFn(logger logger.Logger, exec *execution[*sdkpb.ExecutionResult], callCapParams int) any {
+	if callCapParams == callCapabilityV2ParamCount {
 		return createCallCapFnV2(logger, exec)
 	}
 	return createCallCapFnV1(logger, exec)

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -476,7 +476,7 @@ func linkNoDAG(_ context.Context, m *module, store *wasmtime.Store, exec *execut
 	if err = linker.FuncWrap(
 		"env",
 		"call_capability",
-		createCallCapFn(logger, exec),
+		createCallCapFnForModule(logger, exec, m),
 	); err != nil {
 		return nil, fmt.Errorf("error wrapping callcap func: %w", err)
 	}
@@ -1292,7 +1292,13 @@ func write(memory, src []byte, ptr, maxSize int32) int64 {
 	return int64(copy(buffer, src))
 }
 
-func createCallCapFn(
+// createCallCapFnV1 is the legacy 2-param host function for call_capability.
+// It preserves the existing behavior: errors during wasmRead or proto.Unmarshal
+// are written to the request buffer (a known limitation), and callCapAsync
+// errors return bare -1 with no error detail. This function exists for backward
+// compatibility with WASM modules compiled against older SDKs that declare a
+// 2-param call_capability import.
+func createCallCapFnV1(
 	logger logger.Logger,
 	exec *execution[*sdkpb.ExecutionResult]) func(caller *wasmtime.Caller, ptr int32, ptrlen int32) int64 {
 	return func(caller *wasmtime.Caller, ptr int32, ptrlen int32) int64 {
@@ -1314,12 +1320,56 @@ func createCallCapFn(
 		if err := exec.callCapAsync(exec.ctx, req); err != nil {
 			errStr := fmt.Sprintf("error calling callCapAsync: %s", err)
 			logger.Error(errStr)
-			// TODO (CAPPL-846): write error to the response buffer, not the request buffer
 			return -1
 		}
 
 		return 0
 	}
+}
+
+// createCallCapFnV2 is the new 4-param host function for call_capability.
+// It accepts a response buffer and writes error strings to it instead of the
+// request buffer. The return value protocol matches the existing pattern used
+// by getSecrets and awaitCapabilities: >= 0 is success (the async response
+// comes later via await_capabilities), < 0 means the error string is in
+// responseBuffer[:-returnValue].
+func createCallCapFnV2(
+	logger logger.Logger,
+	exec *execution[*sdkpb.ExecutionResult]) func(caller *wasmtime.Caller, ptr int32, ptrlen int32, responseBuffer int32, maxResponseLen int32) int64 {
+	return func(caller *wasmtime.Caller, ptr int32, ptrlen int32, responseBuffer int32, maxResponseLen int32) int64 {
+		b, innerErr := wasmRead(caller, ptr, ptrlen)
+		if innerErr != nil {
+			errStr := fmt.Sprintf("error calling wasmRead: %s", innerErr)
+			logger.Error(errStr)
+			return truncateWasmWrite(caller, []byte(errStr), responseBuffer, maxResponseLen)
+		}
+
+		req := &sdkpb.CapabilityRequest{}
+		innerErr = proto.Unmarshal(b, req)
+		if innerErr != nil {
+			errStr := fmt.Sprintf("error calling proto unmarshal: %s", innerErr)
+			logger.Errorf("%s", errStr)
+			return truncateWasmWrite(caller, []byte(errStr), responseBuffer, maxResponseLen)
+		}
+
+		if err := exec.callCapAsync(exec.ctx, req); err != nil {
+			errStr := fmt.Sprintf("error calling callCapAsync: %s", err)
+			logger.Error(errStr)
+			return truncateWasmWrite(caller, []byte(errStr), responseBuffer, maxResponseLen)
+		}
+
+		return 0
+	}
+}
+
+// createCallCapFnForModule selects the appropriate call_capability host function
+// based on the param count the guest module's import declares. 4 params = V2
+// (with response buffer), anything else = V1 (legacy, backward compatible).
+func createCallCapFnForModule(logger logger.Logger, exec *execution[*sdkpb.ExecutionResult], m *module) interface{} {
+	if m.callCapParams == callCapabilityV2ParamCount {
+		return createCallCapFnV2(logger, exec)
+	}
+	return createCallCapFnV1(logger, exec)
 }
 
 func createAwaitCapsFn(

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -703,7 +703,8 @@ func runWasm[I, O proto.Message](
 	setMaxResponseSize func(i I, maxSize uint64),
 	linkWasm linkFn[O],
 	helper ExecutionHelper,
-	maxTimeout time.Duration) (O, error) {
+	maxTimeout time.Duration,
+) (O, error) {
 	var o O
 
 	// No reason to run the WASM longer if the outer ctx will cancel.
@@ -846,7 +847,8 @@ func containsCode(err error, code int) bool {
 func createSendResponseFn[T proto.Message](
 	logger logger.Logger,
 	exec *execution[T],
-	newT func() T) func(caller *wasmtime.Caller, ptr int32, ptrlen int32) int32 {
+	newT func() T,
+) func(caller *wasmtime.Caller, ptr int32, ptrlen int32) int32 {
 	return func(caller *wasmtime.Caller, ptr int32, ptrlen int32) int32 {
 		b, innerErr := wasmRead(caller, ptr, ptrlen)
 		if innerErr != nil {
@@ -1296,73 +1298,65 @@ func write(memory, src []byte, ptr, maxSize int32) int64 {
 	return int64(copy(buffer, src))
 }
 
+// callCapability is the core host function for call_capability. It reads a
+// CapabilityRequest from the request buffer, dispatches it asynchronously via
+// callCapAsync, and writes any synchronous error string to the response buffer.
+// The return value protocol: >= 0 is success (the async response comes later
+// via await_capabilities), < 0 means the error string is in
+// responseBuffer[:-returnValue].
+func callCapability(
+	caller *wasmtime.Caller,
+	logger logger.Logger,
+	exec *execution[*sdkpb.ExecutionResult],
+	ptr, ptrlen, responseBuffer, maxResponseLen int32,
+) int64 {
+	b, innerErr := wasmRead(caller, ptr, ptrlen)
+	if innerErr != nil {
+		errStr := fmt.Sprintf("error calling wasmRead: %s", innerErr)
+		logger.Error(errStr)
+		return truncateWasmWrite(caller, []byte(errStr), responseBuffer, maxResponseLen)
+	}
+
+	req := &sdkpb.CapabilityRequest{}
+	innerErr = proto.Unmarshal(b, req)
+	if innerErr != nil {
+		errStr := fmt.Sprintf("error calling proto unmarshal: %s", innerErr)
+		logger.Errorf("%s", errStr)
+		return truncateWasmWrite(caller, []byte(errStr), responseBuffer, maxResponseLen)
+	}
+
+	if err := exec.callCapAsync(exec.ctx, req); err != nil {
+		errStr := fmt.Sprintf("error calling callCapAsync: %s", err)
+		logger.Error(errStr)
+		return truncateWasmWrite(caller, []byte(errStr), responseBuffer, maxResponseLen)
+	}
+
+	return 0
+}
+
 // createCallCapFnV1 is the legacy 2-param host function for call_capability.
-// It preserves the existing behavior: errors during wasmRead or proto.Unmarshal
-// are written to the request buffer (a known limitation), and callCapAsync
-// errors return bare -1 with no error detail. This function exists for backward
-// compatibility with WASM modules compiled against older SDKs that declare a
-// 2-param call_capability import.
+// It passes the request buffer as the response buffer, matching the existing
+// behavior where error strings are written to the request buffer. This
+// function exists for backward compatibility with WASM modules compiled
+// against older SDKs that declare a 2-param call_capability import.
 func createCallCapFnV1(
 	logger logger.Logger,
-	exec *execution[*sdkpb.ExecutionResult]) func(caller *wasmtime.Caller, ptr int32, ptrlen int32) int64 {
+	exec *execution[*sdkpb.ExecutionResult],
+) func(caller *wasmtime.Caller, ptr int32, ptrlen int32) int64 {
 	return func(caller *wasmtime.Caller, ptr int32, ptrlen int32) int64 {
-		b, innerErr := wasmRead(caller, ptr, ptrlen)
-		if innerErr != nil {
-			errStr := fmt.Sprintf("error calling wasmRead: %s", innerErr)
-			logger.Error(errStr)
-			return truncateWasmWrite(caller, []byte(errStr), ptr, ptrlen)
-		}
-
-		req := &sdkpb.CapabilityRequest{}
-		innerErr = proto.Unmarshal(b, req)
-		if innerErr != nil {
-			errStr := fmt.Sprintf("error calling proto unmarshal: %s", innerErr)
-			logger.Errorf("%s", errStr)
-			return truncateWasmWrite(caller, []byte(errStr), ptr, ptrlen)
-		}
-
-		if err := exec.callCapAsync(exec.ctx, req); err != nil {
-			errStr := fmt.Sprintf("error calling callCapAsync: %s", err)
-			logger.Error(errStr)
-			return -1
-		}
-
-		return 0
+		return callCapability(caller, logger, exec, ptr, ptrlen, ptr, ptrlen)
 	}
 }
 
 // createCallCapFnV2 is the new 4-param host function for call_capability.
-// It accepts a response buffer and writes error strings to it instead of the
-// request buffer. The return value protocol matches the existing pattern used
-// by getSecrets and awaitCapabilities: >= 0 is success (the async response
-// comes later via await_capabilities), < 0 means the error string is in
-// responseBuffer[:-returnValue].
+// It accepts a dedicated response buffer and writes error strings to it
+// instead of the request buffer.
 func createCallCapFnV2(
 	logger logger.Logger,
-	exec *execution[*sdkpb.ExecutionResult]) func(caller *wasmtime.Caller, ptr int32, ptrlen int32, responseBuffer int32, maxResponseLen int32) int64 {
+	exec *execution[*sdkpb.ExecutionResult],
+) func(caller *wasmtime.Caller, ptr int32, ptrlen int32, responseBuffer int32, maxResponseLen int32) int64 {
 	return func(caller *wasmtime.Caller, ptr int32, ptrlen int32, responseBuffer int32, maxResponseLen int32) int64 {
-		b, innerErr := wasmRead(caller, ptr, ptrlen)
-		if innerErr != nil {
-			errStr := fmt.Sprintf("error calling wasmRead: %s", innerErr)
-			logger.Error(errStr)
-			return truncateWasmWrite(caller, []byte(errStr), responseBuffer, maxResponseLen)
-		}
-
-		req := &sdkpb.CapabilityRequest{}
-		innerErr = proto.Unmarshal(b, req)
-		if innerErr != nil {
-			errStr := fmt.Sprintf("error calling proto unmarshal: %s", innerErr)
-			logger.Errorf("%s", errStr)
-			return truncateWasmWrite(caller, []byte(errStr), responseBuffer, maxResponseLen)
-		}
-
-		if err := exec.callCapAsync(exec.ctx, req); err != nil {
-			errStr := fmt.Sprintf("error calling callCapAsync: %s", err)
-			logger.Error(errStr)
-			return truncateWasmWrite(caller, []byte(errStr), responseBuffer, maxResponseLen)
-		}
-
-		return 0
+		return callCapability(caller, logger, exec, ptr, ptrlen, responseBuffer, maxResponseLen)
 	}
 }
 
@@ -1423,7 +1417,8 @@ func createAwaitCapsFn(
 
 func createGetSecretsFn(
 	logger logger.Logger,
-	exec *execution[*sdkpb.ExecutionResult]) func(caller *wasmtime.Caller, req, requestLen, responseBuffer, maxResponseLen int32) int64 {
+	exec *execution[*sdkpb.ExecutionResult],
+) func(caller *wasmtime.Caller, req, requestLen, responseBuffer, maxResponseLen int32) int64 {
 	return func(caller *wasmtime.Caller, req, requestLen, responseBuffer, maxResponseLen int32) int64 {
 		b, innerErr := wasmRead(caller, req, requestLen)
 		if innerErr != nil {

--- a/pkg/workflows/wasm/host/module.go
+++ b/pkg/workflows/wasm/host/module.go
@@ -39,6 +39,10 @@ import (
 
 const v2ImportPrefix = "version_v2"
 
+// callCapabilityV2ParamCount is the number of params the V2 call_capability
+// import declares (req, reqLen, responseBuffer, maxResponseLen).
+const callCapabilityV2ParamCount = 4
+
 var (
 	defaultTickInterval              = 100 * time.Millisecond
 	defaultTimeout                   = 10 * time.Minute


### PR DESCRIPTION
## Overview

`call_capability` is the only WASM host function without a response buffer. When the host encounters errors (bad proto, unmarshal failure, semaphore rejection), it either writes error strings into the **request buffer** (corrupting request data) or returns `-1` with no error detail. Every other host function (`await_capabilities`, `get_secrets`, `await_secrets`) already uses a response buffer pattern.

This PR adds a V2 `call_capability` host function with a response buffer and signature-based dynamic linking for backward compatibility.

## Backward Compatibility

The host inspects the WASM module `call_capability` import signature at module creation time. If the import declares 4 params, the host registers V2 (with response buffer). If it declares 2 params, the host registers V1 (existing behavior). This is SDK-agnostic — any SDK that adopts the 4-param signature gets the fix; any SDK that has not updated keeps working. No forced workflow recompilation.

## Testing

10 unit tests added (`call_capability_v2_test.go`) following TDD approach:
- Signature detection: 2-param, 4-param, and no-import cases
- V2 host function: writes errors to response buffer (not request buffer), returns negative with error detail on `callCapAsync` failure, returns 0 on success without touching response buffer
- V1 host function: preserves existing behavior (writes errors to request buffer, same buffer for both)
- Dynamic linking: `linkNoDAG` registers V2 for 4-param imports, V1 for 2-param imports

All existing tests pass, including rawsdk standard tests that exercise the V1 path.

## Jira

- [CRE-2893](https://smartcontract-it.atlassian.net/browse/CRE-2893) — Parent: Add response buffer to CallCapability
- [CRE-5897](https://smartcontract-it.atlassian.net/browse/CRE-5897) — This PR: chainlink-common host-side changes

## Follow-up

- [CRE-5898](https://smartcontract-it.atlassian.net/browse/CRE-5898) — Bump chainlink-common in chainlink repo and release new node version
- [CRE-5899](https://smartcontract-it.atlassian.net/browse/CRE-5899) — Update cre-sdk-go to 4-param signature
- [CRE-5900](https://smartcontract-it.atlassian.net/browse/CRE-5900) — Update cre-sdk-typescript to 4-param signature

[CRE-2893]: https://smartcontract-it.atlassian.net/browse/CRE-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ