### PR TITLE
Validate Stellar tx status enum conversions

### DIFF
--- a/pkg/chains/stellar/proto_helpers.go
+++ b/pkg/chains/stellar/proto_helpers.go
@@ -458,8 +458,13 @@ func ConvertSubmitTransactionResponseToProto(reply *stellar.SubmitTransactionRes
 			return nil, fmt.Errorf("invalid result meta xdr %q: %w", reply.ResultMetaXDR, err)
 		}
 	}
+	txStatus, err := convertTxStatusToProto(reply.TxStatus)
+	if err != nil {
+		return nil, fmt.Errorf("txStatus: %w", err)
+	}
+
 	resp := &SubmitTransactionResponse{
-		TxStatus:         TxStatus(reply.TxStatus),
+		TxStatus:         txStatus,
 		TxHash:           reply.TxHash,
 		TxIdempotencyKey: reply.TxIdempotencyKey,
 		ResultXdr:        resultXDR,
@@ -480,8 +485,13 @@ func ConvertSubmitTransactionResponseFromProto(p *SubmitTransactionResponse) (*s
 	if p == nil {
 		return nil, errors.New("submit transaction reply is nil")
 	}
+	txStatus, err := convertTxStatusFromProto(p.GetTxStatus())
+	if err != nil {
+		return nil, fmt.Errorf("txStatus: %w", err)
+	}
+
 	resp := &stellar.SubmitTransactionResponse{
-		TxStatus:         stellar.TransactionStatus(p.GetTxStatus()),
+		TxStatus:         txStatus,
 		TxHash:           p.GetTxHash(),
 		TxIdempotencyKey: p.GetTxIdempotencyKey(),
 		ResultXDR:        base64.StdEncoding.EncodeToString(p.GetResultXdr()),
@@ -848,6 +858,32 @@ func convertEventTypeFromProto(t EventType) (stellar.EventType, error) {
 		return stellar.EventTypeContract, nil
 	default:
 		return 0, fmt.Errorf("unsupported proto event type: %d", t)
+	}
+}
+
+func convertTxStatusToProto(s stellar.TransactionStatus) (TxStatus, error) {
+	switch s {
+	case stellar.TxFatal:
+		return TxStatus_TX_STATUS_FATAL, nil
+	case stellar.TxFailed:
+		return TxStatus_TX_STATUS_FAILED, nil
+	case stellar.TxSuccess:
+		return TxStatus_TX_STATUS_SUCCESS, nil
+	default:
+		return 0, fmt.Errorf("unsupported tx status: %d", s)
+	}
+}
+
+func convertTxStatusFromProto(s TxStatus) (stellar.TransactionStatus, error) {
+	switch s {
+	case TxStatus_TX_STATUS_FATAL:
+		return stellar.TxFatal, nil
+	case TxStatus_TX_STATUS_FAILED:
+		return stellar.TxFailed, nil
+	case TxStatus_TX_STATUS_SUCCESS:
+		return stellar.TxSuccess, nil
+	default:
+		return 0, fmt.Errorf("unsupported proto tx status: %d", s)
 	}
 }
 

--- a/pkg/chains/stellar/proto_helpers_test.go
+++ b/pkg/chains/stellar/proto_helpers_test.go
@@ -710,6 +710,24 @@ func TestConvertSubmitTransactionResponseToProto_InvalidResultMetaXDR(t *testing
 	require.Contains(t, err.Error(), "invalid result meta xdr")
 }
 
+func TestConvertSubmitTransactionResponseToProto_UnsupportedTxStatus(t *testing.T) {
+	_, err := conv.ConvertSubmitTransactionResponseToProto(&stellartypes.SubmitTransactionResponse{
+		TxStatus: stellartypes.TransactionStatus(99),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "txStatus")
+	require.Contains(t, err.Error(), "unsupported tx status")
+}
+
+func TestConvertSubmitTransactionResponseFromProto_UnsupportedTxStatus(t *testing.T) {
+	_, err := conv.ConvertSubmitTransactionResponseFromProto(&conv.SubmitTransactionResponse{
+		TxStatus: conv.TxStatus(99),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "txStatus")
+	require.Contains(t, err.Error(), "unsupported proto tx status")
+}
+
 func TestConvertSubmitTransactionRequestFromProto_BadArg(t *testing.T) {
 	_, err := conv.ConvertSubmitTransactionRequestFromProto(&conv.SubmitTransactionRequest{
 		ContractId: "C_X",
@@ -1099,6 +1117,28 @@ func TestConvertGetEventsResponseFromProto_MissingValue(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "events[0]")
 	require.Contains(t, err.Error(), "value is required")
+}
+
+func TestConvertGetEventsResponseFromProto_UnsupportedEventType(t *testing.T) {
+	u64 := uint64(1)
+	value, err := stellarcap.ScValToProto(stellartypes.ScVal{
+		Type: stellartypes.ScValTypeU64,
+		U64:  &u64,
+	})
+	require.NoError(t, err)
+
+	_, err = conv.ConvertGetEventsResponseFromProto(&conv.GetEventsResponse{
+		Events: []*conv.EventInfo{
+			{
+				EventType: conv.EventType(99),
+				Value:     value,
+			},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "events[0]")
+	require.Contains(t, err.Error(), "eventType")
+	require.Contains(t, err.Error(), "unsupported proto event type")
 }
 
 func TestConvertGetEventsResponseToProto_BadValue(t *testing.T) {


### PR DESCRIPTION
Adds checked Stellar TxStatus converters instead of raw enum casts.

Also adds regression coverage for invalid TxStatus values and documents existing unknown EventType rejection. Avoids proto presence changes to preserve compatibility with existing zero-valued enum senders.