### PR TITLE
chore: add MaxPublicKeyRetries and MaxPublicKeyRetriesBackoff to CRESettings

### DIFF
--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -294,7 +294,7 @@ flowchart
         ConfidentialCompute.PublicKeyRequestTimeout>ConfidentialCompute.PublicKeyRequestTimeout]:::time
         ConfidentialCompute.InsecureSkipTLSVerify[/ConfidentialCompute.InsecureSkipTLSVerify\]:::gate
         ConfidentialCompute.EnclaveRefreshInterval>ConfidentialCompute.EnclaveRefreshInterval]:::time
-        ConfidentialCompute.MaxPublicKeyRetries{{ConfidentialCompute.MaxPublicKeyRetries}}:::bound
+        ConfidentialCompute.PublicKeyRetriesMax{{ConfidentialCompute.PublicKeyRetriesMax}}:::bound
         ConfidentialCompute.PublicKeyRetriesBackoff>ConfidentialCompute.PublicKeyRetriesBackoff:::time
         subgraph ConfidentialCompute.PublicKeyCache
             ConfidentialCompute.PublicKeyCache.Enabled[/Enabled\]:::gate

--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -295,7 +295,7 @@ flowchart
         ConfidentialCompute.InsecureSkipTLSVerify[/ConfidentialCompute.InsecureSkipTLSVerify\]:::gate
         ConfidentialCompute.EnclaveRefreshInterval>ConfidentialCompute.EnclaveRefreshInterval]:::time
         ConfidentialCompute.MaxPublicKeyRetries{{ConfidentialCompute.MaxPublicKeyRetries}}:::bound
-        ConfidentialCompute.MaxPublicKeyRetriesBackoffSeconds{{ConfidentialCompute.MaxPublicKeyRetriesBackoffSeconds}}:::bound
+        ConfidentialCompute.MaxPublicKeyRetriesBackoffSeconds>ConfidentialCompute.MaxPublicKeyRetriesBackoffSeconds]:::time
         subgraph ConfidentialCompute.PublicKeyCache
             ConfidentialCompute.PublicKeyCache.Enabled[/Enabled\]:::gate
             ConfidentialCompute.PublicKeyCache.TTL>TTL]:::time

--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -295,7 +295,7 @@ flowchart
         ConfidentialCompute.InsecureSkipTLSVerify[/ConfidentialCompute.InsecureSkipTLSVerify\]:::gate
         ConfidentialCompute.EnclaveRefreshInterval>ConfidentialCompute.EnclaveRefreshInterval]:::time
         ConfidentialCompute.MaxPublicKeyRetries{{ConfidentialCompute.MaxPublicKeyRetries}}:::bound
-        ConfidentialCompute.MaxPublicKeyRetriesBackoff>ConfidentialCompute.MMaxPublicKeyRetriesBackoff:::time
+        ConfidentialCompute.PublicKeyRetriesBackoff>ConfidentialCompute.MPublicKeyRetriesBackoff:::time
         subgraph ConfidentialCompute.PublicKeyCache
             ConfidentialCompute.PublicKeyCache.Enabled[/Enabled\]:::gate
             ConfidentialCompute.PublicKeyCache.TTL>TTL]:::time

--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -294,6 +294,8 @@ flowchart
         ConfidentialCompute.PublicKeyRequestTimeout>ConfidentialCompute.PublicKeyRequestTimeout]:::time
         ConfidentialCompute.InsecureSkipTLSVerify[/ConfidentialCompute.InsecureSkipTLSVerify\]:::gate
         ConfidentialCompute.EnclaveRefreshInterval>ConfidentialCompute.EnclaveRefreshInterval]:::time
+        ConfidentialCompute.MaxPublicKeyRetries{{ConfidentialCompute.MaxPublicKeyRetries}}:::bound
+        ConfidentialCompute.MaxPublicKeyRetriesBackoffSeconds{{ConfidentialCompute.MaxPublicKeyRetriesBackoffSeconds}}:::bound
         subgraph ConfidentialCompute.PublicKeyCache
             ConfidentialCompute.PublicKeyCache.Enabled[/Enabled\]:::gate
             ConfidentialCompute.PublicKeyCache.TTL>TTL]:::time

--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -295,7 +295,7 @@ flowchart
         ConfidentialCompute.InsecureSkipTLSVerify[/ConfidentialCompute.InsecureSkipTLSVerify\]:::gate
         ConfidentialCompute.EnclaveRefreshInterval>ConfidentialCompute.EnclaveRefreshInterval]:::time
         ConfidentialCompute.MaxPublicKeyRetries{{ConfidentialCompute.MaxPublicKeyRetries}}:::bound
-        ConfidentialCompute.PublicKeyRetriesBackoff>ConfidentialCompute.MPublicKeyRetriesBackoff:::time
+        ConfidentialCompute.PublicKeyRetriesBackoff>ConfidentialCompute.PublicKeyRetriesBackoff:::time
         subgraph ConfidentialCompute.PublicKeyCache
             ConfidentialCompute.PublicKeyCache.Enabled[/Enabled\]:::gate
             ConfidentialCompute.PublicKeyCache.TTL>TTL]:::time

--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -295,7 +295,7 @@ flowchart
         ConfidentialCompute.InsecureSkipTLSVerify[/ConfidentialCompute.InsecureSkipTLSVerify\]:::gate
         ConfidentialCompute.EnclaveRefreshInterval>ConfidentialCompute.EnclaveRefreshInterval]:::time
         ConfidentialCompute.MaxPublicKeyRetries{{ConfidentialCompute.MaxPublicKeyRetries}}:::bound
-        ConfidentialCompute.MaxPublicKeyRetriesBackoffSeconds>ConfidentialCompute.MaxPublicKeyRetriesBackoffSeconds]:::time
+        ConfidentialCompute.MaxPublicKeyRetriesBackoff>ConfidentialCompute.MMaxPublicKeyRetriesBackoff:::time
         subgraph ConfidentialCompute.PublicKeyCache
             ConfidentialCompute.PublicKeyCache.Enabled[/Enabled\]:::gate
             ConfidentialCompute.PublicKeyCache.TTL>TTL]:::time

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -61,7 +61,7 @@
 		"InsecureSkipTLSVerify": "false",
 		"EnclaveRefreshInterval": "10s",
 		"MaxPublicKeyRetries": "2",
-		"MaxPublicKeyRetriesBackoffSeconds": "5",
+		"MaxPublicKeyRetriesBackoffSeconds": "5s",
 		"PublicKeyCache": {
 			"Enabled": "true",
 			"TTL": "5m0s",

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -60,6 +60,8 @@
 		"ConfidentialRelayHandlerTimeout": "1m0s",
 		"InsecureSkipTLSVerify": "false",
 		"EnclaveRefreshInterval": "10s",
+		"MaxPublicKeyRetries": "2",
+		"MaxPublicKeyRetriesBackoffSeconds": "5",
 		"PublicKeyCache": {
 			"Enabled": "true",
 			"TTL": "5m0s",

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -60,7 +60,7 @@
 		"ConfidentialRelayHandlerTimeout": "1m0s",
 		"InsecureSkipTLSVerify": "false",
 		"EnclaveRefreshInterval": "10s",
-		"MaxPublicKeyRetries": "2",
+		"PublicKeyRetriesMax": "2",
 		"PublicKeyRetriesBackoff": "5s",
 		"PublicKeyCache": {
 			"Enabled": "true",

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -61,7 +61,7 @@
 		"InsecureSkipTLSVerify": "false",
 		"EnclaveRefreshInterval": "10s",
 		"MaxPublicKeyRetries": "2",
-		"MaxPublicKeyRetriesBackoffSeconds": "5s",
+		"MaxPublicKeyRetriesBackoff": "5s",
 		"PublicKeyCache": {
 			"Enabled": "true",
 			"TTL": "5m0s",

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -61,7 +61,7 @@
 		"InsecureSkipTLSVerify": "false",
 		"EnclaveRefreshInterval": "10s",
 		"MaxPublicKeyRetries": "2",
-		"MaxPublicKeyRetriesBackoff": "5s",
+		"PublicKeyRetriesBackoff": "5s",
 		"PublicKeyCache": {
 			"Enabled": "true",
 			"TTL": "5m0s",

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -61,7 +61,7 @@ ConfidentialRelayHandlerTimeout = '1m0s'
 InsecureSkipTLSVerify = 'false'
 EnclaveRefreshInterval = '10s'
 MaxPublicKeyRetries = '2'
-MaxPublicKeyRetriesBackoff = '5s'
+PublicKeyRetriesBackoff = '5s'
 
 [ConfidentialCompute.PublicKeyCache]
 Enabled = 'true'

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -61,7 +61,7 @@ ConfidentialRelayHandlerTimeout = '1m0s'
 InsecureSkipTLSVerify = 'false'
 EnclaveRefreshInterval = '10s'
 MaxPublicKeyRetries = '2'
-MaxPublicKeyRetriesBackoffSeconds = '5'
+MaxPublicKeyRetriesBackoffSeconds = '5s'
 
 [ConfidentialCompute.PublicKeyCache]
 Enabled = 'true'

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -60,6 +60,8 @@ PublicKeyRequestTimeout = '5s'
 ConfidentialRelayHandlerTimeout = '1m0s'
 InsecureSkipTLSVerify = 'false'
 EnclaveRefreshInterval = '10s'
+MaxPublicKeyRetries = '2'
+MaxPublicKeyRetriesBackoffSeconds = '5'
 
 [ConfidentialCompute.PublicKeyCache]
 Enabled = 'true'

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -61,7 +61,7 @@ ConfidentialRelayHandlerTimeout = '1m0s'
 InsecureSkipTLSVerify = 'false'
 EnclaveRefreshInterval = '10s'
 MaxPublicKeyRetries = '2'
-MaxPublicKeyRetriesBackoffSeconds = '5s'
+MaxPublicKeyRetriesBackoff = '5s'
 
 [ConfidentialCompute.PublicKeyCache]
 Enabled = 'true'

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -60,7 +60,7 @@ PublicKeyRequestTimeout = '5s'
 ConfidentialRelayHandlerTimeout = '1m0s'
 InsecureSkipTLSVerify = 'false'
 EnclaveRefreshInterval = '10s'
-MaxPublicKeyRetries = '2'
+PublicKeyRetriesMax = '2'
 PublicKeyRetriesBackoff = '5s'
 
 [ConfidentialCompute.PublicKeyCache]

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -586,7 +586,7 @@ type confidentialCompute struct {
 	InsecureSkipTLSVerify   Setting[bool]
 	EnclaveRefreshInterval  Setting[time.Duration]
 	MaxPublicKeyRetries     Setting[int] `unit:"{attempt}"`
-	PublicKeyRetriesBackoff Setting[int] `unit:"{second}"`
+	PublicKeyRetriesBackoff Setting[time.Duration]
 	PublicKeyCache          ccPublicKeyCache
 	Session                 ccSession
 }

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -156,7 +156,7 @@ var Default = Schema{
 		InsecureSkipTLSVerify:           Bool(false),
 		EnclaveRefreshInterval:          Duration(10 * time.Second),
 		MaxPublicKeyRetries:             Int(2),
-		MaxPublicKeyRetriesBackoff:      Duration(5 * time.Second),
+		PublicKeyRetriesBackoff:         Duration(5 * time.Second),
 		PublicKeyCache: ccPublicKeyCache{
 			Enabled:                 Bool(true),
 			TTL:                     Duration(5 * time.Minute),
@@ -583,12 +583,12 @@ type confidentialCompute struct {
 	// past that point can only produce a response nobody is waiting for.
 	ConfidentialRelayHandlerTimeout Setting[time.Duration]
 
-	InsecureSkipTLSVerify      Setting[bool]
-	EnclaveRefreshInterval     Setting[time.Duration]
-	MaxPublicKeyRetries        Setting[int] `unit:"{attempt}"`
-	MaxPublicKeyRetriesBackoff Setting[int] `unit:"{second}"`
-	PublicKeyCache             ccPublicKeyCache
-	Session                    ccSession
+	InsecureSkipTLSVerify   Setting[bool]
+	EnclaveRefreshInterval  Setting[time.Duration]
+	MaxPublicKeyRetries     Setting[int] `unit:"{attempt}"`
+	PublicKeyRetriesBackoff Setting[int] `unit:"{second}"`
+	PublicKeyCache          ccPublicKeyCache
+	Session                 ccSession
 }
 
 // ccPublicKeyCache holds executor-side enclave ephemeral public-key cache settings.

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -155,7 +155,7 @@ var Default = Schema{
 		ConfidentialRelayHandlerTimeout: Duration(60 * time.Second),
 		InsecureSkipTLSVerify:           Bool(false),
 		EnclaveRefreshInterval:          Duration(10 * time.Second),
-		MaxPublicKeyRetries:             Int(2),
+		PublicKeyRetriesMax:             Int(2),
 		PublicKeyRetriesBackoff:         Duration(5 * time.Second),
 		PublicKeyCache: ccPublicKeyCache{
 			Enabled:                 Bool(true),
@@ -585,7 +585,7 @@ type confidentialCompute struct {
 
 	InsecureSkipTLSVerify   Setting[bool]
 	EnclaveRefreshInterval  Setting[time.Duration]
-	MaxPublicKeyRetries     Setting[int] `unit:"{attempt}"`
+	PublicKeyRetriesMax     Setting[int] `unit:"{attempt}"`
 	PublicKeyRetriesBackoff Setting[time.Duration]
 	PublicKeyCache          ccPublicKeyCache
 	Session                 ccSession

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -156,7 +156,7 @@ var Default = Schema{
 		InsecureSkipTLSVerify:             Bool(false),
 		EnclaveRefreshInterval:            Duration(10 * time.Second),
 		MaxPublicKeyRetries:               Int(2),
-		MaxPublicKeyRetriesBackoffSeconds: Int(5),
+		MaxPublicKeyRetriesBackoffSeconds: Duration(5 * time.Second),
 		PublicKeyCache: ccPublicKeyCache{
 			Enabled:                 Bool(true),
 			TTL:                     Duration(5 * time.Minute),

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -146,17 +146,17 @@ var Default = Schema{
 	// mirror the previous hardcoded executor defaults so behavior is unchanged
 	// until explicitly overridden.
 	ConfidentialCompute: confidentialCompute{
-		GlobalRate:                        Rate(rate.Limit(1000), 1000),
-		MaxRetries:                        Int(3),
-		RetryBackoff:                      Duration(2 * time.Second),
-		SecretsCacheEnabled:               Bool(false),
-		EnclaveRequestTimeout:             Duration(30 * time.Second),
-		PublicKeyRequestTimeout:           Duration(5 * time.Second),
-		ConfidentialRelayHandlerTimeout:   Duration(60 * time.Second),
-		InsecureSkipTLSVerify:             Bool(false),
-		EnclaveRefreshInterval:            Duration(10 * time.Second),
-		MaxPublicKeyRetries:               Int(2),
-		MaxPublicKeyRetriesBackoffSeconds: Duration(5 * time.Second),
+		GlobalRate:                      Rate(rate.Limit(1000), 1000),
+		MaxRetries:                      Int(3),
+		RetryBackoff:                    Duration(2 * time.Second),
+		SecretsCacheEnabled:             Bool(false),
+		EnclaveRequestTimeout:           Duration(30 * time.Second),
+		PublicKeyRequestTimeout:         Duration(5 * time.Second),
+		ConfidentialRelayHandlerTimeout: Duration(60 * time.Second),
+		InsecureSkipTLSVerify:           Bool(false),
+		EnclaveRefreshInterval:          Duration(10 * time.Second),
+		MaxPublicKeyRetries:             Int(2),
+		MaxPublicKeyRetriesBackoff:      Duration(5 * time.Second),
 		PublicKeyCache: ccPublicKeyCache{
 			Enabled:                 Bool(true),
 			TTL:                     Duration(5 * time.Minute),
@@ -583,12 +583,12 @@ type confidentialCompute struct {
 	// past that point can only produce a response nobody is waiting for.
 	ConfidentialRelayHandlerTimeout Setting[time.Duration]
 
-	InsecureSkipTLSVerify             Setting[bool]
-	EnclaveRefreshInterval            Setting[time.Duration]
-	MaxPublicKeyRetries               Setting[int] `unit:"{attempt}"`
-	MaxPublicKeyRetriesBackoffSeconds Setting[int] `unit:"{second}"`
-	PublicKeyCache                    ccPublicKeyCache
-	Session                           ccSession
+	InsecureSkipTLSVerify      Setting[bool]
+	EnclaveRefreshInterval     Setting[time.Duration]
+	MaxPublicKeyRetries        Setting[int] `unit:"{attempt}"`
+	MaxPublicKeyRetriesBackoff Setting[int] `unit:"{second}"`
+	PublicKeyCache             ccPublicKeyCache
+	Session                    ccSession
 }
 
 // ccPublicKeyCache holds executor-side enclave ephemeral public-key cache settings.

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -146,15 +146,17 @@ var Default = Schema{
 	// mirror the previous hardcoded executor defaults so behavior is unchanged
 	// until explicitly overridden.
 	ConfidentialCompute: confidentialCompute{
-		GlobalRate:                      Rate(rate.Limit(1000), 1000),
-		MaxRetries:                      Int(3),
-		RetryBackoff:                    Duration(2 * time.Second),
-		SecretsCacheEnabled:             Bool(false),
-		EnclaveRequestTimeout:           Duration(30 * time.Second),
-		PublicKeyRequestTimeout:         Duration(5 * time.Second),
-		ConfidentialRelayHandlerTimeout: Duration(60 * time.Second),
-		InsecureSkipTLSVerify:           Bool(false),
-		EnclaveRefreshInterval:          Duration(10 * time.Second),
+		GlobalRate:                        Rate(rate.Limit(1000), 1000),
+		MaxRetries:                        Int(3),
+		RetryBackoff:                      Duration(2 * time.Second),
+		SecretsCacheEnabled:               Bool(false),
+		EnclaveRequestTimeout:             Duration(30 * time.Second),
+		PublicKeyRequestTimeout:           Duration(5 * time.Second),
+		ConfidentialRelayHandlerTimeout:   Duration(60 * time.Second),
+		InsecureSkipTLSVerify:             Bool(false),
+		EnclaveRefreshInterval:            Duration(10 * time.Second),
+		MaxPublicKeyRetries:               Int(2),
+		MaxPublicKeyRetriesBackoffSeconds: Int(5),
 		PublicKeyCache: ccPublicKeyCache{
 			Enabled:                 Bool(true),
 			TTL:                     Duration(5 * time.Minute),
@@ -581,10 +583,12 @@ type confidentialCompute struct {
 	// past that point can only produce a response nobody is waiting for.
 	ConfidentialRelayHandlerTimeout Setting[time.Duration]
 
-	InsecureSkipTLSVerify  Setting[bool]
-	EnclaveRefreshInterval Setting[time.Duration]
-	PublicKeyCache         ccPublicKeyCache
-	Session                ccSession
+	InsecureSkipTLSVerify             Setting[bool]
+	EnclaveRefreshInterval            Setting[time.Duration]
+	MaxPublicKeyRetries               Setting[int] `unit:"{attempt}"`
+	MaxPublicKeyRetriesBackoffSeconds Setting[int] `unit:"{second}"`
+	PublicKeyCache                    ccPublicKeyCache
+	Session                           ccSession
 }
 
 // ccPublicKeyCache holds executor-side enclave ephemeral public-key cache settings.


### PR DESCRIPTION
## Summary

Adds `PublicKeyRetriesMax` (default 2) and `PublicKeyRetriesBackoff` (default 5s) settings to the CRE `ConfidentialCompute` settings schema.

## Changes

- `pkg/settings/cresettings/settings.go`: add `PublicKeyRetriesMax Setting[int]` and `PublicKeyRetriesBackoff Setting[time.Duration]` to `confidentialCompute`.
- `defaults.json` / `defaults.toml`: add the two defaults.
- `README.md`: add both to the settings flow diagram.

## Why

Exposes the enclave public-keys fetch retry count and backoff as operator-tunable settings so transient publicKeys-path failures can be retried without code changes.
