### PR TITLE
chipingress: fix retry policy service-config, make it configurable

### DIFF
--- a/pkg/chipingress/client.go
+++ b/pkg/chipingress/client.go
@@ -53,6 +53,7 @@ type clientConfig struct {
 	meterProvider         metric.MeterProvider
 	tracerProvider        trace.TracerProvider
 	nopInfoHeaderProvider HeaderProvider
+	retryPolicy           RetryPolicy
 }
 
 func newClientConfig(host string) *clientConfig {
@@ -64,6 +65,7 @@ func newClientConfig(host string) *clientConfig {
 		insecureConnection:    true,
 		transportCredentials:  insecure.NewCredentials(),
 		nopInfoHeaderProvider: nil,
+		retryPolicy:           defaultRetryPolicy(),
 	}
 	return cfg
 }
@@ -100,15 +102,16 @@ func NewClient(address string, opts ...Opt) (Client, error) {
 			PermitWithoutStream: true,
 		}),
 	}
-	// Retry policy
-	retryPolicy := `{
-		"maxAttempts": 3,
-		"initialBackoff": "100ms",
-		"maxBackoff": "1s",
-		"backoffMultiplier": 2,
-		"retryableStatusCodes": ["UNAVAILABLE", "RESOURCE_EXHAUSTED"]
-	}`
-	grpcOpts = append(grpcOpts, grpc.WithDefaultServiceConfig(retryPolicy))
+	// Retry policy. Built from typed structs (see retry_policy.go) rather than a hand-written
+	// JSON literal - a previous hand-written literal here was malformed (fields missing the
+	// required methodConfig[].retryPolicy nesting) and gRPC's parser silently discarded it
+	// without error, so the client never actually retried anything.
+	throttling := defaultRetryThrottlingPolicy()
+	retryServiceConfig, err := buildRetryServiceConfigJSON(cfg.retryPolicy, &throttling)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build retry policy service config: %w", err)
+	}
+	grpcOpts = append(grpcOpts, grpc.WithDefaultServiceConfig(retryServiceConfig))
 	// Auth
 	if cfg.perRPCCredentials != nil {
 		grpcOpts = append(grpcOpts, grpc.WithPerRPCCredentials(cfg.perRPCCredentials))

--- a/pkg/chipingress/retry_policy.go
+++ b/pkg/chipingress/retry_policy.go
@@ -1,0 +1,200 @@
+package chipingress
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/chipingress/pb"
+)
+
+// RetryPolicy configures the gRPC-level retry behavior the client installs as its default
+// service config (see WithRetryPolicy). It is the Go-native, mistake-resistant equivalent of
+// hand-writing a gRPC "retryPolicy" service-config JSON block, which is easy to get wrong: the
+// nesting (methodConfig[].retryPolicy, not top-level), the duration encoding (protobuf JSON
+// duration, e.g. "0.1s", not Go's "100ms"), and the status-code names are all silently ignored
+// by gRPC's parser if malformed, rather than rejected - see the client_test.go regression test
+// for what that looks like.
+type RetryPolicy struct {
+	// MaxAttempts is the maximum number of call attempts, including the original attempt.
+	// Must be 2 or greater for gRPC to treat the policy as valid; otherwise gRPC silently
+	// installs no retry policy at all for the affected method.
+	MaxAttempts int
+	// InitialBackoff is the base delay before the first retry attempt.
+	InitialBackoff time.Duration
+	// MaxBackoff caps the exponential backoff delay between attempts.
+	MaxBackoff time.Duration
+	// BackoffMultiplier is applied to the backoff delay after each attempt.
+	BackoffMultiplier float64
+	// RetryableStatusCodes is the set of gRPC status codes eligible for retry.
+	RetryableStatusCodes []codes.Code
+}
+
+// RetryThrottlingPolicy configures gRPC's retry throttling, which limits how much additional
+// load retries (and hedged RPCs) can place on an already-struggling server. See
+// https://github.com/grpc/proposal/blob/master/A6-client-retries.md#integration-with-service-config.
+type RetryThrottlingPolicy struct {
+	// MaxTokens is the starting/maximum size of the retry token bucket. Must be in (0, 1000].
+	MaxTokens float64
+	// TokenRatio is the number of tokens restored per successful RPC. Must be > 0.
+	TokenRatio float64
+}
+
+// defaultRetryPolicy is the retry policy installed when no WithRetryPolicy override is
+// supplied. It matches the values the client has always intended to use (see the historical,
+// malformed service-config JSON this replaced), except that the backoff durations are now
+// correctly encoded so gRPC actually installs the policy.
+func defaultRetryPolicy() RetryPolicy {
+	return RetryPolicy{
+		MaxAttempts:          3,
+		InitialBackoff:       100 * time.Millisecond,
+		MaxBackoff:           1 * time.Second,
+		BackoffMultiplier:    2,
+		RetryableStatusCodes: []codes.Code{codes.Unavailable, codes.ResourceExhausted},
+	}
+}
+
+// defaultRetryThrottlingPolicy caps retry amplification against a degraded server. Values
+// follow the example in the gRPC retry design doc (A6): a bucket of 10 tokens, refilled by 0.1
+// per success, so retries taper off quickly once failures dominate.
+func defaultRetryThrottlingPolicy() RetryThrottlingPolicy {
+	return RetryThrottlingPolicy{
+		MaxTokens:  10,
+		TokenRatio: 0.1,
+	}
+}
+
+// grpcServiceConfigDuration renders d in the string form gRPC's service-config parser requires
+// (grpc-go's internal/serviceconfig.Duration, which follows protobuf's JSON duration encoding):
+// a decimal number of seconds followed by "s", e.g. "0.1s" for 100ms. Plain Go duration strings
+// such as "100ms" are NOT accepted by that parser and fail JSON unmarshaling.
+func grpcServiceConfigDuration(d time.Duration) string {
+	return strconv.FormatFloat(d.Seconds(), 'f', -1, 64) + "s"
+}
+
+// grpcStatusCodeName returns the canonical gRPC service-config string name for a status code
+// (e.g. "UNAVAILABLE"), per https://github.com/grpc/grpc/blob/master/doc/statuscodes.md. Falls
+// back to the numeric code for values without a well-known name; gRPC's parser accepts either
+// form.
+func grpcStatusCodeName(c codes.Code) string {
+	switch c {
+	case codes.OK:
+		return "OK"
+	case codes.Canceled:
+		return "CANCELLED"
+	case codes.Unknown:
+		return "UNKNOWN"
+	case codes.InvalidArgument:
+		return "INVALID_ARGUMENT"
+	case codes.DeadlineExceeded:
+		return "DEADLINE_EXCEEDED"
+	case codes.NotFound:
+		return "NOT_FOUND"
+	case codes.AlreadyExists:
+		return "ALREADY_EXISTS"
+	case codes.PermissionDenied:
+		return "PERMISSION_DENIED"
+	case codes.ResourceExhausted:
+		return "RESOURCE_EXHAUSTED"
+	case codes.FailedPrecondition:
+		return "FAILED_PRECONDITION"
+	case codes.Aborted:
+		return "ABORTED"
+	case codes.OutOfRange:
+		return "OUT_OF_RANGE"
+	case codes.Unimplemented:
+		return "UNIMPLEMENTED"
+	case codes.Internal:
+		return "INTERNAL"
+	case codes.Unavailable:
+		return "UNAVAILABLE"
+	case codes.DataLoss:
+		return "DATA_LOSS"
+	case codes.Unauthenticated:
+		return "UNAUTHENTICATED"
+	default:
+		return strconv.Itoa(int(c))
+	}
+}
+
+// serviceConfigJSON mirrors (the small subset of) the gRPC service-config JSON schema this
+// package needs: https://github.com/grpc/grpc/blob/master/doc/service_config.md. Building the
+// JSON via these typed structs (instead of hand-written string literals) is the fix for the bug
+// this package shipped previously: a flat, malformed JSON blob whose fields gRPC's parser
+// silently discarded as unknown, installing no retry policy at all without any error.
+type serviceConfigJSON struct {
+	MethodConfig    []methodConfigJSON   `json:"methodConfig"`
+	RetryThrottling *retryThrottlingJSON `json:"retryThrottling,omitempty"`
+}
+
+type methodConfigJSON struct {
+	Name        []methodNameJSON `json:"name"`
+	RetryPolicy retryPolicyJSON  `json:"retryPolicy"`
+}
+
+type methodNameJSON struct {
+	Service string `json:"service"`
+}
+
+type retryPolicyJSON struct {
+	MaxAttempts          int      `json:"maxAttempts"`
+	InitialBackoff       string   `json:"initialBackoff"`
+	MaxBackoff           string   `json:"maxBackoff"`
+	BackoffMultiplier    float64  `json:"backoffMultiplier"`
+	RetryableStatusCodes []string `json:"retryableStatusCodes"`
+}
+
+type retryThrottlingJSON struct {
+	MaxTokens  float64 `json:"maxTokens"`
+	TokenRatio float64 `json:"tokenRatio"`
+}
+
+// buildRetryServiceConfigJSON marshals policy (and, if non-nil, throttling) into the gRPC
+// default-service-config JSON that grpc.WithDefaultServiceConfig expects, scoped to the
+// ChipIngress gRPC service via its fully-qualified name (from the generated
+// pb.ChipIngress_ServiceDesc, so it can't drift from the actual service).
+func buildRetryServiceConfigJSON(policy RetryPolicy, throttling *RetryThrottlingPolicy) (string, error) {
+	codeNames := make([]string, 0, len(policy.RetryableStatusCodes))
+	for _, c := range policy.RetryableStatusCodes {
+		codeNames = append(codeNames, grpcStatusCodeName(c))
+	}
+
+	sc := serviceConfigJSON{
+		MethodConfig: []methodConfigJSON{
+			{
+				Name: []methodNameJSON{{Service: pb.ChipIngress_ServiceDesc.ServiceName}},
+				RetryPolicy: retryPolicyJSON{
+					MaxAttempts:          policy.MaxAttempts,
+					InitialBackoff:       grpcServiceConfigDuration(policy.InitialBackoff),
+					MaxBackoff:           grpcServiceConfigDuration(policy.MaxBackoff),
+					BackoffMultiplier:    policy.BackoffMultiplier,
+					RetryableStatusCodes: codeNames,
+				},
+			},
+		},
+	}
+	if throttling != nil {
+		sc.RetryThrottling = &retryThrottlingJSON{
+			MaxTokens:  throttling.MaxTokens,
+			TokenRatio: throttling.TokenRatio,
+		}
+	}
+
+	b, err := json.Marshal(sc)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal retry policy service config: %w", err)
+	}
+	return string(b), nil
+}
+
+// WithRetryPolicy overrides the client's default gRPC-level retry policy for the ChipIngress
+// service. If not supplied, the client retries UNAVAILABLE and RESOURCE_EXHAUSTED failures up
+// to 3 times with exponential backoff starting at 100ms and capped at 1s (see
+// defaultRetryPolicy). Retry throttling (see RetryThrottlingPolicy) is always applied alongside
+// whichever retry policy is in effect, so a struggling server isn't amplified by retries.
+func WithRetryPolicy(policy RetryPolicy) Opt {
+	return func(c *clientConfig) { c.retryPolicy = policy }
+}

--- a/pkg/chipingress/retry_policy_test.go
+++ b/pkg/chipingress/retry_policy_test.go
@@ -1,0 +1,223 @@
+package chipingress
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gp "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/serviceconfig"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/chipingress/pb"
+)
+
+// parseServiceConfigJSON drives the given service-config JSON through gRPC's real,
+// production parser (the same one grpc.NewClient uses for grpc.WithDefaultServiceConfig), via
+// a manual resolver. This is the only way to exercise that parser from outside
+// google.golang.org/grpc, since the concrete parsing logic lives under an internal package.
+//
+// This is deliberately NOT a hand-rolled reimplementation of gRPC's parsing rules: the bug this
+// package shipped previously (a malformed, flat service-config JSON) was only "caught" by
+// actually parsing it with gRPC's own code - asserting "NewClient returned no error" is
+// worthless, since that malformed JSON also produced no error.
+func parseServiceConfigJSON(t *testing.T, scJSON string) *serviceconfig.ParseResult {
+	t.Helper()
+
+	scheme := fmt.Sprintf("chipingress-retry-policy-test-%d", time.Now().UnixNano())
+	r := manual.NewBuilderWithScheme(scheme)
+
+	ccCh := make(chan resolver.ClientConn, 1)
+	r.BuildCallback = func(_ resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) {
+		ccCh <- cc
+	}
+
+	conn, err := gp.NewClient(r.Scheme()+":///test",
+		gp.WithTransportCredentials(insecure.NewCredentials()),
+		gp.WithResolvers(r),
+	)
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	conn.Connect()
+
+	select {
+	case cc := <-ccCh:
+		return cc.ParseServiceConfig(scJSON)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the manual resolver to be built")
+		return nil
+	}
+}
+
+// chipIngressMethodPath is the map key gRPC's service-config parser uses for a
+// service-scoped (no method) name selector: "/<service>/".
+var chipIngressMethodPath = "/" + pb.ChipIngress_ServiceDesc.ServiceName + "/"
+
+// TestBuildRetryServiceConfigJSON_DefaultPolicy is the core regression test: it proves the
+// service config the client installs by default actually results in gRPC installing a retry
+// policy for the ChipIngress service, with the exact values the client intends. A test that
+// merely asserted "NewClient/buildRetryServiceConfigJSON returns no error" would NOT have
+// caught the original bug, since the original malformed JSON also parsed without error.
+func TestBuildRetryServiceConfigJSON_DefaultPolicy(t *testing.T) {
+	throttling := defaultRetryThrottlingPolicy()
+	scJSON, err := buildRetryServiceConfigJSON(defaultRetryPolicy(), &throttling)
+	require.NoError(t, err)
+
+	scpr := parseServiceConfigJSON(t, scJSON)
+	require.NoError(t, scpr.Err, "gRPC's parser rejected the generated service config")
+	require.NotNil(t, scpr.Config)
+
+	sc, ok := scpr.Config.(*gp.ServiceConfig)
+	require.True(t, ok, "expected *grpc.ServiceConfig, got %T", scpr.Config)
+	require.NotNil(t, sc.Methods, "MethodConfig must be populated - this is exactly what the old malformed JSON failed to do")
+
+	mc, ok := sc.Methods[chipIngressMethodPath]
+	require.True(t, ok, "expected a MethodConfig entry for %q, got keys %v", chipIngressMethodPath, mapKeys(sc.Methods))
+	require.NotNil(t, mc.RetryPolicy, "expected a retry policy to be installed for the ChipIngress service")
+
+	assert.Equal(t, 3, mc.RetryPolicy.MaxAttempts)
+	assert.Equal(t, 100*time.Millisecond, mc.RetryPolicy.InitialBackoff)
+	assert.Equal(t, 1*time.Second, mc.RetryPolicy.MaxBackoff)
+	assert.InDelta(t, 2.0, mc.RetryPolicy.BackoffMultiplier, 0.0001)
+	assert.True(t, mc.RetryPolicy.RetryableStatusCodes[codes.Unavailable])
+	assert.True(t, mc.RetryPolicy.RetryableStatusCodes[codes.ResourceExhausted])
+	assert.Len(t, mc.RetryPolicy.RetryableStatusCodes, 2)
+}
+
+// TestBuildRetryServiceConfigJSON_CustomPolicy exercises WithRetryPolicy end to end: a custom
+// policy must round-trip through gRPC's parser with the caller's exact values.
+func TestBuildRetryServiceConfigJSON_CustomPolicy(t *testing.T) {
+	custom := RetryPolicy{
+		MaxAttempts:          5,
+		InitialBackoff:       250 * time.Millisecond,
+		MaxBackoff:           5 * time.Second,
+		BackoffMultiplier:    1.5,
+		RetryableStatusCodes: []codes.Code{codes.Unavailable, codes.Internal, codes.DeadlineExceeded},
+	}
+
+	cfg := newClientConfig("localhost")
+	WithRetryPolicy(custom)(cfg)
+	assert.Equal(t, custom, cfg.retryPolicy)
+
+	scJSON, err := buildRetryServiceConfigJSON(cfg.retryPolicy, nil)
+	require.NoError(t, err)
+
+	scpr := parseServiceConfigJSON(t, scJSON)
+	require.NoError(t, scpr.Err)
+
+	sc, ok := scpr.Config.(*gp.ServiceConfig)
+	require.True(t, ok)
+
+	mc, ok := sc.Methods[chipIngressMethodPath]
+	require.True(t, ok)
+	require.NotNil(t, mc.RetryPolicy)
+
+	assert.Equal(t, 5, mc.RetryPolicy.MaxAttempts)
+	assert.Equal(t, 250*time.Millisecond, mc.RetryPolicy.InitialBackoff)
+	assert.Equal(t, 5*time.Second, mc.RetryPolicy.MaxBackoff)
+	assert.InDelta(t, 1.5, mc.RetryPolicy.BackoffMultiplier, 0.0001)
+	assert.True(t, mc.RetryPolicy.RetryableStatusCodes[codes.Unavailable])
+	assert.True(t, mc.RetryPolicy.RetryableStatusCodes[codes.Internal])
+	assert.True(t, mc.RetryPolicy.RetryableStatusCodes[codes.DeadlineExceeded])
+	assert.Len(t, mc.RetryPolicy.RetryableStatusCodes, 3)
+}
+
+// TestOldMalformedServiceConfigInstallsNoRetryPolicy demonstrates the original bug this package
+// shipped: the flat, unnested JSON that used to be hard-coded in NewClient. gRPC's parser
+// accepts it (all its fields are unknown at the top level and silently discarded) and returns
+// no error, yet installs zero MethodConfig entries - i.e., no retry policy at all. This is why
+// asserting "no error" is not a valid regression test for this bug class.
+func TestOldMalformedServiceConfigInstallsNoRetryPolicy(t *testing.T) {
+	const oldMalformedJSON = `{
+		"maxAttempts": 3,
+		"initialBackoff": "100ms",
+		"maxBackoff": "1s",
+		"backoffMultiplier": 2,
+		"retryableStatusCodes": ["UNAVAILABLE", "RESOURCE_EXHAUSTED"]
+	}`
+
+	scpr := parseServiceConfigJSON(t, oldMalformedJSON)
+	require.NoError(t, scpr.Err, "the old malformed shape parses without error - that IS the bug")
+
+	sc, ok := scpr.Config.(*gp.ServiceConfig)
+	require.True(t, ok)
+	assert.Empty(t, sc.Methods, "the old malformed shape must install no retry policy for any method")
+}
+
+// TestGRPCServiceConfigDuration_RejectsGoDurationStrings proves the second, latent defect noted
+// while fixing the first: gRPC's service-config duration parser (protobuf JSON duration
+// encoding) does NOT accept Go duration strings like "100ms" once they're actually reachable
+// (i.e., once correctly nested under methodConfig[].retryPolicy). Before the nesting fix, this
+// was unreachable - the malformed top-level JSON meant the duration strings were never even
+// looked at by gRPC's typed unmarshaling.
+func TestGRPCServiceConfigDuration_RejectsGoDurationStrings(t *testing.T) {
+	const malformedDurationJSON = `{
+		"methodConfig": [{
+			"name": [{"service": "chipingress.pb.ChipIngress"}],
+			"retryPolicy": {
+				"maxAttempts": 3,
+				"initialBackoff": "100ms",
+				"maxBackoff": "1s",
+				"backoffMultiplier": 2,
+				"retryableStatusCodes": ["UNAVAILABLE", "RESOURCE_EXHAUSTED"]
+			}
+		}]
+	}`
+
+	scpr := parseServiceConfigJSON(t, malformedDurationJSON)
+	require.Error(t, scpr.Err, "\"100ms\" is not a valid protobuf JSON duration and must be rejected once actually parsed")
+}
+
+// TestGRPCServiceConfigDuration_Format asserts the exact wire format grpcServiceConfigDuration
+// produces for representative values, and that it round-trips through gRPC's parser.
+func TestGRPCServiceConfigDuration_Format(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{name: "100ms", d: 100 * time.Millisecond, want: "0.1s"},
+		{name: "1s", d: 1 * time.Second, want: "1s"},
+		{name: "250ms", d: 250 * time.Millisecond, want: "0.25s"},
+		{name: "1500ms", d: 1500 * time.Millisecond, want: "1.5s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, grpcServiceConfigDuration(tt.d))
+		})
+	}
+}
+
+// TestBuildRetryServiceConfigJSON_RetryThrottling asserts the retryThrottling block is present
+// and correctly populated when requested, since it lives alongside - but structurally separate
+// from - the per-method retry policy.
+func TestBuildRetryServiceConfigJSON_RetryThrottling(t *testing.T) {
+	throttling := RetryThrottlingPolicy{MaxTokens: 20, TokenRatio: 0.2}
+	scJSON, err := buildRetryServiceConfigJSON(defaultRetryPolicy(), &throttling)
+	require.NoError(t, err)
+
+	scpr := parseServiceConfigJSON(t, scJSON)
+	require.NoError(t, scpr.Err)
+
+	sc, ok := scpr.Config.(*gp.ServiceConfig)
+	require.True(t, ok)
+	// retryThrottling is unexported on grpc.ServiceConfig, so we can't assert its fields
+	// directly; asserting no parse error with maxTokens/tokenRatio present in range is the
+	// available signal that gRPC accepted and applied it (see service_config.go's range
+	// validation: maxTokens in (0, 1000], tokenRatio > 0).
+	require.NotNil(t, sc)
+}
+
+func mapKeys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
## Summary

The retry policy passed to `grpc.WithDefaultServiceConfig` in `pkg/chipingress/client.go` was a bare
retry-policy object, missing the `methodConfig[].retryPolicy` wrapper gRPC service config requires.
The gRPC parser silently discards unknown top-level fields via plain `json.Unmarshal`, so the config
parsed to a valid-but-empty result (`MethodConfig == nil`) with **no error**. `grpc.NewClient`
succeeded silently. **This client has never performed a single gRPC-level retry.**

- Fixes the JSON shape via a typed `RetryPolicy` struct and a JSON builder
  (`buildRetryServiceConfigJSON`) instead of a hand-written literal, so this bug class cannot recur
  silently.
- Adds `WithRetryPolicy` so callers can override without hand-writing service-config JSON themselves.
- Pairs the retry policy with `retryThrottling` (10 tokens, 0.1 ratio) so a genuinely degraded server
  cannot be amplified by a newly-functioning retry policy.

## Verified from source, not assumed

- **Duration format:** the grpc-go internal `serviceconfig.Duration` requires protobuf-JSON seconds
  strings (`"0.1s"`); the original `"100ms"` does not parse. Once `methodConfig` is correctly
  nested, an invalid duration now makes `grpc.NewClient` return a hard error instead of silently
  doing nothing — confirmed with a test.
- **Service name:** read from `pb.ChipIngress_ServiceDesc.ServiceName` at runtime rather than
  hardcoding a copy of the string.
- **Call sites:** only `pkg/beholder/client.go` and `pkg/durableemitter/setup.go` call
  `chipingress.NewClient`, both via variadic `Opt`, so this is non-breaking — existing callers get
  the corrected default policy.

## Regression test

The defining property of this bug is that it produces *no error*, so a bare no error assertion
would not have caught it. `retry_policy_test.go` drives the constructed JSON through the real gRPC
service-config parser (manual resolver + `ClientConn.ParseServiceConfig`) and asserts `MethodConfig`
is actually populated. Also includes a test proving the old malformed JSON parses with zero
`MethodConfig` entries, and a test proving `"100ms"` is rejected.

## Non-goal

This does **not** address `DEADLINE_EXCEEDED` failures and would not have changed the root cause of
a separate production incident found while investigating this — retries share the caller
deadline, and the dominant failure mode there had already exhausted it. This closes a chronic,
unrelated data-loss gap: every `UNAVAILABLE`/`RESOURCE_EXHAUSTED` failure that should have retried
was instead an immediate permanent drop, on a path with no persistence.

## Test plan

- [x] `go build ./...`, `go vet ./pkg/chipingress/...`, `gofmt -l` clean
- [x] New tests in `retry_policy_test.go` pass
- [x] `pkg/beholder/...` full suite passes
