### PR TITLE
Removing ResourceIdentity() method

### DIFF
--- a/pkg/resourcemanager/meterable.go
+++ b/pkg/resourcemanager/meterable.go
@@ -13,14 +13,6 @@ import (
 // active resources, in addition to emitting request-time deltas inline via
 // EmitDelta / EmitUsage.
 type Meterable interface {
-	// ResourceIdentity returns the producer's base identity: the coarse
-	// dimensions (product, tenant, numeric_tenant_id, environment, zone, don, service) plus
-	// the service-level resource_pool / resource_pool_id. Per-resource billing
-	// fields (resource_type/resource_id/org_id/value) are carried by
-	// Utilizations on MeterRecord and MeterSnapshot; event_id is stamped by the
-	// ResourceManager at emit time.
-	ResourceIdentity() ResourceIdentity
-
 	// GetUtilization returns the current level of the producer's currently
 	// active resources, one SnapshotEntry per resource. The manager emits one
 	// MeterSnapshot per entry.

--- a/pkg/resourcemanager/resourcemanager_test.go
+++ b/pkg/resourcemanager/resourcemanager_test.go
@@ -63,8 +63,6 @@ type fakeMeterable struct {
 	entries []SnapshotEntry
 }
 
-func (f *fakeMeterable) ResourceIdentity() ResourceIdentity { return f.identity }
-
 func (f *fakeMeterable) GetUtilization(_ context.Context) []SnapshotEntry {
 	f.mu.Lock()
 	defer f.mu.Unlock()


### PR DESCRIPTION
Simplifies the iface, and there is no current need to export this outside of the ResourceManager as it calls Emit directly
