### PR TITLE
Add FeatureWorkflowTagBackfillActivePeriod cresettings flag

### DIFF
--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -174,6 +174,7 @@ flowchart
         PerWorkflow.FeatureEVMWriteReportL1FeeActivePeriod[/PerWorkflow.FeatureEVMWriteReportL1FeeActivePeriod\]:::gate
         PerWorkflow.FeatureAptosWriteReportBlockTimestampActivePeriod[/PerWorkflow.FeatureAptosWriteReportBlockTimestampActivePeriod\]:::gate
         PerWorkflow.FeatureRequestHashIncludeWorkflowTagActivePeriod[/PerWorkflow.FeatureRequestHashIncludeWorkflowTagActivePeriod\]:::gate
+        PerWorkflow.FeatureWorkflowTagBackfillActivePeriod[/PerWorkflow.FeatureWorkflowTagBackfillActivePeriod\]:::gate
 
         PerWorkflow.ExecutionTimestampsEnabled-->PerWorkflow.FeatureMultiTriggerExecutionIDsActivePeriod-->PerWorkflow.ExecutionTimeout-->PerWorkflow.ExecutionResponseLimit
     end

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -211,6 +211,7 @@
 		"FeatureChainCapabilityHashBasedOCRActivePeriod": "[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]",
 		"FeatureEVMWriteReportL1FeeActivePeriod": "[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]",
 		"FeatureAptosWriteReportBlockTimestampActivePeriod": "[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]",
-		"FeatureRequestHashIncludeWorkflowTagActivePeriod": "[0001-01-01 00:00:00 +0000 UTC,2100-01-01 00:00:00 +0000 UTC]"
+		"FeatureRequestHashIncludeWorkflowTagActivePeriod": "[0001-01-01 00:00:00 +0000 UTC,2100-01-01 00:00:00 +0000 UTC]",
+		"FeatureWorkflowTagBackfillActivePeriod": "[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]"
 	}
 }

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -127,6 +127,7 @@ FeatureChainCapabilityHashBasedOCRActivePeriod = '[2100-01-01 00:00:00 +0000 UTC
 FeatureEVMWriteReportL1FeeActivePeriod = '[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]'
 FeatureAptosWriteReportBlockTimestampActivePeriod = '[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]'
 FeatureRequestHashIncludeWorkflowTagActivePeriod = '[0001-01-01 00:00:00 +0000 UTC,2100-01-01 00:00:00 +0000 UTC]'
+FeatureWorkflowTagBackfillActivePeriod = '[2100-01-01 00:00:00 +0000 UTC,2101-01-01 00:00:00 +0000 UTC]'
 
 [PerWorkflow.ChainAllowed]
 Default = 'false'

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -332,6 +332,14 @@ var Default = Schema{
 		FeatureRequestHashIncludeWorkflowTagActivePeriod: TimeRange(
 			time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC),
 			time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)),
+		// OFF by default: the workflow_specs_v2.workflow_tag reconcile backfill
+		// is intentionally disabled on a fresh deploy. Ops narrows the range to
+		// cover "now" only after FeatureRequestHashIncludeWorkflowTag is muted
+		// on every DON member, so DBs can heal without producing tag-driven
+		// hash divergence during the fill window.
+		FeatureWorkflowTagBackfillActivePeriod: TimeRange(
+			time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2101, 1, 1, 0, 0, 0, 0, time.UTC)),
 	},
 }
 
@@ -487,6 +495,7 @@ type Workflows struct {
 	FeatureEVMWriteReportL1FeeActivePeriod                  Setting[Range[config.Timestamp]]
 	FeatureAptosWriteReportBlockTimestampActivePeriod       Setting[Range[config.Timestamp]]
 	FeatureRequestHashIncludeWorkflowTagActivePeriod        Setting[Range[config.Timestamp]]
+	FeatureWorkflowTagBackfillActivePeriod                  Setting[Range[config.Timestamp]]
 }
 
 type cronTrigger struct {

--- a/pkg/settings/cresettings/settings_test.go
+++ b/pkg/settings/cresettings/settings_test.go
@@ -270,6 +270,18 @@ func TestFeatureRequestHashIncludeWorkflowTagActivePeriodKeyInit(t *testing.T) {
 	}, s.DefaultValue)
 }
 
+func TestFeatureWorkflowTagBackfillActivePeriodKeyInit(t *testing.T) {
+	s := Default.PerWorkflow.FeatureWorkflowTagBackfillActivePeriod
+
+	assert.Equal(t, "PerWorkflow.FeatureWorkflowTagBackfillActivePeriod", s.GetKey())
+	assert.Equal(t, settings.ScopeWorkflow, s.Scope)
+	assert.NotNil(t, s.Parse)
+	assert.Equal(t, settings.Range[config.Timestamp]{
+		Lower: config.Timestamp(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
+		Upper: config.Timestamp(time.Date(2101, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
+	}, s.DefaultValue)
+}
+
 func TestGatewayProxyDonIDKeyInit(t *testing.T) {
 	s := Default.PerWorkflow.HTTPAction.GatewayProxyDonID
 


### PR DESCRIPTION
Adds `PerWorkflow.FeatureWorkflowTagBackfillActivePeriod`,it gate for the chainlink-side `workflow_specs_v2.workflow_tag` reconciler backfill.

Needed for: https://github.com/smartcontractkit/chainlink/pull/23478