### PR TITLE
[CRE] Add v2 SecretValue workflow config type

### DIFF
--- a/pkg/workflows/sdk/v2/secrets.go
+++ b/pkg/workflows/sdk/v2/secrets.go
@@ -1,0 +1,5 @@
+// Package v2 provides shared types for v2 (NoDAG) workflows.
+package v2
+
+// SecretValue marks workflow config fields that hold secret values.
+type SecretValue string


### PR DESCRIPTION
## Context
Part of CRE-5836 (Keystone cleanup: remove the legacy DAG workflow module and wasm utils). The legacy `pkg/workflows/sdk` root package is slated for deletion, but two of its symbols are still used by current v2 code in chainlink (PoR example + canary workflows):
- `sdk.SecretValue` — workflow config field marker type
- `sdk.BreakErr` — pure alias of `capabilities.ErrStopExecution`