### PR TITLE
add Open method to GateLimiter

### DIFF
--- a/pkg/settings/limits/gate.go
+++ b/pkg/settings/limits/gate.go
@@ -17,7 +17,27 @@ import (
 
 type GateLimiter interface {
 	Limiter[bool]
+	// AllowErr returns ErrorNotAllowed if the gate is closed.
 	AllowErr(context.Context) error
+	// Open reports whether the gate is open. Prefer this over Limit: Limit hands out a raw
+	// value and only records the limit gauge, whereas Open goes through the enforcement path
+	// and records the usage/denied metrics. A closed gate is (false, nil), so a non-nil error
+	// means the gate could not be evaluated and callers that fail closed can tell them apart.
+	Open(context.Context) (bool, error)
+}
+
+// gateOpen adapts an AllowErr result to (open, error): a closed gate is (false, nil) and
+// only a genuine evaluation failure returns a non-nil error.
+func gateOpen(ctx context.Context, allowErr func(context.Context) error) (bool, error) {
+	err := allowErr(ctx)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, ErrorNotAllowed{}):
+		return false, nil
+	default:
+		return false, err
+	}
 }
 
 func NewGateLimiter(open bool) GateLimiter {
@@ -33,6 +53,10 @@ func (s *simpleGateLimiter) Close() error { s.closed.Store(true); return nil }
 
 func (s *simpleGateLimiter) Limit(ctx context.Context) (bool, error) {
 	return s.open, nil
+}
+
+func (s *simpleGateLimiter) Open(ctx context.Context) (bool, error) {
+	return gateOpen(ctx, s.AllowErr)
 }
 
 func (s *simpleGateLimiter) AllowErr(ctx context.Context) error {
@@ -176,6 +200,10 @@ func (g *gateLimiter) Limit(ctx context.Context) (bool, error) {
 
 	_, limit, err := g.get(ctx)
 	return limit, err // limit is get()'s resolved value; false if no tenant, or default on error
+}
+
+func (g *gateLimiter) Open(ctx context.Context) (bool, error) {
+	return gateOpen(ctx, g.AllowErr)
 }
 
 func (g *gateLimiter) AllowErr(ctx context.Context) error {

--- a/pkg/settings/limits/gate.go
+++ b/pkg/settings/limits/gate.go
@@ -215,7 +215,11 @@ func (g *gateLimiter) AllowErr(ctx context.Context) error {
 	tenant, open, err := g.get(ctx)
 	if err != nil {
 		return err
-	} else if !open {
+	}
+	if tenant == "" && g.scope != settings.ScopeGlobal {
+		return nil // fail open
+	}
+	if !open {
 		g.recordDenied(ctx, withScope(ctx, g.scope))
 		return ErrorNotAllowed{Key: g.key, Scope: g.scope, Tenant: tenant}
 	}

--- a/pkg/settings/limits/gate_test.go
+++ b/pkg/settings/limits/gate_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/contexts"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
 )
 
@@ -78,6 +79,28 @@ func TestGateLimiter_Open(t *testing.T) {
 		require.ErrorIs(t, err, errGetterUnavailable, "an unevaluatable gate must surface the error")
 		assert.False(t, open)
 	})
+}
+
+// TestGateLimiter_NoTenantFailsOpen pins the missing-tenant behaviour for a scope that
+// does not require one (ScopeOrg). get() returns before resolving a value, so AllowErr
+// used to read the unset `open` as a denial and report ErrorNotAllowed, contradicting its
+// own "failing open" log. It now fails open, matching boundLimiter/rangeLimiter Check.
+func TestGateLimiter_NoTenantFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	setting := settings.Bool(true)
+	setting.Key, setting.Scope = "test.gate.no-tenant", settings.ScopeOrg
+	gl, err := MakeGateLimiter(Factory{Logger: logger.Test(t)}, setting)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, gl.Close()) })
+
+	ctx := t.Context() // no contexts.WithCRE, so no org tenant
+
+	require.NoError(t, gl.AllowErr(ctx), "an org gate with no org in context must not deny")
+
+	open, err := gl.Open(ctx)
+	require.NoError(t, err)
+	assert.True(t, open, "Open must not report a closed gate when the gate was never evaluated")
 }
 
 func TestMakeGateLimiter(t *testing.T) {

--- a/pkg/settings/limits/gate_test.go
+++ b/pkg/settings/limits/gate_test.go
@@ -47,6 +47,39 @@ func ExampleGateLimiter_AllowErr() {
 	// allow: limited: not allowed
 }
 
+// TestGateLimiter_Open covers the property fail-closed callers depend on: a closed gate
+// must not look like an evaluation failure, and vice versa.
+func TestGateLimiter_Open(t *testing.T) {
+	t.Parallel()
+
+	t.Run("open gate", func(t *testing.T) {
+		t.Parallel()
+		open, err := NewGateLimiter(true).Open(t.Context())
+		require.NoError(t, err)
+		assert.True(t, open)
+	})
+
+	t.Run("closed gate is not an error", func(t *testing.T) {
+		t.Parallel()
+		open, err := NewGateLimiter(false).Open(t.Context())
+		require.NoError(t, err, "a closed gate is a normal outcome, not a failure")
+		assert.False(t, open)
+	})
+
+	t.Run("read failure is distinguishable from closed", func(t *testing.T) {
+		t.Parallel()
+		setting := settings.Bool(true)
+		setting.Key, setting.Scope = "test.gate.open", settings.ScopeGlobal
+		gl, err := MakeGateLimiter(Factory{Settings: failingGetter{}}, setting)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, gl.Close()) })
+
+		open, err := gl.Open(t.Context())
+		require.ErrorIs(t, err, errGetterUnavailable, "an unevaluatable gate must surface the error")
+		assert.False(t, open)
+	})
+}
+
 func TestMakeGateLimiter(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/workflows/wasm/host/module_test.go
+++ b/pkg/workflows/wasm/host/module_test.go
@@ -180,6 +180,10 @@ func (*closeTrackingGateLimiter) Limit(context.Context) (bool, error) {
 	return true, nil
 }
 
+func (*closeTrackingGateLimiter) Open(context.Context) (bool, error) {
+	return true, nil
+}
+
 func (*closeTrackingGateLimiter) AllowErr(context.Context) error {
 	return nil
 }


### PR DESCRIPTION
GateLimiter has no way to ask "is this gate open?" that also records enforcement metrics. Limit() returns (bool, error) but only records the limit gauge, while AllowErr() records usage/denied but collapses a closed gate into an error. Callers that just want a boolean have been hand-rolling the adapter — see crelimits.GateOpen in the chainlink repo, which this replaces.

Adds Open(ctx) (bool, error): a closed gate is (false, nil), so a non-nil error means the gate could not be evaluated and fail-closed callers can tell the two apart.

Why not Allow(ctx) bool like RateLimiter? Two downstream callers need the closed-vs-unevaluatable distinction — one wraps the failure into a returned error, the other rejects the request. Collapsing a settings read failure into false would silently fail open on a DON-binding spoof check.
