### PR TITLE
feat(vault): add BuildWorkflowGetSecretsRequestID

### DIFF
--- a/pkg/capabilities/actions/vault/request_id.go
+++ b/pkg/capabilities/actions/vault/request_id.go
@@ -1,0 +1,26 @@
+package vault
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+)
+
+const subscriptionPhaseKey = "subscription"
+
+// BuildWorkflowGetSecretsRequestID returns the pending-queue / OCR request ID for a
+// workflow GetSecrets call. This is the only place this format should be defined.
+//
+// We need to generate sufficiently unique IDs accounting for two cases:
+//  1. called during the subscription phase, in which case the executionID will be blank
+//  2. called during execution, in which case it'll be present.
+//
+// The reference ID is unique per phase, so we need to differentiate when generating
+// an ID.
+func BuildWorkflowGetSecretsRequestID(md capabilities.RequestMetadata) string {
+	phaseOrExecution := md.WorkflowExecutionID
+	if phaseOrExecution == "" {
+		phaseOrExecution = subscriptionPhaseKey
+	}
+	return fmt.Sprintf("%s::%s::%s", md.WorkflowID, phaseOrExecution, md.ReferenceID)
+}

--- a/pkg/capabilities/actions/vault/request_id_test.go
+++ b/pkg/capabilities/actions/vault/request_id_test.go
@@ -1,0 +1,52 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+)
+
+func TestBuildWorkflowGetSecretsRequestID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		md   capabilities.RequestMetadata
+		want string
+	}{
+		{
+			name: "execution path",
+			md: capabilities.RequestMetadata{
+				WorkflowID:          "wf-1",
+				WorkflowExecutionID: "abc123sha",
+				ReferenceID:         "42",
+			},
+			want: "wf-1::abc123sha::42",
+		},
+		{
+			name: "subscription path",
+			md: capabilities.RequestMetadata{
+				WorkflowID:  "wf-1",
+				ReferenceID: "7",
+			},
+			want: "wf-1::subscription::7",
+		},
+		{
+			name: "gate off empty workflow ID",
+			md: capabilities.RequestMetadata{
+				WorkflowExecutionID: "abc123sha",
+				ReferenceID:         "42",
+			},
+			want: "::abc123sha::42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, BuildWorkflowGetSecretsRequestID(tt.md))
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds `BuildWorkflowGetSecretsRequestID` (and its tests) to the shared vault capability package `pkg/capabilities/actions/vault`.

## Why

The VaultDON `GetSecrets` request ID — `WorkflowID::<executionID|subscription>::ReferenceID` — is currently defined in `chainlink`'s `core/capabilities/vault/vaultutils`, and was recently **duplicated** into `chainlink-confidential-compute` (which is a minimal-TCB module that cannot import `chainlink/v2`).

This ID is the identifier used by the VaultDON OCR pending queue. Having one canonical definition here in `chainlink-common` — which both repos already depend on — lets a `GetSecrets` request be correlated end-to-end across the workflow engine, the conf-compute executor, and VaultDON, without keeping two copies of the format in sync.

## Follow-up

This is step 1 of 3. Once this merges:
- `chainlink` will replace `vaultutils.BuildWorkflowGetSecretsRequestID` with this function.
- `chainlink-confidential-compute` will drop its local copy and use this function.

The logic and test cases are moved verbatim from `chainlink`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)