### PR TITLE
Add Stellar write max resource fee setting

### DIFF
--- a/pkg/chains/stellar/proto_helpers.go
+++ b/pkg/chains/stellar/proto_helpers.go
@@ -407,6 +407,7 @@ func ConvertSubmitTransactionRequestToProto(req stellar.SubmitTransactionRequest
 		Function:           req.Function,
 		Args:               args,
 		LedgerBoundsOffset: req.LedgerBoundsOffset,
+		MaxResourceFee:     req.MaxResourceFee,
 	}, nil
 }
 
@@ -433,6 +434,7 @@ func ConvertSubmitTransactionRequestFromProto(p *SubmitTransactionRequest) (stel
 		Function:           p.GetFunction(),
 		Args:               args,
 		LedgerBoundsOffset: p.GetLedgerBoundsOffset(),
+		MaxResourceFee:     p.GetMaxResourceFee(),
 	}, nil
 }
 

--- a/pkg/chains/stellar/stellar.pb.go
+++ b/pkg/chains/stellar/stellar.pb.go
@@ -1295,6 +1295,7 @@ type SubmitTransactionRequest struct {
 	Function           string                 `protobuf:"bytes,4,opt,name=function,proto3" json:"function,omitempty"`                                                  // Soroban function name
 	Args               []*scval.ScVal         `protobuf:"bytes,5,rep,name=args,proto3" json:"args,omitempty"`                                                          // Typed Soroban arguments
 	LedgerBoundsOffset uint32                 `protobuf:"varint,6,opt,name=ledger_bounds_offset,json=ledgerBoundsOffset,proto3" json:"ledger_bounds_offset,omitempty"` // Per-tx ledger-bounds override; 0 = use TXM default
+	MaxResourceFee     uint64                 `protobuf:"varint,7,opt,name=max_resource_fee,json=maxResourceFee,proto3" json:"max_resource_fee,omitempty"`             // Optional per-request Soroban resource-fee ceiling (stroops); 0 = use TXM default
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -1367,6 +1368,13 @@ func (x *SubmitTransactionRequest) GetArgs() []*scval.ScVal {
 func (x *SubmitTransactionRequest) GetLedgerBoundsOffset() uint32 {
 	if x != nil {
 		return x.LedgerBoundsOffset
+	}
+	return 0
+}
+
+func (x *SubmitTransactionRequest) GetMaxResourceFee() uint64 {
+	if x != nil {
+		return x.MaxResourceFee
 	}
 	return 0
 }
@@ -1922,7 +1930,7 @@ const file_stellar_proto_rawDesc = "" +
 	"\fTopicSegment\x12\x1c\n" +
 	"\bwildcard\x18\x01 \x01(\tH\x00R\bwildcard\x12F\n" +
 	"\x05scval\x18\x02 \x01(\v2..capabilities.blockchain.stellar.v1alpha.ScValH\x00R\x05scvalB\a\n" +
-	"\x05value\"\x99\x02\n" +
+	"\x05value\"\xc3\x02\n" +
 	"\x18SubmitTransactionRequest\x12'\n" +
 	"\x0fidempotency_key\x18\x01 \x01(\tR\x0eidempotencyKey\x12!\n" +
 	"\ffrom_address\x18\x02 \x01(\tR\vfromAddress\x12\x1f\n" +
@@ -1930,7 +1938,8 @@ const file_stellar_proto_rawDesc = "" +
 	"contractId\x12\x1a\n" +
 	"\bfunction\x18\x04 \x01(\tR\bfunction\x12B\n" +
 	"\x04args\x18\x05 \x03(\v2..capabilities.blockchain.stellar.v1alpha.ScValR\x04args\x120\n" +
-	"\x14ledger_bounds_offset\x18\x06 \x01(\rR\x12ledgerBoundsOffset\"\xf8\x02\n" +
+	"\x14ledger_bounds_offset\x18\x06 \x01(\rR\x12ledgerBoundsOffset\x12(\n" +
+	"\x10max_resource_fee\x18\a \x01(\x04R\x0emaxResourceFee\"\xf8\x02\n" +
 	"\x19SubmitTransactionResponse\x123\n" +
 	"\ttx_status\x18\x01 \x01(\x0e2\x16.loop.stellar.TxStatusR\btxStatus\x12\x17\n" +
 	"\atx_hash\x18\x02 \x01(\tR\x06txHash\x12,\n" +

--- a/pkg/chains/stellar/stellar.proto
+++ b/pkg/chains/stellar/stellar.proto
@@ -206,6 +206,7 @@ message SubmitTransactionRequest {
   string function            = 4;  // Soroban function name
   repeated capabilities.blockchain.stellar.v1alpha.ScVal args = 5;  // Typed Soroban arguments
   uint32 ledger_bounds_offset = 6; // Per-tx ledger-bounds override; 0 = use TXM default
+  uint64 max_resource_fee   = 7;  // Optional per-request Soroban resource-fee ceiling (stroops); 0 = use TXM default
 }
 
 enum TxStatus {

--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -222,6 +222,11 @@ flowchart
                 PerWorkflow.ChainWrite.Aptos.ReportSizeLimit{{ReportSizeLimit}}:::bound
                 PerWorkflow.ChainWrite.Aptos.GasLimit{{GasLimit}}:::bound
             end
+            subgraph Stellar
+                direction LR
+                PerWorkflow.ChainWrite.Stellar.ReportSizeLimit{{ReportSizeLimit}}:::bound
+                PerWorkflow.ChainWrite.Stellar.MaxResourceFee{{MaxResourceFee}}:::bound
+            end
         end
         subgraph PerWorkflow.ChainRead
             direction LR

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -168,6 +168,13 @@
 					"Default": "2000000",
 					"Values": {}
 				}
+			},
+			"Stellar": {
+				"ReportSizeLimit": "5kb",
+				"MaxResourceFee": {
+					"Default": "1000000",
+					"Values": {}
+				}
 			}
 		},
 		"ChainRead": {

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -182,6 +182,14 @@ Default = '2000000'
 
 [PerWorkflow.ChainWrite.Aptos.GasLimit.Values]
 
+[PerWorkflow.ChainWrite.Stellar]
+ReportSizeLimit = '5kb'
+
+[PerWorkflow.ChainWrite.Stellar.MaxResourceFee]
+Default = '1000000'
+
+[PerWorkflow.ChainWrite.Stellar.MaxResourceFee.Values]
+
 [PerWorkflow.ChainRead]
 CallLimit = '15'
 LogQueryBlockLimit = '100'

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -278,6 +278,10 @@ var Default = Schema{
 				ReportSizeLimit: Size(5 * config.KByte),
 				GasLimit:        PerChainSelector(Uint64(2_000_000), map[string]uint64{}),
 			},
+			Stellar: stellarChainWrite{
+				ReportSizeLimit: Size(5 * config.KByte),
+				MaxResourceFee: PerChainSelector(Uint64(1_000_000), map[string]uint64{}),
+			},
 		},
 		ChainRead: chainRead{
 			CallLimit:          Int(15),
@@ -530,9 +534,10 @@ type chainWrite struct {
 	TargetsLimit    Setting[int]         `unit:"{target}"`
 	ReportSizeLimit Setting[config.Size] // Deprecated
 
-	EVM    evmChainWrite
-	Solana solanaChainWrite
-	Aptos  aptosChainWrite
+	EVM     evmChainWrite
+	Solana  solanaChainWrite
+	Aptos   aptosChainWrite
+	Stellar stellarChainWrite
 }
 type solanaChainWrite struct {
 	ReportSizeLimit Setting[config.Size]
@@ -541,6 +546,10 @@ type solanaChainWrite struct {
 type aptosChainWrite struct {
 	ReportSizeLimit Setting[config.Size]
 	GasLimit        SettingMap[uint64] `unit:"{gas}"`
+}
+type stellarChainWrite struct {
+	ReportSizeLimit Setting[config.Size]
+	MaxResourceFee SettingMap[uint64] `unit:"{stroop}"`
 }
 type evmChainWrite struct {
 	TransactionGasLimit Setting[uint64]    `unit:"{gas}"` // Deprecated

--- a/pkg/types/chains/stellar/stellar.go
+++ b/pkg/types/chains/stellar/stellar.go
@@ -203,7 +203,7 @@ type SubmitTransactionRequest struct {
 	// LedgerBoundsOffset overrides the TXM's configured ledger bounds for this transaction.
 	// Zero means use the TXM default.
 	LedgerBoundsOffset uint32
-	// MaxResourceFee is the per-request ceiling, in stroops, on the Soroban resource fee for this transaction.
+	// MaxResourceFee is an optional per-request Soroban resource-fee ceiling, in stroops.
 	MaxResourceFee uint64
 }
 

--- a/pkg/types/chains/stellar/stellar.go
+++ b/pkg/types/chains/stellar/stellar.go
@@ -203,6 +203,8 @@ type SubmitTransactionRequest struct {
 	// LedgerBoundsOffset overrides the TXM's configured ledger bounds for this transaction.
 	// Zero means use the TXM default.
 	LedgerBoundsOffset uint32
+	// MaxResourceFee is the per-request ceiling, in stroops, on the Soroban resource fee for this transaction.
+	MaxResourceFee uint64
 }
 
 // TransactionStatus is the outcome of a submitted transaction.


### PR DESCRIPTION
Adds Stellar ChainWrite settings for ReportSizeLimit and MaxResourceFee, and exposes MaxResourceFee on Stellar SubmitTransactionRequest so downstream relayers can enforce a per-request Soroban resource-fee ceiling before submit.