### PR TITLE
Fix default config

### DIFF
--- a/pkg/loop/internal/core/services/capability/capabilities_registry.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_registry.go
@@ -146,6 +146,11 @@ func (cr *capabilitiesRegistryClient) ConfigForCapability(ctx context.Context, c
 		return capabilities.CapabilityConfiguration{}, err
 	}
 
+	defaultConfig, err := values.FromMapValueProto(res.CapabilityConfig.DefaultConfig)
+	if err != nil {
+		return capabilities.CapabilityConfiguration{}, fmt.Errorf("could not decode default config: %w", err)
+	}
+
 	var methodConfig map[string]capabilities.CapabilityMethodConfig
 	if res.CapabilityConfig.MethodConfigs != nil {
 		methodConfig = make(map[string]capabilities.CapabilityMethodConfig, len(res.CapabilityConfig.MethodConfigs))
@@ -192,6 +197,7 @@ func (cr *capabilitiesRegistryClient) ConfigForCapability(ctx context.Context, c
 	}
 
 	return capabilities.CapabilityConfiguration{
+		DefaultConfig:          defaultConfig,
 		CapabilityMethodConfig: methodConfig,
 		LocalOnly:              res.CapabilityConfig.LocalOnly,
 		Ocr3Configs:            ocr3Configs,
@@ -400,6 +406,10 @@ func (c *capabilitiesRegistryServer) ConfigForCapability(ctx context.Context, re
 	}
 
 	ccp := &capabilitiespb.CapabilityConfig{}
+
+	if cc.DefaultConfig != nil {
+		ccp.DefaultConfig = values.Proto(cc.DefaultConfig).GetMapValue()
+	}
 
 	// Handle method configs
 	if cc.CapabilityMethodConfig != nil {

--- a/pkg/loop/internal/core/services/capability/capabilities_registry_test.go
+++ b/pkg/loop/internal/core/services/capability/capabilities_registry_test.go
@@ -677,3 +677,97 @@ func ensureEqual(t *testing.T, expectedNode, actualNode capabilities.Node) {
 		require.Equal(t, expectedNode.CapabilityDONs[i].Config, actualNode.CapabilityDONs[i].Config)
 	}
 }
+
+func TestCapabilitiesRegistry_ConfigForCapability_DefaultConfig(t *testing.T) {
+	stopCh := make(chan struct{})
+	logger := logger.Test(t)
+	reg := mocks.NewCapabilitiesRegistry(t)
+
+	pluginName := "registry-test"
+	client, server := plugin.TestPluginGRPCConn(
+		t,
+		true,
+		map[string]plugin.Plugin{
+			pluginName: &testRegistryPlugin{
+				impl: reg,
+				brokerExt: &net.BrokerExt{
+					BrokerConfig: net.BrokerConfig{
+						StopCh: stopCh,
+						Logger: logger,
+					},
+				},
+			},
+		},
+	)
+
+	defer client.Close()
+	defer server.Stop()
+
+	regClient, err := client.Dispense(pluginName)
+	require.NoError(t, err)
+
+	rc, ok := regClient.(*capabilitiesRegistryClient)
+	require.True(t, ok)
+
+	capID := "some-cap@1.0.0"
+	donID := uint32(1)
+
+	defaultConfig, err := values.NewMap(map[string]any{
+		"enclaves": []any{
+			map[string]any{"region": "us-east-2", "enclaveType": "nitro"},
+			map[string]any{"region": "us-west-2", "enclaveType": "nitro"},
+		},
+	})
+	require.NoError(t, err)
+
+	expectedCapConfig := capabilities.CapabilityConfiguration{
+		DefaultConfig: defaultConfig,
+	}
+	reg.On("ConfigForCapability", mock.Anything, capID, donID).Once().Return(expectedCapConfig, nil)
+
+	capConf, err := rc.ConfigForCapability(t.Context(), capID, donID)
+	require.NoError(t, err)
+	require.NotNil(t, capConf.DefaultConfig)
+	assert.Equal(t, defaultConfig.Underlying, capConf.DefaultConfig.Underlying)
+}
+
+func TestCapabilitiesRegistry_ConfigForCapability_NilDefaultConfig(t *testing.T) {
+	stopCh := make(chan struct{})
+	logger := logger.Test(t)
+	reg := mocks.NewCapabilitiesRegistry(t)
+
+	pluginName := "registry-test"
+	client, server := plugin.TestPluginGRPCConn(
+		t,
+		true,
+		map[string]plugin.Plugin{
+			pluginName: &testRegistryPlugin{
+				impl: reg,
+				brokerExt: &net.BrokerExt{
+					BrokerConfig: net.BrokerConfig{
+						StopCh: stopCh,
+						Logger: logger,
+					},
+				},
+			},
+		},
+	)
+
+	defer client.Close()
+	defer server.Stop()
+
+	regClient, err := client.Dispense(pluginName)
+	require.NoError(t, err)
+
+	rc, ok := regClient.(*capabilitiesRegistryClient)
+	require.True(t, ok)
+
+	capID := "some-cap@1.0.0"
+	donID := uint32(1)
+
+	reg.On("ConfigForCapability", mock.Anything, capID, donID).Once().Return(capabilities.CapabilityConfiguration{}, nil)
+
+	capConf, err := rc.ConfigForCapability(t.Context(), capID, donID)
+	require.NoError(t, err)
+	assert.Nil(t, capConf.DefaultConfig)
+}


### PR DESCRIPTION
Deployment validation: mixed rollout in staging works for confidential HTTP & confidential workflows