### PR TITLE
Require Stellar enum presence in proto responses

### DIFF
--- a/pkg/chains/stellar/proto_helpers.go
+++ b/pkg/chains/stellar/proto_helpers.go
@@ -500,7 +500,7 @@ func ConvertSubmitTransactionResponseToProto(reply *stellar.SubmitTransactionRes
 	}
 
 	resp := &SubmitTransactionResponse{
-		TxStatus:         txStatus,
+		TxStatus:         &txStatus,
 		TxHash:           reply.TxHash,
 		TxIdempotencyKey: reply.TxIdempotencyKey,
 		ResultXdr:        resultXDR,
@@ -520,6 +520,9 @@ func ConvertSubmitTransactionResponseToProto(reply *stellar.SubmitTransactionRes
 func ConvertSubmitTransactionResponseFromProto(p *SubmitTransactionResponse) (*stellar.SubmitTransactionResponse, error) {
 	if p == nil {
 		return nil, errors.New("submit transaction reply is nil")
+	}
+	if p.TxStatus == nil {
+		return nil, errors.New("txStatus is required")
 	}
 	txStatus, err := convertTxStatusFromProto(p.GetTxStatus())
 	if err != nil {
@@ -828,7 +831,7 @@ func convertEventInfoToProto(e stellar.EventInfo) (*EventInfo, error) {
 	}
 
 	return &EventInfo{
-		EventType:        eventType,
+		EventType:        &eventType,
 		Ledger:           e.Ledger,
 		LedgerClosedAt:   e.LedgerClosedAt,
 		ContractId:       e.ContractID,
@@ -844,6 +847,9 @@ func convertEventInfoToProto(e stellar.EventInfo) (*EventInfo, error) {
 func convertEventInfoFromProto(p *EventInfo) (stellar.EventInfo, error) {
 	if p == nil {
 		return stellar.EventInfo{}, errors.New("event info is nil")
+	}
+	if p.EventType == nil {
+		return stellar.EventInfo{}, errors.New("eventType is required")
 	}
 
 	eventType, err := convertEventTypeFromProto(p.GetEventType())

--- a/pkg/chains/stellar/proto_helpers_test.go
+++ b/pkg/chains/stellar/proto_helpers_test.go
@@ -826,12 +826,19 @@ func TestConvertSubmitTransactionResponseToProto_UnsupportedTxStatus(t *testing.
 }
 
 func TestConvertSubmitTransactionResponseFromProto_UnsupportedTxStatus(t *testing.T) {
+	txStatus := conv.TxStatus(99)
 	_, err := conv.ConvertSubmitTransactionResponseFromProto(&conv.SubmitTransactionResponse{
-		TxStatus: conv.TxStatus(99),
+		TxStatus: &txStatus,
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "txStatus")
 	require.Contains(t, err.Error(), "unsupported proto tx status")
+}
+
+func TestConvertSubmitTransactionResponseFromProto_MissingTxStatus(t *testing.T) {
+	_, err := conv.ConvertSubmitTransactionResponseFromProto(&conv.SubmitTransactionResponse{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "txStatus is required")
 }
 
 func TestConvertSubmitTransactionRequestFromProto_BadArg(t *testing.T) {
@@ -1213,10 +1220,11 @@ func TestConvertGetEventsResponseFromProto_NilEvent(t *testing.T) {
 }
 
 func TestConvertGetEventsResponseFromProto_MissingValue(t *testing.T) {
+	eventType := conv.EventType_EVENT_TYPE_CONTRACT
 	_, err := conv.ConvertGetEventsResponseFromProto(&conv.GetEventsResponse{
 		Events: []*conv.EventInfo{
 			{
-				EventType: conv.EventType_EVENT_TYPE_CONTRACT,
+				EventType: &eventType,
 			},
 		},
 	})
@@ -1226,6 +1234,7 @@ func TestConvertGetEventsResponseFromProto_MissingValue(t *testing.T) {
 }
 
 func TestConvertGetEventsResponseFromProto_UnsupportedEventType(t *testing.T) {
+	eventType := conv.EventType(99)
 	u64 := uint64(1)
 	value, err := stellarcap.ScValToProto(stellartypes.ScVal{
 		Type: stellartypes.ScValTypeU64,
@@ -1236,7 +1245,7 @@ func TestConvertGetEventsResponseFromProto_UnsupportedEventType(t *testing.T) {
 	_, err = conv.ConvertGetEventsResponseFromProto(&conv.GetEventsResponse{
 		Events: []*conv.EventInfo{
 			{
-				EventType: conv.EventType(99),
+				EventType: &eventType,
 				Value:     value,
 			},
 		},
@@ -1245,6 +1254,26 @@ func TestConvertGetEventsResponseFromProto_UnsupportedEventType(t *testing.T) {
 	require.Contains(t, err.Error(), "events[0]")
 	require.Contains(t, err.Error(), "eventType")
 	require.Contains(t, err.Error(), "unsupported proto event type")
+}
+
+func TestConvertGetEventsResponseFromProto_MissingEventType(t *testing.T) {
+	u64 := uint64(1)
+	value, err := stellarcap.ScValToProto(stellartypes.ScVal{
+		Type: stellartypes.ScValTypeU64,
+		U64:  &u64,
+	})
+	require.NoError(t, err)
+
+	_, err = conv.ConvertGetEventsResponseFromProto(&conv.GetEventsResponse{
+		Events: []*conv.EventInfo{
+			{
+				Value: value,
+			},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "events[0]")
+	require.Contains(t, err.Error(), "eventType is required")
 }
 
 func TestConvertGetEventsResponseToProto_BadValue(t *testing.T) {
@@ -1286,6 +1315,7 @@ func TestConvertGetEventsResponseToProto_BadTopic(t *testing.T) {
 }
 
 func TestConvertGetEventsResponseFromProto_BadTopic(t *testing.T) {
+	eventType := conv.EventType_EVENT_TYPE_CONTRACT
 	u64 := uint64(1)
 	value, err := stellarcap.ScValToProto(stellartypes.ScVal{
 		Type: stellartypes.ScValTypeU64,
@@ -1296,7 +1326,7 @@ func TestConvertGetEventsResponseFromProto_BadTopic(t *testing.T) {
 	_, err = conv.ConvertGetEventsResponseFromProto(&conv.GetEventsResponse{
 		Events: []*conv.EventInfo{
 			{
-				EventType: conv.EventType_EVENT_TYPE_CONTRACT,
+				EventType: &eventType,
 				Topics: []*scval.ScVal{
 					{},
 				},

--- a/pkg/chains/stellar/stellar.pb.go
+++ b/pkg/chains/stellar/stellar.pb.go
@@ -696,7 +696,7 @@ func (x *GetEventsRequest) GetPagination() *PaginationOptions {
 
 type EventInfo struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
-	EventType        EventType              `protobuf:"varint,1,opt,name=event_type,json=eventType,proto3,enum=loop.stellar.EventType" json:"event_type,omitempty"`
+	EventType        *EventType             `protobuf:"varint,1,opt,name=event_type,json=eventType,proto3,enum=loop.stellar.EventType,oneof" json:"event_type,omitempty"`
 	Ledger           uint32                 `protobuf:"varint,2,opt,name=ledger,proto3" json:"ledger,omitempty"`
 	LedgerClosedAt   string                 `protobuf:"bytes,3,opt,name=ledger_closed_at,json=ledgerClosedAt,proto3" json:"ledger_closed_at,omitempty"`
 	ContractId       string                 `protobuf:"bytes,4,opt,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
@@ -741,8 +741,8 @@ func (*EventInfo) Descriptor() ([]byte, []int) {
 }
 
 func (x *EventInfo) GetEventType() EventType {
-	if x != nil {
-		return x.EventType
+	if x != nil && x.EventType != nil {
+		return *x.EventType
 	}
 	return EventType_EVENT_TYPE_SYSTEM
 }
@@ -1382,7 +1382,7 @@ func (x *SubmitTransactionRequest) GetMaxResourceFee() uint64 {
 // SubmitTransactionResponse carries the outcome of a transaction submission.
 type SubmitTransactionResponse struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
-	TxStatus         TxStatus               `protobuf:"varint,1,opt,name=tx_status,json=txStatus,proto3,enum=loop.stellar.TxStatus" json:"tx_status,omitempty"`
+	TxStatus         *TxStatus              `protobuf:"varint,1,opt,name=tx_status,json=txStatus,proto3,enum=loop.stellar.TxStatus,oneof" json:"tx_status,omitempty"`
 	TxHash           string                 `protobuf:"bytes,2,opt,name=tx_hash,json=txHash,proto3" json:"tx_hash,omitempty"`
 	TxIdempotencyKey string                 `protobuf:"bytes,3,opt,name=tx_idempotency_key,json=txIdempotencyKey,proto3" json:"tx_idempotency_key,omitempty"` // Assigned key (caller-supplied or TXM-generated)
 	ResultXdr        []byte                 `protobuf:"bytes,4,opt,name=result_xdr,json=resultXdr,proto3" json:"result_xdr,omitempty"`                        // TransactionResult binary XDR; empty if unavailable
@@ -1425,8 +1425,8 @@ func (*SubmitTransactionResponse) Descriptor() ([]byte, []int) {
 }
 
 func (x *SubmitTransactionResponse) GetTxStatus() TxStatus {
-	if x != nil {
-		return x.TxStatus
+	if x != nil && x.TxStatus != nil {
+		return *x.TxStatus
 	}
 	return TxStatus_TX_STATUS_FATAL
 }
@@ -1886,10 +1886,10 @@ const file_stellar_proto_rawDesc = "" +
 	"\afilters\x18\x03 \x03(\v2\x19.loop.stellar.EventFilterR\afilters\x12?\n" +
 	"\n" +
 	"pagination\x18\x04 \x01(\v2\x1f.loop.stellar.PaginationOptionsR\n" +
-	"pagination\"\xc5\x03\n" +
-	"\tEventInfo\x126\n" +
+	"pagination\"\xd9\x03\n" +
+	"\tEventInfo\x12;\n" +
 	"\n" +
-	"event_type\x18\x01 \x01(\x0e2\x17.loop.stellar.EventTypeR\teventType\x12\x16\n" +
+	"event_type\x18\x01 \x01(\x0e2\x17.loop.stellar.EventTypeH\x00R\teventType\x88\x01\x01\x12\x16\n" +
 	"\x06ledger\x18\x02 \x01(\rR\x06ledger\x12(\n" +
 	"\x10ledger_closed_at\x18\x03 \x01(\tR\x0eledgerClosedAt\x12\x1f\n" +
 	"\vcontract_id\x18\x04 \x01(\tR\n" +
@@ -1900,7 +1900,8 @@ const file_stellar_proto_rawDesc = "" +
 	"\x10transaction_hash\x18\b \x01(\tR\x0ftransactionHash\x12F\n" +
 	"\x06topics\x18\t \x03(\v2..capabilities.blockchain.stellar.v1alpha.ScValR\x06topics\x12D\n" +
 	"\x05value\x18\n" +
-	" \x01(\v2..capabilities.blockchain.stellar.v1alpha.ScValR\x05value\"\x98\x02\n" +
+	" \x01(\v2..capabilities.blockchain.stellar.v1alpha.ScValR\x05valueB\r\n" +
+	"\v_event_type\"\x98\x02\n" +
 	"\x11GetEventsResponse\x12/\n" +
 	"\x06events\x18\x01 \x03(\v2\x17.loop.stellar.EventInfoR\x06events\x12\x16\n" +
 	"\x06cursor\x18\x02 \x01(\tR\x06cursor\x12#\n" +
@@ -1939,17 +1940,19 @@ const file_stellar_proto_rawDesc = "" +
 	"\bfunction\x18\x04 \x01(\tR\bfunction\x12B\n" +
 	"\x04args\x18\x05 \x03(\v2..capabilities.blockchain.stellar.v1alpha.ScValR\x04args\x120\n" +
 	"\x14ledger_bounds_offset\x18\x06 \x01(\rR\x12ledgerBoundsOffset\x12(\n" +
-	"\x10max_resource_fee\x18\a \x01(\x04R\x0emaxResourceFee\"\xf8\x02\n" +
-	"\x19SubmitTransactionResponse\x123\n" +
-	"\ttx_status\x18\x01 \x01(\x0e2\x16.loop.stellar.TxStatusR\btxStatus\x12\x17\n" +
+	"\x10max_resource_fee\x18\a \x01(\x04R\x0emaxResourceFee\"\x8b\x03\n" +
+	"\x19SubmitTransactionResponse\x128\n" +
+	"\ttx_status\x18\x01 \x01(\x0e2\x16.loop.stellar.TxStatusH\x00R\btxStatus\x88\x01\x01\x12\x17\n" +
 	"\atx_hash\x18\x02 \x01(\tR\x06txHash\x12,\n" +
 	"\x12tx_idempotency_key\x18\x03 \x01(\tR\x10txIdempotencyKey\x12\x1d\n" +
 	"\n" +
 	"result_xdr\x18\x04 \x01(\fR\tresultXdr\x12&\n" +
 	"\x0fresult_meta_xdr\x18\x05 \x01(\fR\rresultMetaXdr\x12\x14\n" +
 	"\x05error\x18\x06 \x01(\tR\x05error\x12,\n" +
-	"\x0ftransaction_fee\x18\a \x01(\x04H\x00R\x0etransactionFee\x88\x01\x01\x12,\n" +
-	"\x0fblock_timestamp\x18\b \x01(\x04H\x01R\x0eblockTimestamp\x88\x01\x01B\x12\n" +
+	"\x0ftransaction_fee\x18\a \x01(\x04H\x01R\x0etransactionFee\x88\x01\x01\x12,\n" +
+	"\x0fblock_timestamp\x18\b \x01(\x04H\x02R\x0eblockTimestamp\x88\x01\x01B\f\n" +
+	"\n" +
+	"_tx_statusB\x12\n" +
 	"\x10_transaction_feeB\x12\n" +
 	"\x10_block_timestamp\"\xfc\x01\n" +
 	"\x17GetLatestLedgerResponse\x12\x12\n" +
@@ -2090,6 +2093,7 @@ func file_stellar_proto_init() {
 	if File_stellar_proto != nil {
 		return
 	}
+	file_stellar_proto_msgTypes[8].OneofWrappers = []any{}
 	file_stellar_proto_msgTypes[16].OneofWrappers = []any{
 		(*TopicSegment_Wildcard)(nil),
 		(*TopicSegment_Scval)(nil),

--- a/pkg/chains/stellar/stellar.proto
+++ b/pkg/chains/stellar/stellar.proto
@@ -123,7 +123,7 @@ message GetEventsRequest {
 }
 
 message EventInfo {
-  EventType event_type = 1;
+  optional EventType event_type = 1;
 
   uint32 ledger = 2;
   string ledger_closed_at = 3;
@@ -217,7 +217,7 @@ enum TxStatus {
 
 // SubmitTransactionResponse carries the outcome of a transaction submission.
 message SubmitTransactionResponse {
-  TxStatus tx_status = 1;
+  optional TxStatus tx_status = 1;
   string   tx_hash = 2;
   string   tx_idempotency_key = 3;  // Assigned key (caller-supplied or TXM-generated)
   bytes    result_xdr = 4;       // TransactionResult binary XDR; empty if unavailable


### PR DESCRIPTION
## Summary
- make Stellar `event_type` and `tx_status` proto fields optional
- reject omitted enum fields on inbound conversion
- keep checked enum conversion for unknown values
