### PR TITLE
[PRIV-644] add confidential relay memo settings to cresettings

### DIFF
--- a/pkg/settings/cresettings/README.md
+++ b/pkg/settings/cresettings/README.md
@@ -330,6 +330,12 @@ flowchart
 %%      executor's ConfidentialCompute.EnclaveRequestTimeout bounds, so it is a
 %%      separate entry point rather than part of the executor subgraph above.
         ConfidentialCompute.ConfidentialRelayHandlerTimeout>ConfidentialCompute.ConfidentialRelayHandlerTimeout]:::time
+%%      The completed-response memo: an enclave retry (re-fan-out after a gateway
+%%      rotation or timeout) is served from here instead of re-executing.
+        subgraph ConfidentialCompute.RelayResponseCache
+            ConfidentialCompute.RelayResponseCache.TTL>TTL]:::time
+            ConfidentialCompute.RelayResponseCache.CleanupInterval>CleanupInterval]:::time
+        end
     end
 
     handleRequest-->Store.FetchWorkflowArtifacts-->host.NewModule-->Engine.init-->Engine.runTriggerSubscriptionPhase-->triggers-->Engine.handleAllTriggerEvents-->Engine.startExecution

--- a/pkg/settings/cresettings/defaults.json
+++ b/pkg/settings/cresettings/defaults.json
@@ -58,6 +58,10 @@
 		"EnclaveRequestTimeout": "30s",
 		"PublicKeyRequestTimeout": "5s",
 		"ConfidentialRelayHandlerTimeout": "1m0s",
+		"RelayResponseCache": {
+			"TTL": "10m0s",
+			"CleanupInterval": "1m0s"
+		},
 		"InsecureSkipTLSVerify": "false",
 		"EnclaveRefreshInterval": "10s",
 		"PublicKeyRetriesMax": "2",

--- a/pkg/settings/cresettings/defaults.toml
+++ b/pkg/settings/cresettings/defaults.toml
@@ -63,6 +63,10 @@ EnclaveRefreshInterval = '10s'
 PublicKeyRetriesMax = '2'
 PublicKeyRetriesBackoff = '5s'
 
+[ConfidentialCompute.RelayResponseCache]
+TTL = '10m0s'
+CleanupInterval = '1m0s'
+
 [ConfidentialCompute.PublicKeyCache]
 Enabled = 'true'
 TTL = '5m0s'

--- a/pkg/settings/cresettings/settings.go
+++ b/pkg/settings/cresettings/settings.go
@@ -52,47 +52,47 @@ var DefaultGetter Getter
 var Config Schema
 
 var Default = Schema{
-	WorkflowLimit:                               Int(1000),
-	WorkflowExecutionConcurrencyLimit:           Int(1000),
-	GatewayIncomingPayloadSizeLimit:             Size(1 * config.MByte),
-	GatewayVaultManagementEnabled:               Bool(true),
+	WorkflowLimit:                     Int(1000),
+	WorkflowExecutionConcurrencyLimit: Int(1000),
+	GatewayIncomingPayloadSizeLimit:   Size(1 * config.MByte),
+	GatewayVaultManagementEnabled:     Bool(true),
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
 	VaultJWTAuthEnabled:                         Bool(false),
 	CentralizedWorkflowOwnerVerificationEnabled: Bool(false),
 	RemoteExecutableWorkflowDONBindingEnabled:   Bool(false),
 	TenantID: Uint64(0),
 	// Deprecated: retained for backwards compatibility; workflow owner identifies secret ownership.
-	VaultOrgIdAsSecretOwnerEnabled:                    Bool(false),
-	PropagateOrgIDInRequestMetadata:                   Bool(false),
-	VaultBase64EncodingEnabled:                        Bool(false),
-	VaultForceEmptyOCRRounds:                          Bool(false),
+	VaultOrgIdAsSecretOwnerEnabled:  Bool(false),
+	PropagateOrgIDInRequestMetadata: Bool(false),
+	VaultBase64EncodingEnabled:      Bool(false),
+	VaultForceEmptyOCRRounds:        Bool(false),
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultOptimizationsEnabled:                         Bool(false),
+	VaultOptimizationsEnabled: Bool(false),
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
 	VaultGetSecretsShareAggregationIncludesPublicKeys: Bool(false),
 	VaultOwnerAddressCanonicalizationEnabled:          Bool(false),
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultJSONOmitUnpopulatedEnabled:                   Bool(false),
+	VaultJSONOmitUnpopulatedEnabled: Bool(false),
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultGetSecretsRelaxedConsensusEnabled:            Bool(false),
+	VaultGetSecretsRelaxedConsensusEnabled: Bool(false),
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultIncludeInvalidPendingItemsEnabled:            Bool(false),
-	VaultPendingQueueStallThreshold:                   Int(0),
+	VaultIncludeInvalidPendingItemsEnabled: Bool(false),
+	VaultPendingQueueStallThreshold:        Int(0),
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultSignedResponseRequestIDEnabled:               Bool(false),
-	VaultZoneBWorkflowGetSecretsRestrictEnabled:       Bool(false),
-	GatewayHTTPGlobalRate:                             Rate(rate.Limit(500), 500),
-	GatewayHTTPPerNodeRate:                            Rate(rate.Limit(100), 100),
-	GatewayConfidentialRelayGlobalRate:                Rate(rate.Limit(50), 10),
-	GatewayConfidentialRelayPerNodeRate:               Rate(rate.Limit(10), 10),
-	GatewayHTTPActionMtlsRequestRate:                  Rate(rate.Every(30*time.Second), 0),
-	GatewayHTTPActionMtlsConcurrencyLimit:             Int(50),
-	TriggerRegistrationStatusUpdateTimeout:            Duration(0 * time.Second),
-	BaseTriggerRetryInterval:                          Duration(30 * time.Second),
-	BaseTriggerMaxRetries:                             Int(20),
-	BaseTriggerPruneAge:                               Duration(24 * time.Hour),
-	BaseTriggerMaxSendsPerTick:                        Int(20),
-	WASMPollOneoffSubscriptionLimit:                   Int(128),
+	VaultSignedResponseRequestIDEnabled:         Bool(false),
+	VaultZoneBWorkflowGetSecretsRestrictEnabled: Bool(false),
+	GatewayHTTPGlobalRate:                       Rate(rate.Limit(500), 500),
+	GatewayHTTPPerNodeRate:                      Rate(rate.Limit(100), 100),
+	GatewayConfidentialRelayGlobalRate:          Rate(rate.Limit(50), 10),
+	GatewayConfidentialRelayPerNodeRate:         Rate(rate.Limit(10), 10),
+	GatewayHTTPActionMtlsRequestRate:            Rate(rate.Every(30*time.Second), 0),
+	GatewayHTTPActionMtlsConcurrencyLimit:       Int(50),
+	TriggerRegistrationStatusUpdateTimeout:      Duration(0 * time.Second),
+	BaseTriggerRetryInterval:                    Duration(30 * time.Second),
+	BaseTriggerMaxRetries:                       Int(20),
+	BaseTriggerPruneAge:                         Duration(24 * time.Hour),
+	BaseTriggerMaxSendsPerTick:                  Int(20),
+	WASMPollOneoffSubscriptionLimit:             Int(128),
 
 	// DANGER(cedric): Be extremely careful changing these vault limits below as they act as a default value
 	// used by the Vault OCR plugin -- changing these values could cause issues with the plugin during an image
@@ -160,10 +160,14 @@ var Default = Schema{
 		EnclaveRequestTimeout:           Duration(30 * time.Second),
 		PublicKeyRequestTimeout:         Duration(5 * time.Second),
 		ConfidentialRelayHandlerTimeout: Duration(60 * time.Second),
-		InsecureSkipTLSVerify:           Bool(false),
-		EnclaveRefreshInterval:          Duration(10 * time.Second),
-		PublicKeyRetriesMax:             Int(2),
-		PublicKeyRetriesBackoff:         Duration(5 * time.Second),
+		RelayResponseCache: ccRelayResponseCache{
+			TTL:             Duration(10 * time.Minute),
+			CleanupInterval: Duration(1 * time.Minute),
+		},
+		InsecureSkipTLSVerify:   Bool(false),
+		EnclaveRefreshInterval:  Duration(10 * time.Second),
+		PublicKeyRetriesMax:     Int(2),
+		PublicKeyRetriesBackoff: Duration(5 * time.Second),
 		PublicKeyCache: ccPublicKeyCache{
 			Enabled:                 Bool(true),
 			TTL:                     Duration(5 * time.Minute),
@@ -280,7 +284,7 @@ var Default = Schema{
 			},
 			Stellar: stellarChainWrite{
 				ReportSizeLimit: Size(5 * config.KByte),
-				MaxResourceFee: PerChainSelector(Uint64(1_000_000), map[string]uint64{}),
+				MaxResourceFee:  PerChainSelector(Uint64(1_000_000), map[string]uint64{}),
 			},
 		},
 		ChainRead: chainRead{
@@ -357,10 +361,10 @@ var Default = Schema{
 }
 
 type Schema struct {
-	WorkflowLimit                               Setting[int] `unit:"{workflow}"`
-	WorkflowExecutionConcurrencyLimit           Setting[int] `unit:"{workflow}"`
-	GatewayIncomingPayloadSizeLimit             Setting[config.Size]
-	GatewayVaultManagementEnabled               Setting[bool]
+	WorkflowLimit                     Setting[int] `unit:"{workflow}"`
+	WorkflowExecutionConcurrencyLimit Setting[int] `unit:"{workflow}"`
+	GatewayIncomingPayloadSizeLimit   Setting[config.Size]
+	GatewayVaultManagementEnabled     Setting[bool]
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
 	VaultJWTAuthEnabled                         Setting[bool]
 	CentralizedWorkflowOwnerVerificationEnabled Setting[bool]
@@ -369,34 +373,34 @@ type Schema struct {
 	// RequestMetadata.WorkflowDonID does not match the authenticated calling DON
 	// (msg.CallerDonId). Binds caller-supplied WorkflowDonID to the authenticated
 	// sender DON so it cannot be spoofed by a colluding calling DON.
-	RemoteExecutableWorkflowDONBindingEnabled         Setting[bool]
-	TenantID                                          Setting[uint64]
-	VaultOrgIdAsSecretOwnerEnabled                    Setting[bool] // Deprecated
-	PropagateOrgIDInRequestMetadata                   Setting[bool]
-	VaultBase64EncodingEnabled                        Setting[bool]
-	VaultForceEmptyOCRRounds                          Setting[bool]
+	RemoteExecutableWorkflowDONBindingEnabled Setting[bool]
+	TenantID                                  Setting[uint64]
+	VaultOrgIdAsSecretOwnerEnabled            Setting[bool] // Deprecated
+	PropagateOrgIDInRequestMetadata           Setting[bool]
+	VaultBase64EncodingEnabled                Setting[bool]
+	VaultForceEmptyOCRRounds                  Setting[bool]
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultOptimizationsEnabled                         Setting[bool]
+	VaultOptimizationsEnabled Setting[bool]
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
 	VaultGetSecretsShareAggregationIncludesPublicKeys Setting[bool]
 	VaultOwnerAddressCanonicalizationEnabled          Setting[bool]
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultJSONOmitUnpopulatedEnabled                   Setting[bool]
+	VaultJSONOmitUnpopulatedEnabled Setting[bool]
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultGetSecretsRelaxedConsensusEnabled            Setting[bool]
+	VaultGetSecretsRelaxedConsensusEnabled Setting[bool]
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultIncludeInvalidPendingItemsEnabled            Setting[bool]
-	VaultPendingQueueStallThreshold                   Setting[int] `unit:"{observation}"`
+	VaultIncludeInvalidPendingItemsEnabled Setting[bool]
+	VaultPendingQueueStallThreshold        Setting[int] `unit:"{observation}"`
 	// Deprecated: feature flag has been retired; behavior is now always enabled.
-	VaultSignedResponseRequestIDEnabled               Setting[bool]
-	VaultZoneBWorkflowGetSecretsRestrictEnabled       Setting[bool]
-	GatewayHTTPGlobalRate                             Setting[config.Rate]
-	GatewayHTTPPerNodeRate                            Setting[config.Rate]
-	GatewayConfidentialRelayGlobalRate                Setting[config.Rate]
-	GatewayConfidentialRelayPerNodeRate               Setting[config.Rate]
-	GatewayHTTPActionMtlsRequestRate                  Setting[config.Rate]
-	GatewayHTTPActionMtlsConcurrencyLimit             Setting[int] `unit:"{request}"`
-	TriggerRegistrationStatusUpdateTimeout            Setting[time.Duration]
+	VaultSignedResponseRequestIDEnabled         Setting[bool]
+	VaultZoneBWorkflowGetSecretsRestrictEnabled Setting[bool]
+	GatewayHTTPGlobalRate                       Setting[config.Rate]
+	GatewayHTTPPerNodeRate                      Setting[config.Rate]
+	GatewayConfidentialRelayGlobalRate          Setting[config.Rate]
+	GatewayConfidentialRelayPerNodeRate         Setting[config.Rate]
+	GatewayHTTPActionMtlsRequestRate            Setting[config.Rate]
+	GatewayHTTPActionMtlsConcurrencyLimit       Setting[int] `unit:"{request}"`
+	TriggerRegistrationStatusUpdateTimeout      Setting[time.Duration]
 
 	BaseTriggerRetryInterval   Setting[time.Duration]
 	BaseTriggerMaxRetries      Setting[int] `unit:"{attempt}"`
@@ -549,7 +553,7 @@ type aptosChainWrite struct {
 }
 type stellarChainWrite struct {
 	ReportSizeLimit Setting[config.Size]
-	MaxResourceFee SettingMap[uint64] `unit:"{stroop}"`
+	MaxResourceFee  SettingMap[uint64] `unit:"{stroop}"`
 }
 type evmChainWrite struct {
 	TransactionGasLimit Setting[uint64]    `unit:"{gas}"` // Deprecated
@@ -606,12 +610,30 @@ type confidentialCompute struct {
 	// past that point can only produce a response nobody is waiting for.
 	ConfidentialRelayHandlerTimeout Setting[time.Duration]
 
+	// RelayResponseCache configures the relay-DON node's completed-response memo.
+	RelayResponseCache ccRelayResponseCache
+
 	InsecureSkipTLSVerify   Setting[bool]
 	EnclaveRefreshInterval  Setting[time.Duration]
 	PublicKeyRetriesMax     Setting[int] `unit:"{attempt}"`
 	PublicKeyRetriesBackoff Setting[time.Duration]
 	PublicKeyCache          ccPublicKeyCache
 	Session                 ccSession
+}
+
+// ccRelayResponseCache holds the relay-DON node's completed-response memo
+// settings. The memo lets an enclave retry — a re-fan-out after a gateway
+// rotation or per-request timeout — return the already-computed signed result
+// instead of re-executing the capability or re-fetching from the vault.
+type ccRelayResponseCache struct {
+	// TTL bounds how long a completed signed result stays in the memo. It should
+	// exceed EnclaveRequestTimeout so a retry issued within the enclave's own
+	// deadline still hits the memo, but it need not live longer: the enclave
+	// stops retrying once it has quorum.
+	TTL Setting[time.Duration]
+
+	// CleanupInterval is how often expired entries are swept from the memo.
+	CleanupInterval Setting[time.Duration]
 }
 
 // ccPublicKeyCache holds executor-side enclave ephemeral public-key cache settings.


### PR DESCRIPTION
## Summary

Adds a `RelayResponseCache` sub-setting (TTL default 10m, CleanupInterval default 1m) to the CRE `ConfidentialCompute` settings, for memoizing completed relay responses.

## Changes

- `pkg/settings/cresettings/settings.go`: add `RelayResponseCache` (`ccRelayResponseCache{ TTL, CleanupInterval }`) to `confidentialCompute`; gofmt-aligns the surrounding struct literals.
- `defaults.json` / `defaults.toml`: add `[ConfidentialCompute.RelayResponseCache]` with `TTL = "10m0s"`, `CleanupInterval = "1m0s"`.
- `README.md`: add a `RelayResponseCache` subgraph to the `HandleGatewayMessage` entry point in the settings diagram.

## Why

When an enclave retries (re-fan-out after a gateway rotation or timeout), the completed response can be served from this cache instead of re-executing the workflow, avoiding duplicate work and duplicate charges.


[PRIV-644]: https://smartcontract-it.atlassian.net/browse/PRIV-644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ