### PR TITLE
Introduce ErrMissingTenant for scoped limiters

### DIFF
--- a/pkg/settings/limits/bound.go
+++ b/pkg/settings/limits/bound.go
@@ -225,7 +225,7 @@ func (b *boundLimiter[N]) get(ctx context.Context) (tenant string, bound N, err 
 				b.lggr.Errorw("Unable to get scoped bound limit due to missing tenant: failing open", append([]any{"scope", b.scope}, kvs...)...)
 				return
 			}
-			err = fmt.Errorf("unable to get scoped bound limit due to missing tenant for scope: %s", b.scope)
+			err = fmt.Errorf("unable to get scoped bound limit for scope %s: %w", b.scope, ErrMissingTenant)
 			return
 		}
 

--- a/pkg/settings/limits/bound.go
+++ b/pkg/settings/limits/bound.go
@@ -225,7 +225,7 @@ func (b *boundLimiter[N]) get(ctx context.Context) (tenant string, bound N, err 
 				b.lggr.Errorw("Unable to get scoped bound limit due to missing tenant: failing open", append([]any{"scope", b.scope}, kvs...)...)
 				return
 			}
-			err = fmt.Errorf("unable to get scoped bound limit for scope %s: %w", b.scope, ErrMissingTenant)
+			err = fmt.Errorf("unable to get scoped bound limit: %w", ErrMissingTenant{Scope: b.scope})
 			return
 		}
 

--- a/pkg/settings/limits/errors.go
+++ b/pkg/settings/limits/errors.go
@@ -11,6 +11,14 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
 )
 
+// ErrMissingTenant is returned when a scoped limiter is used without the tenant that its
+// scope requires in ctx. Unlike a settings read failure, where the limiter still resolves a
+// usable value alongside the error, no lookup is attempted here, so callers must not treat
+// the returned value as a limit. It signals that the CRE context was never populated, which
+// is a programming error rather than a degraded system. Deliberately not a [LimitError]:
+// nothing was limited.
+var ErrMissingTenant = errors.New("missing tenant")
+
 // LimitError is implemented by errors returned when a limit is exceeded.
 // Use [errors.As] to identify limit errors, for example:
 //

--- a/pkg/settings/limits/errors.go
+++ b/pkg/settings/limits/errors.go
@@ -15,9 +15,31 @@ import (
 // scope requires in ctx. Unlike a settings read failure, where the limiter still resolves a
 // usable value alongside the error, no lookup is attempted here, so callers must not treat
 // the returned value as a limit. It signals that the CRE context was never populated, which
-// is a programming error rather than a degraded system. Deliberately not a [LimitError]:
-// nothing was limited.
-var ErrMissingTenant = errors.New("missing tenant")
+// is a programming error rather than a degraded system.
+type ErrMissingTenant struct {
+	Scope settings.Scope
+}
+
+func (e ErrMissingTenant) Is(target error) bool {
+	var errorMissingTenant ErrMissingTenant
+	return errors.As(target, &errorMissingTenant)
+}
+
+func (e ErrMissingTenant) Error() string {
+	return fmt.Sprintf("missing tenant for scope: %s", e.Scope)
+}
+
+// IsErrRecoverable reports whether err still left the caller a usable value. Limiters fall back
+// to the compiled default when a settings read fails, so those errors are advisory and the
+// returned limit can still be enforced. It reports false when no value was resolved and
+// enforcing the zero value would be wrong.
+//
+// Unknown errors are treated as recoverable, so that a degraded settings service does not
+// cause callers to drop work. Match on this rather than on specific error types, so callers
+// pick up future non-recoverable cases automatically.
+func IsErrRecoverable(err error) bool {
+	return !errors.Is(err, ErrMissingTenant{})
+}
 
 // LimitError is implemented by errors returned when a limit is exceeded.
 // Use [errors.As] to identify limit errors, for example:

--- a/pkg/settings/limits/gate.go
+++ b/pkg/settings/limits/gate.go
@@ -236,7 +236,7 @@ func (g *gateLimiter) get(ctx context.Context) (tenant string, open bool, err er
 				g.lggr.Errorw("Unable to get scoped gate status due to missing tenant: failing open", append([]any{"scope", g.scope}, kvs...)...)
 				return
 			}
-			err = fmt.Errorf("unable to get scoped gate status for scope %s: %w", g.scope, ErrMissingTenant)
+			err = fmt.Errorf("unable to get scoped gate status: %w", ErrMissingTenant{Scope: g.scope})
 			return
 		}
 

--- a/pkg/settings/limits/gate.go
+++ b/pkg/settings/limits/gate.go
@@ -236,7 +236,7 @@ func (g *gateLimiter) get(ctx context.Context) (tenant string, open bool, err er
 				g.lggr.Errorw("Unable to get scoped gate status due to missing tenant: failing open", append([]any{"scope", g.scope}, kvs...)...)
 				return
 			}
-			err = fmt.Errorf("unable to get scoped gate status due to missing tenant for scope: %s", g.scope)
+			err = fmt.Errorf("unable to get scoped gate status for scope %s: %w", g.scope, ErrMissingTenant)
 			return
 		}
 

--- a/pkg/settings/limits/missing_tenant_test.go
+++ b/pkg/settings/limits/missing_tenant_test.go
@@ -2,6 +2,7 @@ package limits
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -14,11 +15,11 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/settings"
 )
 
-// TestErrMissingTenant asserts that every scoped limiter reports a missing required tenant
-// as ErrMissingTenant. Callers need to tell this apart from a settings read failure: a read
+// TestErrorMissingTenant asserts that every scoped limiter reports a missing required tenant
+// as ErrMissingTenant, carrying the scope that was missing. Callers need to tell this apart from a settings read failure: a read
 // failure still resolves a usable value, whereas here no lookup happens at all, so the
 // returned value is meaningless (zero for most limiters) and must not be enforced as a limit.
-func TestErrMissingTenant(t *testing.T) {
+func TestErrorMissingTenant(t *testing.T) {
 	t.Parallel()
 
 	// ScopeWorkflow requires a tenant; no contexts.WithCRE below, so none is present.
@@ -86,8 +87,12 @@ func TestErrMissingTenant(t *testing.T) {
 
 			err := limit(t.Context())
 			require.Error(t, err, "a required but missing tenant must be an error")
-			assert.ErrorIs(t, err, ErrMissingTenant,
+
+			var missing ErrMissingTenant
+			require.ErrorAs(t, err, &missing,
 				"callers must be able to tell a missing tenant from a settings read failure")
+			assert.Equal(t, scope, missing.Scope, "the error must carry the scope that was missing")
+			assert.False(t, IsErrRecoverable(err), "no value was resolved, so there is nothing to fall back to")
 		})
 	}
 }
@@ -96,7 +101,7 @@ func TestErrMissingTenant(t *testing.T) {
 // missing one there is not a programming error and must not carry the sentinel. Queues are
 // the only scoped limiter with no unlimited instance to fail open to, so they still error —
 // just not as ErrMissingTenant.
-func TestErrMissingTenant_OnlyForRequiredScopes(t *testing.T) {
+func TestErrorMissingTenant_OnlyForRequiredScopes(t *testing.T) {
 	t.Parallel()
 	require.False(t, settings.ScopeOrg.IsTenantRequired(), "precondition: org scope is optional")
 
@@ -108,16 +113,31 @@ func TestErrMissingTenant_OnlyForRequiredScopes(t *testing.T) {
 
 	_, err = q.Limit(t.Context()) // no contexts.WithCRE, so no org tenant
 	require.Error(t, err)
-	assert.NotErrorIs(t, err, ErrMissingTenant,
+	assert.NotErrorIs(t, err, ErrMissingTenant{},
 		"an optional scope missing its tenant is not a programming error")
 }
 
 // TestErrMissingTenant_NotALimitError guards the categorisation: a missing tenant is a
 // programming error, not a breached limit, so it must not satisfy LimitError (which carries
 // gRPC ResourceExhausted/PermissionDenied semantics).
-func TestErrMissingTenant_NotALimitError(t *testing.T) {
+func TestErrorMissingTenant_NotALimitError(t *testing.T) {
 	t.Parallel()
 
 	var limitErr LimitError
-	assert.NotErrorAs(t, ErrMissingTenant, &limitErr)
+	assert.NotErrorAs(t, ErrMissingTenant{Scope: settings.ScopeWorkflow}, &limitErr)
+}
+
+// TestIsRecoverable pins the predicate callers are told to use instead of matching concrete
+// error types, so that adding a non-recoverable case later does not silently change meaning.
+func TestIsRecoverable(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsErrRecoverable(nil), "no error at all is trivially recoverable")
+	assert.True(t, IsErrRecoverable(errGetterUnavailable),
+		"a settings read failure still leaves the compiled default")
+	assert.True(t, IsErrRecoverable(fmt.Errorf("wrapped: %w", errGetterUnavailable)))
+
+	assert.False(t, IsErrRecoverable(ErrMissingTenant{Scope: settings.ScopeWorkflow}))
+	assert.False(t, IsErrRecoverable(fmt.Errorf("wrapped: %w", ErrMissingTenant{Scope: settings.ScopeOwner})),
+		"must match through wrapping, since limiters add context")
 }

--- a/pkg/settings/limits/missing_tenant_test.go
+++ b/pkg/settings/limits/missing_tenant_test.go
@@ -1,0 +1,103 @@
+package limits
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/settings"
+)
+
+// TestErrMissingTenant asserts that every scoped limiter reports a missing required tenant
+// as ErrMissingTenant. Callers need to tell this apart from a settings read failure: a read
+// failure still resolves a usable value, whereas here no lookup happens at all, so the
+// returned value is meaningless (zero for most limiters) and must not be enforced as a limit.
+func TestErrMissingTenant(t *testing.T) {
+	t.Parallel()
+
+	// ScopeWorkflow requires a tenant; no contexts.WithCRE below, so none is present.
+	const scope = settings.ScopeWorkflow
+	newFactory := func(t *testing.T) Factory { return Factory{Logger: logger.Test(t)} }
+
+	limitOf := map[string]func(t *testing.T) (func(context.Context) error, func() error){
+		"bound": func(t *testing.T) (func(context.Context) error, func() error) {
+			s := settings.Size(1 * config.GByte)
+			s.Key, s.Scope = "test.missing.bound", scope
+			l, err := MakeUpperBoundLimiter(newFactory(t), s)
+			require.NoError(t, err)
+			return func(ctx context.Context) error { _, e := l.Limit(ctx); return e }, l.Close
+		},
+		"range": func(t *testing.T) (func(context.Context) error, func() error) {
+			s := settings.NewSetting(settings.Range[int]{Lower: 1, Upper: 5},
+				settings.ParseRangeFn(func(string) (int, error) { return 0, nil }))
+			s.Key, s.Scope = "test.missing.range", scope
+			l, err := MakeRangeLimiter[int](newFactory(t), s)
+			require.NoError(t, err)
+			return func(ctx context.Context) error { _, e := l.Limit(ctx); return e }, l.Close
+		},
+		"gate": func(t *testing.T) (func(context.Context) error, func() error) {
+			s := settings.Bool(true)
+			s.Key, s.Scope = "test.missing.gate", scope
+			l, err := MakeGateLimiter(newFactory(t), s)
+			require.NoError(t, err)
+			return func(ctx context.Context) error { _, e := l.Limit(ctx); return e }, l.Close
+		},
+		"time": func(t *testing.T) (func(context.Context) error, func() error) {
+			s := settings.Duration(time.Minute)
+			s.Key, s.Scope = "test.missing.time", scope
+			l, err := newFactory(t).MakeTimeLimiter(s)
+			require.NoError(t, err)
+			return func(ctx context.Context) error { _, e := l.Limit(ctx); return e }, l.Close
+		},
+		"queue": func(t *testing.T) (func(context.Context) error, func() error) {
+			s := settings.Int(10)
+			s.Key, s.Scope = "test.missing.queue", scope
+			l, err := MakeQueueLimiter[int](newFactory(t), s)
+			require.NoError(t, err)
+			return func(ctx context.Context) error { _, e := l.Limit(ctx); return e }, l.Close
+		},
+		"rate": func(t *testing.T) (func(context.Context) error, func() error) {
+			s := settings.Rate(rate.Every(time.Second), 5)
+			s.Key, s.Scope = "test.missing.rate", scope
+			l, err := newFactory(t).MakeRateLimiter(s)
+			require.NoError(t, err)
+			return func(ctx context.Context) error { _, e := l.Limit(ctx); return e }, l.Close
+		},
+		"resource": func(t *testing.T) (func(context.Context) error, func() error) {
+			s := settings.Int(10)
+			s.Key, s.Scope = "test.missing.resource", scope
+			l, err := MakeResourcePoolLimiter(newFactory(t), s)
+			require.NoError(t, err)
+			return func(ctx context.Context) error { _, e := l.Limit(ctx); return e }, l.Close
+		},
+	}
+
+	for name, build := range limitOf {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limit, closeFn := build(t)
+			t.Cleanup(func() { assert.NoError(t, closeFn()) })
+
+			err := limit(t.Context())
+			require.Error(t, err, "a required but missing tenant must be an error")
+			assert.ErrorIs(t, err, ErrMissingTenant,
+				"callers must be able to tell a missing tenant from a settings read failure")
+		})
+	}
+}
+
+// TestErrMissingTenant_NotALimitError guards the categorisation: a missing tenant is a
+// programming error, not a breached limit, so it must not satisfy LimitError (which carries
+// gRPC ResourceExhausted/PermissionDenied semantics).
+func TestErrMissingTenant_NotALimitError(t *testing.T) {
+	t.Parallel()
+
+	var limitErr LimitError
+	assert.NotErrorAs(t, ErrMissingTenant, &limitErr)
+}

--- a/pkg/settings/limits/missing_tenant_test.go
+++ b/pkg/settings/limits/missing_tenant_test.go
@@ -92,6 +92,26 @@ func TestErrMissingTenant(t *testing.T) {
 	}
 }
 
+// TestErrMissingTenant_OnlyForRequiredScopes: ScopeOrg does not require a tenant, so a
+// missing one there is not a programming error and must not carry the sentinel. Queues are
+// the only scoped limiter with no unlimited instance to fail open to, so they still error —
+// just not as ErrMissingTenant.
+func TestErrMissingTenant_OnlyForRequiredScopes(t *testing.T) {
+	t.Parallel()
+	require.False(t, settings.ScopeOrg.IsTenantRequired(), "precondition: org scope is optional")
+
+	s := settings.Int(10)
+	s.Key, s.Scope = "test.optional.queue", settings.ScopeOrg
+	q, err := MakeQueueLimiter[int](Factory{Logger: logger.Test(t)}, s)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, q.Close()) })
+
+	_, err = q.Limit(t.Context()) // no contexts.WithCRE, so no org tenant
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrMissingTenant,
+		"an optional scope missing its tenant is not a programming error")
+}
+
 // TestErrMissingTenant_NotALimitError guards the categorisation: a missing tenant is a
 // programming error, not a breached limit, so it must not satisfy LimitError (which carries
 // gRPC ResourceExhausted/PermissionDenied semantics).

--- a/pkg/settings/limits/queue.go
+++ b/pkg/settings/limits/queue.go
@@ -357,7 +357,7 @@ func (s *scopedQueue[T]) getOrCreate(ctx context.Context) (*queue[T], func(), er
 		if !s.scope.IsTenantRequired() {
 			return nil, nil, fmt.Errorf("failed to get queue for scope %s: no tenant in context", s.scope)
 		}
-		return nil, nil, fmt.Errorf("failed to get queue for scope %s: %w", s.scope, ErrMissingTenant)
+		return nil, nil, fmt.Errorf("failed to get queue: %w", ErrMissingTenant{Scope: s.scope})
 	}
 
 	q := s.newQueue(tenant)

--- a/pkg/settings/limits/queue.go
+++ b/pkg/settings/limits/queue.go
@@ -354,7 +354,7 @@ func (s *scopedQueue[T]) getOrCreate(ctx context.Context) (*queue[T], func(), er
 	tenant := s.scope.Value(ctx)
 	if tenant == "" {
 		s.wg.Done()
-		return nil, nil, fmt.Errorf("failed to get queue: missing tenant for scope: %s", s.scope)
+		return nil, nil, fmt.Errorf("failed to get queue for scope %s: %w", s.scope, ErrMissingTenant)
 	}
 
 	q := s.newQueue(tenant)

--- a/pkg/settings/limits/queue.go
+++ b/pkg/settings/limits/queue.go
@@ -354,6 +354,9 @@ func (s *scopedQueue[T]) getOrCreate(ctx context.Context) (*queue[T], func(), er
 	tenant := s.scope.Value(ctx)
 	if tenant == "" {
 		s.wg.Done()
+		if !s.scope.IsTenantRequired() {
+			return nil, nil, fmt.Errorf("failed to get queue for scope %s: no tenant in context", s.scope)
+		}
 		return nil, nil, fmt.Errorf("failed to get queue for scope %s: %w", s.scope, ErrMissingTenant)
 	}
 

--- a/pkg/settings/limits/range.go
+++ b/pkg/settings/limits/range.go
@@ -214,7 +214,7 @@ func (b *rangeLimiter[N]) get(ctx context.Context) (tenant string, bound setting
 				b.lggr.Errorw("Unable to get scoped bounds limit due to missing tenant: failing open", append([]any{"scope", b.scope}, kvs...)...)
 				return
 			}
-			err = fmt.Errorf("unable to get scoped bounds limit for scope %s: %w", b.scope, ErrMissingTenant)
+			err = fmt.Errorf("unable to get scoped bounds limit: %w", ErrMissingTenant{Scope: b.scope})
 			return
 		}
 

--- a/pkg/settings/limits/range.go
+++ b/pkg/settings/limits/range.go
@@ -214,7 +214,7 @@ func (b *rangeLimiter[N]) get(ctx context.Context) (tenant string, bound setting
 				b.lggr.Errorw("Unable to get scoped bounds limit due to missing tenant: failing open", append([]any{"scope", b.scope}, kvs...)...)
 				return
 			}
-			err = fmt.Errorf("unable to get scoped bounds limit due to missing tenant for scope: %s", b.scope)
+			err = fmt.Errorf("unable to get scoped bounds limit for scope %s: %w", b.scope, ErrMissingTenant)
 			return
 		}
 

--- a/pkg/settings/limits/rate.go
+++ b/pkg/settings/limits/rate.go
@@ -439,7 +439,7 @@ func (s *scopedRateLimiter) getOrCreate(ctx context.Context) (RateLimiter, func(
 			return UnlimitedRateLimiter(), s.wg.Done, nil
 		}
 		s.wg.Done()
-		return nil, nil, fmt.Errorf("failed to get rate limiter for scope %s: %w", s.scope, ErrMissingTenant)
+		return nil, nil, fmt.Errorf("failed to get rate limiter: %w", ErrMissingTenant{Scope: s.scope})
 	}
 
 	limiter := s.newRateLimiter(tenant)

--- a/pkg/settings/limits/rate.go
+++ b/pkg/settings/limits/rate.go
@@ -439,7 +439,7 @@ func (s *scopedRateLimiter) getOrCreate(ctx context.Context) (RateLimiter, func(
 			return UnlimitedRateLimiter(), s.wg.Done, nil
 		}
 		s.wg.Done()
-		return nil, nil, fmt.Errorf("failed to get rate limiter: missing tenant for scope: %s", s.scope)
+		return nil, nil, fmt.Errorf("failed to get rate limiter for scope %s: %w", s.scope, ErrMissingTenant)
 	}
 
 	limiter := s.newRateLimiter(tenant)

--- a/pkg/settings/limits/resource.go
+++ b/pkg/settings/limits/resource.go
@@ -679,7 +679,7 @@ func (s *scopedResourcePoolLimiter[N]) getOrCreate(ctx context.Context) (resourc
 			return unlimitedResourcePool[N]{}, s.wg.Done, nil
 		}
 		s.wg.Done()
-		return nil, nil, fmt.Errorf("failed to get resource pool for scope %s: %w", s.scope, ErrMissingTenant)
+		return nil, nil, fmt.Errorf("failed to get resource pool: %w", ErrMissingTenant{Scope: s.scope})
 	}
 
 	usage := s.newLimitUsage(tenant)

--- a/pkg/settings/limits/resource.go
+++ b/pkg/settings/limits/resource.go
@@ -679,7 +679,7 @@ func (s *scopedResourcePoolLimiter[N]) getOrCreate(ctx context.Context) (resourc
 			return unlimitedResourcePool[N]{}, s.wg.Done, nil
 		}
 		s.wg.Done()
-		return nil, nil, fmt.Errorf("failed to get resource pool: missing tenant for scope: %s", s.scope)
+		return nil, nil, fmt.Errorf("failed to get resource pool for scope %s: %w", s.scope, ErrMissingTenant)
 	}
 
 	usage := s.newLimitUsage(tenant)

--- a/pkg/settings/limits/time.go
+++ b/pkg/settings/limits/time.go
@@ -230,7 +230,7 @@ func (l *timeLimiter) get(ctx context.Context) (tenant string, timeout time.Dura
 				l.lggr.Errorw("Unable to get scoped time limit due to missing tenant: using default value", append([]any{"scope", l.scope, "default", timeout}, kvs...)...)
 				return
 			}
-			err = fmt.Errorf("unable to get scoped time limit for scope %s: %w", l.scope, ErrMissingTenant)
+			err = fmt.Errorf("unable to get scoped time limit: %w", ErrMissingTenant{Scope: l.scope})
 			return
 		}
 

--- a/pkg/settings/limits/time.go
+++ b/pkg/settings/limits/time.go
@@ -230,7 +230,7 @@ func (l *timeLimiter) get(ctx context.Context) (tenant string, timeout time.Dura
 				l.lggr.Errorw("Unable to get scoped time limit due to missing tenant: using default value", append([]any{"scope", l.scope, "default", timeout}, kvs...)...)
 				return
 			}
-			err = fmt.Errorf("unable to get scoped time limit due to missing tenant for scope: %s", l.scope)
+			err = fmt.Errorf("unable to get scoped time limit for scope %s: %w", l.scope, ErrMissingTenant)
 			return
 		}
 


### PR DESCRIPTION
This pull request standardizes how missing tenant errors are reported across all scoped limiters in the `pkg/settings/limits` package. It introduces a new sentinel error, `ErrMissingTenant`, and updates all relevant limiters to wrap and return this error when a required tenant is missing from the context. Comprehensive tests are also added to ensure correct error handling and categorization.

**Error handling improvements:**

* Introduced a new sentinel error `ErrMissingTenant` in `errors.go` to represent the case where a scoped limiter is used without the required tenant in the context. This error is not a `LimitError` and signals a programming error rather than a system issue.
* Updated all scoped limiters (`bound.go`, `range.go`, `gate.go`, `queue.go`, `rate.go`, `resource.go`, `time.go`) to wrap and return `ErrMissingTenant` when the tenant is missing, ensuring consistent error reporting. 

**Testing and validation:**

* Added `missing_tenant_test.go` to assert that all scoped limiters return `ErrMissingTenant` when the tenant is missing, and to verify that this error is not misclassified as a `LimitError`.