### PR TITLE
Add callback ID to the SecretsRequestParams type

### DIFF
--- a/pkg/capabilities/v2/actions/confidentialrelay/types.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/types.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash"
 	"sort"
+	"strconv"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/teeattestation"
 	"github.com/smartcontractkit/libocr/ragep2p/peeridhelper"
@@ -54,6 +55,7 @@ type SecretsRequestParams struct {
 	Owner            string             `json:"owner"`            // Ethereum address (hex, 0x-prefixed)
 	ExecutionID      string             `json:"execution_id"`     // 32 bytes, hex-encoded
 	OrgID            string             `json:"org_id,omitempty"` // Organization identifier for org-based secret ownership
+	CallbackID       int                `json:"callback_id"`
 	Secrets          []SecretIdentifier `json:"secrets"`
 	EnclavePublicKey string             `json:"enclave_public_key"`
 	// EnclaveConfig is the enclave's current config, included so the relay can
@@ -393,6 +395,10 @@ func writeSecretsRequestParams(h hash.Hash, params SecretsRequestParams) {
 	writeString(h, params.ExecutionID)
 	writeString(h, params.OrgID)
 
+	if params.CallbackID != 0 {
+		writeInt(h, params.CallbackID)
+	}
+
 	secrets := append([]SecretIdentifier(nil), params.Secrets...)
 	sortSecretIdentifiers(secrets)
 
@@ -454,6 +460,10 @@ func sortSecretEntries(secrets []SecretEntry) {
 
 func writeString(h hash.Hash, s string) {
 	writeBytes(h, []byte(s))
+}
+
+func writeInt(h hash.Hash, i int) {
+	writeBytes(h, []byte(strconv.Itoa(i)))
 }
 
 func writeBytes(h hash.Hash, b []byte) {

--- a/pkg/capabilities/v2/actions/confidentialrelay/types.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/types.go
@@ -55,7 +55,7 @@ type SecretsRequestParams struct {
 	Owner            string             `json:"owner"`            // Ethereum address (hex, 0x-prefixed)
 	ExecutionID      string             `json:"execution_id"`     // 32 bytes, hex-encoded
 	OrgID            string             `json:"org_id,omitempty"` // Organization identifier for org-based secret ownership
-	CallbackID       int                `json:"callback_id"`
+	CallbackID       int                `json:"callback_id,omitempty"`
 	Secrets          []SecretIdentifier `json:"secrets"`
 	EnclavePublicKey string             `json:"enclave_public_key"`
 	// EnclaveConfig is the enclave's current config, included so the relay can

--- a/pkg/capabilities/v2/actions/confidentialrelay/types_test.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/types_test.go
@@ -54,6 +54,7 @@ func validSecretsParams() SecretsRequestParams {
 		Owner:            validOwnerA,
 		ExecutionID:      validExecutionID,
 		OrgID:            "org-1",
+		CallbackID:       7,
 		EnclavePublicKey: validEnclavePubKey,
 		EnclaveConfig:    validEnclaveConfigPtr(),
 		Attestation:      "att-a",
@@ -464,6 +465,45 @@ func TestCapabilityResponseHash_BindsEnclaveConfig(t *testing.T) {
 	c.F = params.EnclaveConfig.F + 1
 	changed.EnclaveConfig = &c
 	require.NotEqual(t, base, mustCapabilityHash(t, result, changed))
+}
+
+// TestSecretsResponseHash_BindsCallbackID proves that a non-zero CallbackID
+// is bound into the response signature hash. Two requests differing only in
+// CallbackID must produce different hashes, otherwise a signature over one
+// callback could be replayed against another.
+func TestSecretsResponseHash_BindsCallbackID(t *testing.T) {
+	result := SecretsResponseResult{
+		Secrets: []SecretEntry{
+			{ID: SecretIdentifier{Key: "alpha", Namespace: "ns-a"}, Ciphertext: "c", EncryptedShares: []string{"s"}},
+		},
+	}
+	base := mustSecretsHash(t, result, validSecretsParams())
+
+	changed := validSecretsParams()
+	changed.CallbackID = validSecretsParams().CallbackID + 1
+	require.NotEqual(t, base, mustSecretsHash(t, result, changed))
+}
+
+// TestSecretsResponseHash_CallbackIDZeroOmitted proves that a zero
+// CallbackID is omitted from the hash rather than encoded as "0", so a
+// request with CallbackID=0 hashes identically to one on an older protocol
+// that never set the field. It also confirms that zero and non-zero never
+// collide.
+func TestSecretsResponseHash_CallbackIDZeroOmitted(t *testing.T) {
+	result := SecretsResponseResult{
+		Secrets: []SecretEntry{
+			{ID: SecretIdentifier{Key: "alpha", Namespace: "ns-a"}, Ciphertext: "c", EncryptedShares: []string{"s"}},
+		},
+	}
+
+	pZeroA := validSecretsParams()
+	pZeroA.CallbackID = 0
+	pZeroB := validSecretsParams()
+	pZeroB.CallbackID = 0
+	require.Equal(t, mustSecretsHash(t, result, pZeroA), mustSecretsHash(t, result, pZeroB))
+
+	pNonZero := validSecretsParams()
+	require.NotEqual(t, mustSecretsHash(t, result, pZeroA), mustSecretsHash(t, result, pNonZero))
 }
 
 // TestSecretsResponseHash_StableUnderSignerReordering proves that the


### PR DESCRIPTION
## Summary

Adds a `CallbackID int` field to `SecretsRequestParams` and binds it into the secrets response signature hash.

## Changes

- `pkg/capabilities/v2/actions/confidentialrelay/types.go`: add `CallbackID` to `SecretsRequestParams`; write it into the hash via a new `writeInt` helper, but only when non-zero (so older protocols that never set it hash identically).
- `types_test.go`: `TestSecretsResponseHash_BindsCallbackID` (different IDs → different hashes) and `TestSecretsResponseHash_CallbackIDZeroOmitted` (zero is omitted, never collides with non-zero).

## Why

The relay DON needs to correlate a secrets response back to the originating callback. Binding the callback ID into the signed hash prevents a signature over one callback from being replayed against another.
