### PR TITLE
Add async confidential relay methods

### DIFF
--- a/pkg/capabilities/v2/actions/confidentialrelay/types.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/types.go
@@ -10,6 +10,7 @@ import (
 	"hash"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/teeattestation"
 	"github.com/smartcontractkit/libocr/ragep2p/peeridhelper"
@@ -19,6 +20,12 @@ const (
 	MethodSecretsGet     = "confidential.secrets.get"
 	MethodCapabilityExec = "confidential.capability.execute"
 
+	// asyncSuffix marks the asynchronous (enclave-polled) variants of the relay methods
+	asyncSuffix = ".async"
+
+	MethodSecretsGetAsync     = MethodSecretsGet + asyncSuffix
+	MethodCapabilityExecAsync = MethodCapabilityExec + asyncSuffix
+
 	DomainSecretsGet     = "ConfidentialSecretsGet"
 	DomainCapabilityExec = "ConfidentialCapabilityExecute"
 
@@ -26,6 +33,18 @@ const (
 	// response hashes from other ed25519 payloads in the system.
 	RelayResponseSignaturePrefix = "CONFIDENTIAL_RELAY_PAYLOAD_"
 )
+
+// IsAsyncMethod reports whether method is one of the asynchronous (enclave-polled)
+// relay routes.
+func IsAsyncMethod(method string) bool {
+	return strings.HasSuffix(method, asyncSuffix)
+}
+
+// SyncMethod returns the synchronous route for method, stripping the async
+// suffix if present. Non-async methods are returned unchanged.
+func SyncMethod(method string) string {
+	return strings.TrimSuffix(method, asyncSuffix)
+}
 
 // EnclaveConfig mirrors the confidential-compute EnclaveConfig fields the
 // relay needs to verify against onchain DON state. The enclave fills this

--- a/pkg/capabilities/v2/actions/confidentialrelay/types.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/types.go
@@ -34,8 +34,8 @@ const (
 	RelayResponseSignaturePrefix = "CONFIDENTIAL_RELAY_PAYLOAD_"
 )
 
-// IsAsyncMethod reports whether method is one of the asynchronous (enclave-polled)
-// relay routes.
+// IsAsyncMethod reports whether method is an asynchronous (enclave-polled) relay route,
+// identified by the ".async" suffix.
 func IsAsyncMethod(method string) bool {
 	return strings.HasSuffix(method, asyncSuffix)
 }

--- a/pkg/capabilities/v2/actions/confidentialrelay/types_test.go
+++ b/pkg/capabilities/v2/actions/confidentialrelay/types_test.go
@@ -506,6 +506,52 @@ func TestSecretsResponseHash_CallbackIDZeroOmitted(t *testing.T) {
 	require.NotEqual(t, mustSecretsHash(t, result, pZeroA), mustSecretsHash(t, result, pNonZero))
 }
 
+// TestIsAsyncMethod covers the method-routing predicate: it must report true
+// only for the asynchronous (enclave-polled) relay routes and false for the
+// synchronous routes and any unknown method.
+func TestIsAsyncMethod(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		want   bool
+	}{
+		{"secrets get async", MethodSecretsGetAsync, true},
+		{"capability exec async", MethodCapabilityExecAsync, true},
+		{"secrets get sync", MethodSecretsGet, false},
+		{"capability exec sync", MethodCapabilityExec, false},
+		{"unknown method", "confidential.unknown", false},
+		{"empty method", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, IsAsyncMethod(tc.method))
+		})
+	}
+}
+
+// TestSyncMethod covers stripping the async suffix: async routes map back to
+// their synchronous counterpart, while sync and unknown methods are returned
+// unchanged.
+func TestSyncMethod(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		want   string
+	}{
+		{"secrets get async strips suffix", MethodSecretsGetAsync, MethodSecretsGet},
+		{"capability exec async strips suffix", MethodCapabilityExecAsync, MethodCapabilityExec},
+		{"secrets get sync unchanged", MethodSecretsGet, MethodSecretsGet},
+		{"capability exec sync unchanged", MethodCapabilityExec, MethodCapabilityExec},
+		{"unknown method unchanged", "confidential.unknown", "confidential.unknown"},
+		{"empty method unchanged", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, SyncMethod(tc.method))
+		})
+	}
+}
+
 // TestSecretsResponseHash_StableUnderSignerReordering proves that the
 // EnclaveConfig.Signers ordering does not affect the hash. The relay-side
 // comparison against onchain state is order-independent so the hash must be


### PR DESCRIPTION
## Summary

Adds asynchronous (enclave-polled) variants of the confidential relay methods and helpers to identify/map them.

## Changes

- `pkg/capabilities/v2/actions/confidentialrelay/types.go`: add `asyncSuffix = ".async"`, `MethodSecretsGetAsync`, `MethodCapabilityExecAsync`, plus `IsAsyncMethod(method)` and `SyncMethod(method)` helpers.
- `types_test.go`: `TestIsAsyncMethod` and `TestSyncMethod` covering async/sync/unknown/empty methods.

## Why

The async relay flow lets an enclave poll for a response instead of blocking on a synchronous round-trip, which is needed for long-running capability executions that can't fit within a single gateway exchange.
